### PR TITLE
#165 Fix 2d projection

### DIFF
--- a/docs/developer_guide/plot/index.md
+++ b/docs/developer_guide/plot/index.md
@@ -1,0 +1,162 @@
+# How to Create a Plot
+
+A quick guide to using the plot system to visualize section data in 2D or 3D.
+
+## The Basics
+
+The plot system has three main pieces:
+
+- **PlotService** - Manages all the plot data and settings
+- **StudioComponent** - The container that sets everything up
+- **SectionPlotComponent** - Actually draws the plot
+
+When you give `StudioComponent` a section, it automatically:
+1. Waits for the Python worker to be ready
+2. Fetches the section data
+3. Passes it to `SectionPlotComponent` to render
+
+## Quick Start
+
+Just use the `StudioComponent` in your template:
+
+```html
+<app-studio
+  [section]="mySection"
+  [isSupportZoom]="true"
+></app-studio>
+```
+
+The component handles loading states and errors automatically. That's it!
+
+## Changing Plot Options
+
+Use `PlotService` to change how the plot looks:
+
+```typescript
+constructor(public plotService: PlotService) {}
+
+// Switch between 2D and 3D
+plotService.plotOptionsChange({ view: '2d' });
+
+// Show different support range
+plotService.plotOptionsChange({
+  startSupport: 0,
+  endSupport: 5
+});
+
+// Change viewing angle (2D only)
+plotService.plotOptionsChange({ side: 'face' });
+```
+
+### Available Options
+
+```typescript
+interface PlotOptions {
+  view: '2d' | '3d';           // 2D or 3D view
+  side: 'profile' | 'face';    // Viewing angle (2D only)
+  startSupport: number;         // First support to show
+  endSupport: number;           // Last support to show
+  invert: boolean;              // Flip Y-axis (3D only)
+}
+```
+
+## How It Works
+
+### Data Flow
+
+1. You provide a `section` to `StudioComponent`
+2. `StudioComponent` calls `plotService.refreshSection(section)`
+3. The service fetches data from the Python worker
+4. Data flows into `SectionPlotComponent` via signals
+5. The plot automatically updates when data or options change
+
+### Plot Rendering
+
+`SectionPlotComponent` uses an Angular `effect()` to watch for changes. When data arrives, it:
+- Transforms the raw data into Plotly format
+- Creates the plot in a `<div id="plotly-output">` element
+- Preserves camera position in 3D mode
+
+## Common Tasks
+
+### Recalculate with Different Climate Parameters
+
+```typescript
+await plotService.calculateCharge(
+  50,    // wind pressure (Pa)
+  20,    // cable temperature (°C)
+  0      // ice thickness (mm)
+);
+```
+
+### Get Current Camera Position
+
+```typescript
+const camera = plotService.getCamera();
+// Camera is automatically preserved during updates
+```
+
+### Reset Everything
+
+```typescript
+plotService.resetAll(); // Clears plot and all state
+```
+
+## Error Handling
+
+The system handles errors automatically. Common errors:
+- `NO_CABLE_FOUND` - Cable data missing
+- `CALCULATION_ERROR` - Calculation failed
+- `SOLVER_DID_NOT_CONVERGE` - Solver couldn't find solution
+- `PYODIDE_LOAD_ERROR` - Python worker didn't load
+
+Errors show up in the `StudioComponent` template automatically.
+
+## Cleanup
+
+Don't forget to clean up when your component is destroyed:
+
+```typescript
+ngOnDestroy() {
+  if (this.subscription) {
+    this.subscription.unsubscribe();
+  }
+  this.plotService.resetAll();
+}
+```
+
+## Full Example
+
+```typescript
+@Component({
+  selector: 'app-my-plot',
+  template: `
+    <app-studio
+      [section]="currentSection()"
+      [isSupportZoom]="true"
+    ></app-studio>
+    
+    <button (click)="toggleView()">Toggle 2D/3D</button>
+  `,
+  imports: [StudioComponent]
+})
+export class MyPlotComponent {
+  currentSection = signal<Section | null>(null);
+  
+  constructor(public plotService: PlotService) {}
+  
+  toggleView() {
+    const current = this.plotService.plotOptions();
+    this.plotService.plotOptionsChange({
+      view: current.view === '3d' ? '2d' : '3d'
+    });
+  }
+}
+```
+
+## Tips
+
+- The plot updates automatically when data or options change - you usually don't need to manually refresh
+- Always use `plotOptionsChange()` instead of directly setting options
+- Camera position is preserved automatically in 3D mode
+- Make sure the Python worker is ready before calling `refreshSection()`

