### PR TITLE
#263 Make better scale and traces for plot

### DIFF
--- a/docs/developer_guide/plot/objects.md
+++ b/docs/developer_guide/plot/objects.md
@@ -1,0 +1,95 @@
+# Plot Data Object Creation
+
+`createPlotData.ts` and `createPlotDataObject.ts` are the two files that turn 3D coordinate arrays into Plotly.js data objects for rendering. They handle three types of objects:
+- **Spans** (blue) - main structural elements
+- **Supports** (indigo) - support structures with numbered labels
+- **Insulators** (red) - insulator elements
+
+## How It Works
+
+### `createPlotData.ts`
+
+This is the entry point. It takes section output data and plot options, then:
+1. Loops through spans, supports, and insulators
+2. Calls `createDataObject()` for each type
+3. Flattens everything into one array of Plotly data objects
+
+```typescript
+const plotData = createPlotData(sectionData, {
+  view: '3d',
+  side: 'profile',
+  startSupport: 0,
+  endSupport: 5,
+  invert: false
+});
+```
+
+### `createPlotDataObject.ts`
+
+This does the actual work of transforming coordinates into Plotly objects.
+
+**`createDataObject()`** - The main function:
+- Slices the data based on support indices (spans exclude the end, supports/insulators include it)
+- Extracts x, y, z coordinates from each point
+- Transforms coordinates based on view:
+  - **3D**: Uses x, y, z directly with `scatter3d`
+  - **2D Profile**: Projects onto XZ plane (x→x, z→z, y→y)
+  - **2D Face**: Projects onto YZ plane (y→x, z→z, swaps axes)
+- Applies styling (colors, line width, markers, text labels)
+
+**Helper functions:**
+- `getLine()` - Returns color (blue/indigo/red), dash style, and width (thicker in 3D)
+- `getMode()` - Returns `'text+lines+markers'` for supports, `'lines+markers'` for others
+- `getText()` - Labels supports with their number (1-indexed) on the highest point
+- `getMarker()` - Sets marker sizes (varies by type and view)
+
+## Quick Reference
+
+**Coordinate transformations:**
+- 3D: `x, y, z` → `x, y, z` (scatter3d)
+- 2D Profile: `x, y, z` → `x, z, y` (scatter)
+- 2D Face: `x, y, z` → `y, z, y` (scatter, swaps x/y)
+
+**Styling:**
+- Spans: dodgerblue, width 8 (3D) or 4 (2D)
+- Supports: indigo, width 8 (3D) or 4 (2D), shows numbered labels
+- Insulators: red, width 8 (3D) or 4 (2D)
+
+**Note:** Support indices are 0-based internally but displayed as 1-based in labels.
+
+## Style Configuration Summary
+
+### Lines
+
+All line styles use `dash: 'solid'`. Line width varies by view mode (thicker in 3D):
+
+| Type | Color | Width (3D) | Width (2D) |
+|------|-------|------------|------------|
+| **Spans** | `dodgerblue` | 8 | 4 |
+| **Supports** | `indigo` | 8 | 4 |
+| **Insulators** | `red` | 8 | 4 |
+| **Default** | `black` | 8 | 4 |
+
+### Markers
+
+Marker sizes vary by object type and view mode:
+
+| Type | Size (3D) | Size (2D) |
+|------|-----------|-----------|
+| **Spans** | 3 | 5 |
+| **Supports** | 3 | 4 |
+| **Insulators** | 4 | 6 |
+| **Default** | 3 | 3 |
+
+### Text
+
+- **Mode**: 
+  - Supports: `'text+lines+markers'` (displays text labels)
+  - All others: `'lines+markers'` (no text labels)
+  
+- **Text Labels** (Supports only):
+  - Display: Support number (1-indexed) on the highest point (maximum z-coordinate)
+  - Position: `'top center'` (applied to all data objects)
+  - Logic: Only the point with the highest z-value in each support gets labeled; all other points have empty strings
+
+- **Text Position**: `'top center'` (applied globally to all data objects)

--- a/mkdocs.yaml
+++ b/mkdocs.yaml
@@ -24,12 +24,12 @@ theme:
     - python
     - typescript
     - bash
-  palette: 
+  palette:
     - primary: indigo
     # Palette toggle for light mode
     - scheme: default
       toggle:
-        icon: material/brightness-7 
+        icon: material/brightness-7
         name: Switch to dark mode
     # Palette toggle for dark mode
     - scheme: slate
