### PR TITLE
fix modal transition between init and main for toolbar-dialog

### DIFF
--- a/src/app/ui/pages/studio/toolbar-dialog/field-measuring/field-measuring.component.spec.ts
+++ b/src/app/ui/pages/studio/toolbar-dialog/field-measuring/field-measuring.component.spec.ts
@@ -14,6 +14,7 @@ import { PlotService } from '@ui/pages/studio/services/plot.service';
 import { BehaviorSubject } from 'rxjs';
 import { Section } from '@core/domain';
 import { LinesService } from '@services/lines/lines.service';
+import { CablesService } from '@services/cables/cables.service';
 
 @Component({
   selector: 'app-button',
@@ -92,6 +93,11 @@ describe('FieldMeasuringComponent', () => {
       getLines: jest.fn().mockResolvedValue([])
     } as unknown as LinesService;
 
+    const mockCablesService = {
+      getCables: jest.fn().mockResolvedValue([]),
+      ready: new BehaviorSubject<boolean>(true)
+    } as unknown as CablesService;
+
     await TestBed.configureTestingModule({
       providers: [
         ToolbarDialogService,
@@ -102,7 +108,8 @@ describe('FieldMeasuringComponent', () => {
         { provide: StudiesService, useValue: mockStudiesService },
         { provide: SectionService, useValue: mockSectionService },
         { provide: PlotService, useValue: mockPlotService },
-        { provide: LinesService, useValue: mockLinesService }
+        { provide: LinesService, useValue: mockLinesService },
+        { provide: CablesService, useValue: mockCablesService }
       ]
     })
       .overrideComponent(FieldMeasuringComponent, {
@@ -370,11 +377,9 @@ describe('FieldMeasuringComponent', () => {
       expect(toolbarDialogService.isOpen()).toBe(true);
       expect(toolbarDialogService.phase()).toBe('init');
 
-      // Proceed to main component
+      // Proceed to main component (event-driven transition)
       toolbarDialogService.proceedToMainComponent();
-
-      // Wait for the timeout that opens main dialog
-      await new Promise((resolve) => setTimeout(resolve, 200));
+      toolbarDialogService.completePendingTransition();
       expect(toolbarDialogService.isOpen()).toBe(true);
       expect(toolbarDialogService.phase()).toBe('main');
 
@@ -384,12 +389,10 @@ describe('FieldMeasuringComponent', () => {
       expect(toolbarDialogService.phase()).toBe('main');
     });
 
-    it('should work with onVisibleChange integration', async () => {
+    it('should work with onVisibleChange integration', () => {
       toolbarDialogService.openTool('field-measuring');
       toolbarDialogService.proceedToMainComponent();
-
-      // Wait for the timeout that opens main dialog
-      await new Promise((resolve) => setTimeout(resolve, 200));
+      toolbarDialogService.completePendingTransition();
       expect(toolbarDialogService.isOpen()).toBe(true);
       expect(toolbarDialogService.phase()).toBe('main');
 
@@ -412,18 +415,18 @@ describe('FieldMeasuringComponent', () => {
       // Open main dialog to initialize measureData from PlotService
       toolbarDialogService.openTool('field-measuring');
       toolbarDialogService.proceedToMainComponent();
-      await new Promise((resolve) => setTimeout(resolve, 100));
+      toolbarDialogService.completePendingTransition();
 
       await component.onSave();
       // Re-open for subsequent calls
       toolbarDialogService.openTool('field-measuring');
       toolbarDialogService.proceedToMainComponent();
-      await new Promise((resolve) => setTimeout(resolve, 100));
+      toolbarDialogService.completePendingTransition();
       await component.onSave();
       // Re-open for third call
       toolbarDialogService.openTool('field-measuring');
       toolbarDialogService.proceedToMainComponent();
-      await new Promise((resolve) => setTimeout(resolve, 100));
+      toolbarDialogService.completePendingTransition();
       await component.onSave();
 
       expect(modifySectionSpy).toHaveBeenCalledTimes(3);
@@ -453,9 +456,11 @@ describe('FieldMeasuringComponent', () => {
 
       toolbarDialogService.openTool('field-measuring');
       toolbarDialogService.proceedToMainComponent();
+      toolbarDialogService.completePendingTransition();
+      fixture.detectChanges();
 
-      // Wait for async operations
-      await new Promise((resolve) => setTimeout(resolve, 200));
+      // Wait for async operations (getLines, getCables)
+      await new Promise((resolve) => setTimeout(resolve, 50));
       fixture.detectChanges();
 
       // Verify that getLines was called as part of initialization

--- a/src/app/ui/pages/studio/toolbar-dialog/toolbar-dialog.component.html
+++ b/src/app/ui/pages/studio/toolbar-dialog/toolbar-dialog.component.html
@@ -1,7 +1,7 @@
 <p-dialog
   dismissableMask="false"
   [visible]="toolbarDialogService.isOpen()"
-  (visibleChange)="toolbarDialogService.isOpen.set($event)"
+  (visibleChange)="onVisibleChange($event)"
   [modal]="true"
   [style]="toolbarDialogService.getDialogStyle()"
   closeAriaLabel="Close"

--- a/src/app/ui/pages/studio/toolbar-dialog/toolbar-dialog.component.spec.ts
+++ b/src/app/ui/pages/studio/toolbar-dialog/toolbar-dialog.component.spec.ts
@@ -150,13 +150,44 @@ describe('ToolbarDialogComponent', () => {
       expect(closeToolSpy).toHaveBeenCalled();
     });
 
-    it('should not call closeTool when transitioning', () => {
+    it('should call completePendingTransition when transitioning', () => {
+      const completeSpy = jest.spyOn(
+        toolbarDialogService,
+        'completePendingTransition'
+      );
       const closeToolSpy = jest.spyOn(toolbarDialogService, 'closeTool');
       toolbarDialogService.openTool('field-measuring');
       toolbarDialogService.proceedToMainComponent();
 
       component.onDialogHide();
+      expect(completeSpy).toHaveBeenCalled();
       expect(closeToolSpy).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('onVisibleChange', () => {
+    it('should update isOpen when not transitioning', () => {
+      toolbarDialogService.isOpen.set(true);
+      component.onVisibleChange(false);
+      expect(toolbarDialogService.isOpen()).toBe(false);
+    });
+
+    it('should not set isOpen to false when transitioning', () => {
+      toolbarDialogService.openTool('field-measuring');
+      toolbarDialogService.proceedToMainComponent();
+
+      component.onVisibleChange(false);
+      expect(toolbarDialogService.isOpen()).toBe(false);
+      // isOpen was already false from proceedToMainComponent,
+      // but the key is the event didn't interfere
+    });
+
+    it('should allow setting isOpen to true during transition', () => {
+      toolbarDialogService.openTool('field-measuring');
+      toolbarDialogService.proceedToMainComponent();
+
+      component.onVisibleChange(true);
+      expect(toolbarDialogService.isOpen()).toBe(true);
     });
   });
 });

--- a/src/app/ui/pages/studio/toolbar-dialog/toolbar-dialog.component.ts
+++ b/src/app/ui/pages/studio/toolbar-dialog/toolbar-dialog.component.ts
@@ -12,8 +12,17 @@ export class ToolbarDialogComponent {
   readonly toolbarDialogService = inject(ToolbarDialogService);
   readonly injector = inject(Injector);
 
+  onVisibleChange(visible: boolean): void {
+    if (!visible && this.toolbarDialogService.isTransitioning()) {
+      return;
+    }
+    this.toolbarDialogService.isOpen.set(visible);
+  }
+
   onDialogHide(): void {
-    if (!this.toolbarDialogService.isTransitioning()) {
+    if (this.toolbarDialogService.isTransitioning()) {
+      this.toolbarDialogService.completePendingTransition();
+    } else {
       this.toolbarDialogService.closeTool();
     }
   }

--- a/src/app/ui/pages/studio/toolbar-dialog/toolbar-dialog.service.spec.ts
+++ b/src/app/ui/pages/studio/toolbar-dialog/toolbar-dialog.service.spec.ts
@@ -70,21 +70,16 @@ describe('ToolbarDialogService', () => {
       expect(service.phase()).toBe('main');
     });
 
-    it('should reset to init phase when reopening tool with initComponent', (done) => {
+    it('should reset to init phase when reopening tool with initComponent', () => {
       service.openTool('field-measuring');
       service.proceedToMainComponent();
-      expect(service.isOpen()).toBe(false);
+      service.completePendingTransition();
+      expect(service.isOpen()).toBe(true);
+      expect(service.phase()).toBe('main');
 
-      // Wait for the timeout that opens main dialog
-      setTimeout(() => {
-        expect(service.isOpen()).toBe(true);
-        expect(service.phase()).toBe('main');
-
-        service.openTool('field-measuring');
-        expect(service.isOpen()).toBe(true);
-        expect(service.phase()).toBe('init');
-        done();
-      }, 200);
+      service.openTool('field-measuring');
+      expect(service.isOpen()).toBe(true);
+      expect(service.phase()).toBe('init');
     });
   });
 
@@ -135,14 +130,11 @@ describe('ToolbarDialogService', () => {
       expect(service.getComponent()).toBe(InitComponent);
     });
 
-    it('should return FieldMeasuringComponent after proceeding to main phase', (done) => {
+    it('should return FieldMeasuringComponent after proceeding to main phase', () => {
       service.openTool('field-measuring');
       service.proceedToMainComponent();
-
-      setTimeout(() => {
-        expect(service.getComponent()).toBe(FieldMeasuringComponent);
-        done();
-      }, 200);
+      service.completePendingTransition();
+      expect(service.getComponent()).toBe(FieldMeasuringComponent);
     });
 
     it('should return null for other-tool in init phase check', () => {
@@ -173,17 +165,14 @@ describe('ToolbarDialogService', () => {
       });
     });
 
-    it('should return main style after proceeding from init', (done) => {
+    it('should return main style after proceeding from init', () => {
       service.openTool('field-measuring');
       service.proceedToMainComponent();
-
-      setTimeout(() => {
-        expect(service.getDialogStyle()).toEqual({
-          width: '72.5rem',
-          'max-width': '90%'
-        });
-        done();
-      }, 200);
+      service.completePendingTransition();
+      expect(service.getDialogStyle()).toEqual({
+        width: '72.5rem',
+        'max-width': '90%'
+      });
     });
 
     it('should return empty object for other-tool with no custom style', () => {
@@ -204,44 +193,43 @@ describe('ToolbarDialogService', () => {
   });
 
   describe('proceedToMainComponent', () => {
-    it('should close dialog and reopen in main phase', (done) => {
+    it('should close dialog and set transitioning flag', () => {
       service.openTool('field-measuring');
       expect(service.isOpen()).toBe(true);
       expect(service.phase()).toBe('init');
 
       service.proceedToMainComponent();
       expect(service.isOpen()).toBe(false);
-
-      // Wait for the timeout that opens main dialog
-      setTimeout(() => {
-        expect(service.isOpen()).toBe(true);
-        expect(service.phase()).toBe('main');
-        done();
-      }, 200);
+      expect(service.isTransitioning()).toBe(true);
+      expect(service.phase()).toBe('init');
     });
 
-    it('should not affect other state when called', () => {
+    it('should not affect currentTool when called', () => {
       service.openTool('field-measuring');
       service.proceedToMainComponent();
 
       expect(service.currentTool()).toBe('field-measuring');
     });
+  });
 
-    it('should set transitioning flag during transition', () => {
+  describe('completePendingTransition', () => {
+    it('should switch to main phase and reopen dialog', () => {
       service.openTool('field-measuring');
       service.proceedToMainComponent();
 
-      expect(service.isTransitioning()).toBe(true);
+      service.completePendingTransition();
+      expect(service.isOpen()).toBe(true);
+      expect(service.phase()).toBe('main');
+      expect(service.isTransitioning()).toBe(false);
     });
 
-    it('should clear transitioning flag after transition completes', (done) => {
+    it('should do nothing if no transition is pending', () => {
       service.openTool('field-measuring');
-      service.proceedToMainComponent();
+      expect(service.phase()).toBe('init');
 
-      setTimeout(() => {
-        expect(service.isTransitioning()).toBe(false);
-        done();
-      }, 200);
+      service.completePendingTransition();
+      expect(service.phase()).toBe('init');
+      expect(service.isOpen()).toBe(true);
     });
   });
 
@@ -313,7 +301,7 @@ describe('ToolbarDialogService', () => {
       expect(service.isOpen()).toBe(false);
     });
 
-    it('should update phase signal value when transitioning to main', (done) => {
+    it('should update phase signal value when transitioning to main', () => {
       expect(service.isOpen()).toBe(false);
 
       service.openTool('field-measuring');
@@ -322,12 +310,12 @@ describe('ToolbarDialogService', () => {
 
       service.proceedToMainComponent();
       expect(service.isOpen()).toBe(false);
+      expect(service.isTransitioning()).toBe(true);
 
-      setTimeout(() => {
-        expect(service.isOpen()).toBe(true);
-        expect(service.phase()).toBe('main');
-        done();
-      }, 200);
+      service.completePendingTransition();
+      expect(service.isOpen()).toBe(true);
+      expect(service.phase()).toBe('main');
+      expect(service.isTransitioning()).toBe(false);
     });
   });
 

--- a/src/app/ui/pages/studio/toolbar-dialog/toolbar-dialog.service.ts
+++ b/src/app/ui/pages/studio/toolbar-dialog/toolbar-dialog.service.ts
@@ -41,8 +41,6 @@ export class ToolbarDialogService {
   readonly templates = signal<ToolTemplates>({});
   readonly loadTableContext = signal<LoadTableContext | null>(null);
 
-  private transitioning = false;
-
   private readonly toolMap: Record<Tool, ToolConfig> = {
     'field-measuring': {
       component: FieldMeasuringComponent,
@@ -94,14 +92,19 @@ export class ToolbarDialogService {
     }, 300);
   }
 
+  private transitioning = false;
+
   proceedToMainComponent(): void {
     this.transitioning = true;
     this.isOpen.set(false);
-    setTimeout(() => {
+  }
+
+  completePendingTransition(): void {
+    if (this.transitioning) {
+      this.transitioning = false;
       this.phase.set('main');
       this.isOpen.set(true);
-      this.transitioning = false;
-    }, 150);
+    }
   }
 
   isTransitioning(): boolean {


### PR DESCRIPTION
Fix the bug encountered for transition between init and main content modal with toolbar-dialog.
timeout method was too weak to rely on for transition. Now using native primeNG visibleChange event to flag the current state for init / main