--- a/mkdocs.yaml
+++ b/mkdocs.yaml
@@ -46,8 +46,9 @@ nav:
 
       # - Guidelines : developer_guide/guidelines.md
       - Documentation: developer_guide/documentation.md
-      - Studio:
-          - Plot: developer_guide/plot/objects.md
+      - Plot:
+          - Home: developer_guide/plot/index.md
+          - Data Objects: developer_guide/plot/objects.md
 
 plugins:
   - search

--- a/src/app/ui/pages/studio/studio-page.component.spec.ts
+++ b/src/app/ui/pages/studio/studio-page.component.spec.ts
@@ -152,7 +152,9 @@ describe('StudioPageComponent', () => {
 
     expect(typeof plotService.study.set).toBe('function');
     expect(sectionSetSpy).toHaveBeenCalledWith(study.sections[1]);
-    expect(plotService.plotOptionsChange).toHaveBeenCalledWith('endSupport', 2);
+    expect(plotService.plotOptionsChange).toHaveBeenCalledWith({
+      endSupport: 2
+    });
   });
 
   it('ngOnInit should navigate if section not found', () => {
@@ -178,10 +180,9 @@ describe('StudioPageComponent', () => {
     expect(plotService.plotOptionsChange).not.toHaveBeenCalled();
 
     jest.advanceTimersByTime(300);
-    expect(plotService.plotOptionsChange).toHaveBeenCalledWith(
-      'startSupport',
-      1
-    );
+    expect(plotService.plotOptionsChange).toHaveBeenCalledWith({
+      startSupport: 1
+    });
   });
 
   it('ngOnDestroy should clean up subscription, section, and resizeObserver', () => {

--- a/src/app/ui/pages/studio/studio-page.component.ts
+++ b/src/app/ui/pages/studio/studio-page.component.ts
@@ -138,10 +138,9 @@ export class StudioPageComponent implements OnInit, OnDestroy {
               );
               if (section) {
                 this.plotService.section.set(section);
-                this.plotService.plotOptionsChange(
-                  'endSupport',
-                  section.supports.length - 1
-                );
+                this.plotService.plotOptionsChange({
+                  endSupport: section.supports.length - 1
+                });
               } else {
                 this.router.navigate(['/studies']);
               }
@@ -165,7 +164,7 @@ export class StudioPageComponent implements OnInit, OnDestroy {
 
   debounceUpdateSliderOptions = debounce(
     (key: 'endSupport' | 'startSupport', value: number) => {
-      this.plotService.plotOptionsChange(key, value);
+      this.plotService.plotOptionsChange({ [key]: value });
       const options = this.plotService.plotOptions();
       const diff = Math.abs(options.endSupport - options.startSupport);
       this.supports.set(diff === 1 ? 'single' : diff === 2 ? 'double' : 'all');
@@ -211,13 +210,14 @@ export class StudioPageComponent implements OnInit, OnDestroy {
     const maxSupport = (this.plotService.section()?.supports.length ?? 0) - 1;
     const offset = value === 'single' ? 1 : value === 'double' ? 2 : null;
     if (offset !== null) {
-      this.plotService.plotOptionsChange(
-        'endSupport',
-        Math.min(startSupport + offset, maxSupport)
-      );
+      this.plotService.plotOptionsChange({
+        endSupport: Math.min(startSupport + offset, maxSupport)
+      });
     } else {
-      this.plotService.plotOptionsChange('startSupport', 0);
-      this.plotService.plotOptionsChange('endSupport', maxSupport);
+      this.plotService.plotOptionsChange({
+        startSupport: 0,
+        endSupport: maxSupport
+      });
     }
   }
 
@@ -228,15 +228,9 @@ export class StudioPageComponent implements OnInit, OnDestroy {
       supportButton === 'single' ? 1 : supportButton === 'double' ? 2 : 0;
     const increment = direction === 'left' ? -incrementValue : incrementValue;
     const options = this.plotService.plotOptions();
-    const updateOrder: ('startSupport' | 'endSupport')[] =
-      direction === 'left'
-        ? ['startSupport', 'endSupport']
-        : ['endSupport', 'startSupport'];
-    updateOrder.forEach((key) => {
-      this.plotService.plotOptionsChange(
-        key,
-        Math.max(options[key] + increment, 0)
-      );
+    this.plotService.plotOptionsChange({
+      startSupport: Math.max(options.startSupport + increment, 0),
+      endSupport: Math.max(options.endSupport + increment, 0)
     });
   }
 }

--- a/src/app/ui/pages/studio/top-toolbar/top-toolbar.component.html
+++ b/src/app/ui/pages/studio/top-toolbar/top-toolbar.component.html
@@ -3,7 +3,7 @@
     [options]="threeDOptions()"
     [disabled]="plotService.loading()"
     [ngModel]="plotService.plotOptions().view"
-    (onChange)="plotService.plotOptionsChange('view', $event.value)"
+    (onChange)="plotService.plotOptionsChange({ view: $event.value })"
     optionLabel="label"
     optionValue="value"
     allowEmpty="false"
@@ -18,7 +18,7 @@
     <p-selectbutton
       [options]="sideOptions()"
       [ngModel]="plotService.plotOptions().side"
-      (onChange)="plotService.plotOptionsChange('side', $event.value)"
+      (onChange)="plotService.plotOptionsChange({ side: $event.value })"
       optionLabel="label"
       optionValue="value"
       ariaLabelledBy="side"
@@ -34,7 +34,7 @@
     <p-toggleswitch
       inputId="invert"
       [(ngModel)]="plotService.plotOptions().invert"
-      (onChange)="plotService.plotOptionsChange('invert', $event.checked)"
+      (onChange)="plotService.plotOptionsChange({ invert: $event.checked })"
     />
   </div>
 

--- a/src/app/ui/pages/study/tabs/sections/newSectionModal/manualSection/manualSection.component.ts
+++ b/src/app/ui/pages/study/tabs/sections/newSectionModal/manualSection/manualSection.component.ts
@@ -377,7 +377,7 @@ export class ManualSectionComponent implements OnInit {
 
   debounceUpdateSliderOptions = debounce(
     (key: 'endSupport' | 'startSupport', value: number) => {
-      this.plotService.plotOptionsChange(key, value);
+      this.plotService.plotOptionsChange({ [key]: value });
     },
     DEBOUNCED_REFRESH_STUDIO_DELAY
   );

--- a/src/app/ui/shared/components/studio/studio.component.ts
+++ b/src/app/ui/shared/components/studio/studio.component.ts
@@ -65,7 +65,6 @@ export class StudioComponent implements OnInit, OnDestroy {
     if (this.subscription) {
       this.subscription.unsubscribe();
     }
-    this.plotService.purgePlot();
-    this.plotService.camera.set(null);
+    this.plotService.resetAll();
   }
 }


### PR DESCRIPTION
#165 

Fix the fact that there was no reload of projection when moving the slider from left to right when being in 2D.


**Please check if the PR fulfills these requirements**
<!-- please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes -->
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**Does this PR already have an issue describing the problem?**
<!-- If so, link to this issue using `'Fixes #XXX'` and skip the rest -->



**What kind of change does this PR introduce?**
<!-- Bug fix, feature, docs update, ... -->



**What is the current behavior?**
<!-- You can also link to an open issue here -->



**What is the new behavior (if this is a feature change)?**



**Does this PR introduce a breaking change or deprecate an API?**
- [ ] Yes
- [x] No