@@ -40,44 +40,45 @@ theme:
 nav:
   - Home: index.md
   - Getting Started: home/home.md
-  # - User Guide: 
+  # - User Guide:
   - Developer guide:
-    # - API Reference:
-      
-    # - Guidelines : developer_guide/guidelines.md
-    - Documentation : developer_guide/documentation.md
+      # - API Reference:
 
-
+      # - Guidelines : developer_guide/guidelines.md
+      - Documentation: developer_guide/documentation.md
+      - Studio:
+          - Plot: developer_guide/plot/objects.md
 
 plugins:
   - search
   - offline
   - mkdocstrings:
-      default_handler: typescript
+      default_handler:
+        typescript
         # See: https://mkdocstrings.github.io/python/usage/
         # python:
-          # paths: [src]
-          # import:
-          #   - url: https://docs.python.org/3/objects.inv
-          #     domains: [py, std]
-          # options:
-          #   docstring_options:
-          #     ignore_init_summary: true
-          #   # docstring_section_style: list
-          #   filters: ["!^_"]
-          #   heading_level: 1
-          #   inherited_members: true
-          #   merge_init_into_class: true
-          #   parameter_headings: true
-          #   separate_signature: true
-          #   show_root_heading: true
-          #   show_root_full_path: false
-          #   show_signature_annotations: true
-          #   # show_source: false
-          #   show_symbol_type_heading: true
-          #   show_symbol_type_toc: true
-          #   signature_crossrefs: true
-            # summary: true
+        # paths: [src]
+        # import:
+        #   - url: https://docs.python.org/3/objects.inv
+        #     domains: [py, std]
+        # options:
+        #   docstring_options:
+        #     ignore_init_summary: true
+        #   # docstring_section_style: list
+        #   filters: ["!^_"]
+        #   heading_level: 1
+        #   inherited_members: true
+        #   merge_init_into_class: true
+        #   parameter_headings: true
+        #   separate_signature: true
+        #   show_root_heading: true
+        #   show_root_full_path: false
+        #   show_signature_annotations: true
+        #   # show_source: false
+        #   show_symbol_type_heading: true
+        #   show_symbol_type_toc: true
+        #   signature_crossrefs: true
+        # summary: true
 
 markdown_extensions:
   - admonition # https://squidfunk.github.io/mkdocs-material/reference/admonitions/#collapsible-blocks

--- a/src/app/ui/pages/studio/plot.service.ts
+++ b/src/app/ui/pages/studio/plot.service.ts
@@ -168,10 +168,10 @@ export class PlotService {
   };
 
   purgePlot = () => {
-    if (!document.getElementById('plotly-output')) {
+    if (!document.getElementById(PLOT_ID)) {
       return;
     }
-    plotly.purge('plotly-output');
+    plotly.purge(PLOT_ID);
     this.litData.set(null);
     this.error.set(null);
     this.loading.set(false);

--- a/src/app/ui/shared/components/studio/section/helpers/createPlot.spec.ts
+++ b/src/app/ui/shared/components/studio/section/helpers/createPlot.spec.ts
@@ -83,22 +83,144 @@ describe('createPlot', () => {
   });
 
   describe('scene configuration', () => {
-    it('should configure scene with manual aspectmode', () => {
+    it('should configure scene with data aspectmode', () => {
       createPlot('test-plot-id', mockData, false, false, '3d', null, 'profile');
 
       const layoutArg = (Plotly.newPlot as jest.Mock).mock.calls[0][2];
-      expect(layoutArg.scene.aspectmode).toBe('manual');
+      expect(layoutArg.scene.aspectmode).toBe('data');
     });
 
     it('should configure scene with correct aspectratio', () => {
       createPlot('test-plot-id', mockData, false, false, '3d', null, 'profile');
 
       const layoutArg = (Plotly.newPlot as jest.Mock).mock.calls[0][2];
-      expect(layoutArg.scene.aspectratio).toEqual({
-        x: 3,
-        y: 0.2,
-        z: 0.5
+      expect(layoutArg.scene.aspectratio).toEqual(undefined);
+    });
+  });
+
+  describe('layout2d configuration', () => {
+    it('should have basic layout properties', () => {
+      createPlot('test-plot-id', mockData, false, false, '2d', null, 'profile');
+
+      const layoutArg = (Plotly.newPlot as jest.Mock).mock.calls[0][2];
+      expect(layoutArg.autosize).toBe(true);
+      expect(layoutArg.showlegend).toBe(false);
+      expect(layoutArg.plot_bgcolor).toBe('gainsboro');
+    });
+
+    it('should have correct margin configuration', () => {
+      createPlot('test-plot-id', mockData, false, false, '2d', null, 'profile');
+
+      const layoutArg = (Plotly.newPlot as jest.Mock).mock.calls[0][2];
+      expect(layoutArg.margin).toEqual({
+        l: 50,
+        r: 0,
+        t: 20,
+        b: 20
       });
+    });
+
+    it('should configure xaxis with autorange true for profile side', () => {
+      createPlot('test-plot-id', mockData, false, false, '2d', null, 'profile');
+
+      const layoutArg = (Plotly.newPlot as jest.Mock).mock.calls[0][2];
+      expect(layoutArg.xaxis.autorange).toBe(true);
+    });
+
+    it('should configure xaxis with autorange false for face side', () => {
+      createPlot('test-plot-id', mockData, false, false, '2d', null, 'face');
+
+      const layoutArg = (Plotly.newPlot as jest.Mock).mock.calls[0][2];
+      expect(layoutArg.xaxis.autorange).toBe(false);
+    });
+
+    it('should configure xaxis with common properties', () => {
+      createPlot('test-plot-id', mockData, false, false, '2d', null, 'profile');
+
+      const layoutArg = (Plotly.newPlot as jest.Mock).mock.calls[0][2];
+      expect(layoutArg.xaxis.backgroundcolor).toBe('gainsboro');
+      expect(layoutArg.xaxis.gridcolor).toBe('dimgray');
+      expect(layoutArg.xaxis.showbackground).toBe(true);
+      expect(layoutArg.xaxis.showticklabels).toBe(true);
+      expect(layoutArg.xaxis.showgrid).toBe(true);
+      expect(layoutArg.xaxis.showline).toBe(true);
+    });
+
+    it('should configure yaxis with scaleratio and scaleanchor for face side', () => {
+      createPlot('test-plot-id', mockData, false, false, '2d', null, 'face');
+
+      const layoutArg = (Plotly.newPlot as jest.Mock).mock.calls[0][2];
+      expect(layoutArg.yaxis.scaleratio).toBe(0.2);
+      expect(layoutArg.yaxis.scaleanchor).toBe('x');
+    });
+
+    it('should configure yaxis without scaleratio and scaleanchor for profile side', () => {
+      createPlot('test-plot-id', mockData, false, false, '2d', null, 'profile');
+
+      const layoutArg = (Plotly.newPlot as jest.Mock).mock.calls[0][2];
+      expect(layoutArg.yaxis.scaleratio).toBeUndefined();
+      expect(layoutArg.yaxis.scaleanchor).toBeUndefined();
+    });
+
+    it('should configure yaxis with common properties', () => {
+      createPlot('test-plot-id', mockData, false, false, '2d', null, 'profile');
+
+      const layoutArg = (Plotly.newPlot as jest.Mock).mock.calls[0][2];
+      expect(layoutArg.yaxis.backgroundcolor).toBe('gainsboro');
+      expect(layoutArg.yaxis.gridcolor).toBe('dimgray');
+      expect(layoutArg.yaxis.showbackground).toBe(true);
+      expect(layoutArg.yaxis.showticklabels).toBe(true);
+      expect(layoutArg.yaxis.showgrid).toBe(true);
+      expect(layoutArg.yaxis.showline).toBe(true);
+    });
+
+    it('should not have scene property in 2d layout', () => {
+      createPlot('test-plot-id', mockData, false, false, '2d', null, 'profile');
+
+      const layoutArg = (Plotly.newPlot as jest.Mock).mock.calls[0][2];
+      expect(layoutArg.scene).toBeUndefined();
+    });
+
+    it('should work with different data arrays', () => {
+      const differentData: Data[] = [
+        {
+          x: [10, 20, 30, 40],
+          y: [100, 200, 300, 400],
+          type: 'scatter',
+          mode: 'markers'
+        }
+      ];
+
+      createPlot(
+        'test-plot-id',
+        differentData,
+        false,
+        false,
+        '2d',
+        null,
+        'face'
+      );
+
+      const layoutArg = (Plotly.newPlot as jest.Mock).mock.calls[0][2];
+      expect(layoutArg.autosize).toBe(true);
+      expect(layoutArg.xaxis.autorange).toBe(false);
+      expect(layoutArg.yaxis.scaleratio).toBe(0.2);
+    });
+
+    it('should work with invert parameter set to true', () => {
+      createPlot('test-plot-id', mockData, false, true, '2d', null, 'profile');
+
+      const layoutArg = (Plotly.newPlot as jest.Mock).mock.calls[0][2];
+      expect(layoutArg.autosize).toBe(true);
+      expect(layoutArg.xaxis.autorange).toBe(true);
+    });
+
+    it('should work with invert parameter set to false', () => {
+      createPlot('test-plot-id', mockData, false, false, '2d', null, 'face');
+
+      const layoutArg = (Plotly.newPlot as jest.Mock).mock.calls[0][2];
+      expect(layoutArg.autosize).toBe(true);
+      expect(layoutArg.xaxis.autorange).toBe(false);
     });
   });
 });

--- a/src/app/ui/shared/components/studio/section/helpers/createPlot.ts
+++ b/src/app/ui/shared/components/studio/section/helpers/createPlot.ts
@@ -2,8 +2,7 @@ import Plotly, {
   Camera,
   Data,
   Layout,
-  ModeBarDefaultButtons,
-  ScatterData
+  ModeBarDefaultButtons
 } from 'plotly.js-dist-min';
 import { Side, View } from './types';
 
@@ -47,15 +46,10 @@ const scene = (
   invert: boolean,
   camera: Camera | null
 ) => ({
-  aspectmode: 'manual' as 'manual' | 'auto' | 'cube' | 'data' | undefined,
+  aspectmode: 'data' as 'manual' | 'auto' | 'cube' | 'data' | undefined,
   xaxis: axis,
-  yaxis: axis,
+  yaxis: { ...axis, scaleanchor: 'x', scaleratio: 1 },
   zaxis: axis,
-  aspectratio: {
-    x: 3,
-    y: 0.2,
-    z: 0.5
-  },
   camera: camera ?? {
     ...(isSupportZoom ? supportCamera : normalCamera(invert))
   }
@@ -98,17 +92,6 @@ const layout2d: (
   data: Data[],
   side: Side
 ) => Partial<Layout> = (invert: boolean, data: Data[], side: Side) => {
-  let xMin = 0;
-  let xMax = 0;
-  if (side === 'face') {
-    const allXValues = data.flatMap(
-      (d) => ((d as ScatterData).x as number[]) ?? []
-    ) as number[];
-    xMin = Math.min(...allXValues);
-    xMax = Math.max(...allXValues);
-    xMin -= 1;
-    xMax += 1;
-  }
   return {
     autosize: true,
     showlegend: false,
@@ -124,14 +107,15 @@ const layout2d: (
       autorange: side === 'face' ? false : true,
       showticklabels: true,
       showgrid: true,
-      showline: true,
-      range: side === 'face' ? [xMin, xMax] : undefined
+      showline: true
     },
     yaxis: {
       ...axis,
       showticklabels: true,
       showgrid: true,
-      showline: true
+      showline: true,
+      scaleratio: side === 'face' ? 0.2 : undefined,
+      scaleanchor: side === 'face' ? 'x' : undefined
     }
   };
 };

--- a/src/app/ui/shared/components/studio/section/helpers/createPlotData.ts
+++ b/src/app/ui/shared/components/studio/section/helpers/createPlotData.ts
@@ -8,7 +8,7 @@ export const createPlotData = (
   options: PlotOptions
 ): Data[] => {
   const data = (
-    ['spans', 'insulators', 'supports'] as (keyof GetSectionOutput)[]
+    ['spans', 'supports', 'insulators'] as (keyof GetSectionOutput)[]
   ).map((type) => {
     return createDataObject(
       params[type as keyof GetSectionOutput] as number[][][],

--- a/src/app/ui/shared/components/studio/section/helpers/createPlotDataObject.spec.ts
+++ b/src/app/ui/shared/components/studio/section/helpers/createPlotDataObject.spec.ts
@@ -21,7 +21,7 @@ describe('createPlotDataObject', () => {
       expect(
         // eslint-disable-next-line @typescript-eslint/no-explicit-any
         (result[0] as any).line
-      ).toEqual({ color: 'dodgerblue', dash: 'solid', width: 8 });
+      ).toEqual({ color: 'dodgerblue', dash: 'solid', width: 4 });
     });
 
     it('should return blue color for supports type', () => {
@@ -37,7 +37,7 @@ describe('createPlotDataObject', () => {
       expect(
         // eslint-disable-next-line @typescript-eslint/no-explicit-any
         (result[0] as any).line
-      ).toEqual({ color: 'indigo', dash: 'solid', width: 8 });
+      ).toEqual({ color: 'indigo', dash: 'solid', width: 4 });
     });
 
     it('should return green color for insulators type', () => {
@@ -56,7 +56,7 @@ describe('createPlotDataObject', () => {
       ).toEqual({
         color: 'red',
         dash: 'solid',
-        width: 8
+        width: 4
       });
     });
 
@@ -76,7 +76,7 @@ describe('createPlotDataObject', () => {
       ).toEqual({
         color: 'black',
         dash: 'solid',
-        width: 8
+        width: 4
       });
     });
   });

--- a/src/app/ui/shared/components/studio/section/helpers/createPlotDataObject.ts
+++ b/src/app/ui/shared/components/studio/section/helpers/createPlotDataObject.ts
@@ -2,7 +2,8 @@ import { Dash, Data, PlotData } from 'plotly.js-dist-min';
 import { PlotObjectsType, Side, View } from './types';
 
 const getLine = (
-  type: PlotObjectsType
+  type: PlotObjectsType,
+  view: View
 ): {
   color: string;
   dash: Dash;
@@ -10,13 +11,17 @@ const getLine = (
 } => {
   switch (type) {
     case 'spans':
-      return { color: 'dodgerblue', dash: 'solid', width: 8 };
+      return {
+        color: 'dodgerblue',
+        dash: 'solid',
+        width: view === '3d' ? 8 : 4
+      };
     case 'supports':
-      return { color: 'indigo', dash: 'solid', width: 8 };
+      return { color: 'indigo', dash: 'solid', width: view === '3d' ? 8 : 4 };
     case 'insulators':
-      return { color: 'red', dash: 'solid', width: 8 };
+      return { color: 'red', dash: 'solid', width: view === '3d' ? 8 : 4 };
     default:
-      return { color: 'black', dash: 'solid', width: 8 };
+      return { color: 'black', dash: 'solid', width: view === '3d' ? 8 : 4 };
   }
 };
 
@@ -37,6 +42,19 @@ const getText = (
   return points.map((point, index) =>
     index === highestPointIndex ? (supportIndex + 1).toString() : ''
   );
+};
+
+const getMarker = (type: PlotObjectsType, view: View): PlotData['marker'] => {
+  switch (type) {
+    case 'spans':
+      return { size: view === '3d' ? 3 : 5 };
+    case 'supports':
+      return { size: view === '3d' ? 3 : 4 };
+    case 'insulators':
+      return { size: view === '3d' ? 4 : 6 };
+    default:
+      return { size: 3 };
+  }
 };
 
 export const createDataObject = (
@@ -61,11 +79,9 @@ export const createDataObject = (
       y: view === '3d' ? y : z,
       type: view === '3d' ? 'scatter3d' : 'scatter',
       mode: getMode(type),
-      line: getLine(type),
+      line: getLine(type, view),
       textposition: 'top center',
-      marker: {
-        size: 3
-      },
+      marker: getMarker(type, view),
       text: getText(type, points, startSupport + index)
     };
     return dataObject;


### PR DESCRIPTION
Make that the y axis is the same than the x axis when being in 3D.

note from review (add in the scope):

- doc on the different parameters used
- to variablelize : yaxis depends on side (profile/face)
- appearance order to meet the following : from background : support , cable, insulator

**Please check if the PR fulfills these requirements**
<!-- please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes -->
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**Does this PR already have an issue describing the problem?**
<!-- If so, link to this issue using `'Fixes #XXX'` and skip the rest -->



**What kind of change does this PR introduce?**
<!-- Bug fix, feature, docs update, ... -->



**What is the current behavior?**
<!-- You can also link to an open issue here -->



**What is the new behavior (if this is a feature change)?**



**Does this PR introduce a breaking change or deprecate an API?**
- [ ] Yes
- [ ] No

**If yes, please check if the following requirements are fulfilled**
<!-- If no breaking changes or API deprecations were introduced, delete this section -->
- [ ] The *breaking change* or *deprecated* label has been added
- [ ] The migration steps are described in the following section

**What changes might users need to make in their application due to this PR? (migration steps)**
<!-- If this PR introduces a breaking change, describe the migration steps -->
<!-- The content of this section will be copied in the migration guide -->



**Other information**:
<!-- if any of the questions/checkboxes don't apply, please delete them entirely -->
