### PR TITLE
fixbug 570 bug freeze app when change span in charge

### DIFF
--- a/docs-sphinx/source/user_docs/developer_guide/app/angular_signals_pitfalls.md
+++ b/docs-sphinx/source/user_docs/developer_guide/app/angular_signals_pitfalls.md
@@ -1,0 +1,115 @@
+
+
+
+
+# Angular Signals — Common Pitfalls (section, span, support)
+
+This document lists the reactive bugs identified in the application related to the use of Angular signals (`signal`, `computed`, `effect`, `toSignal`).
+It serves as a reference to avoid reproducing these errors in future developments, using the project's business vocabulary: **section** (sometimes called "canton"), **span**, **support**.
+
+---
+
+
+
+## Bug #447 — Application freeze when changing span
+
+**Affected component**: `src/app/ui/pages/studio/loads/span/span.component.ts`
+
+**Fix branch**: `fixbug/freeze-app-when-switch-span-in-charge`
+
+### Symptom
+
+The entire application would freeze as soon as the user selected a value in the span selector of the loads panel.
+
+
+### Identified causes
+
+Three distinct issues combined to cause this behavior.
+
+---
+
+
+
+#### Cause 1 — Unintentional reactive dependency on `section()` in an `effect`
+
+In the project, a **section** (sometimes called "canton") groups several **spans**, and each span is delimited by two **supports**. Any function called inside an `effect()` body that reads an Angular signal will register that signal as a **reactive dependency** of the effect — even if this is not the intended behavior.
+
+In `spanSelectEffect`, the methods `getSupportIndex()` and `getSupportOptions()` of `PlotService` read `section()` internally. Angular therefore registered `section()` as a dependency of the effect. However, `section()` is updated on every Dexie emission (with a new reference object, even if the data is identical), which caused `spanSelectEffect` to reload in a loop, freezing the app.
+
+```typescript
+// INCORRECT — section() is registered as a dependency of the effect
+private readonly spanSelectEffect = effect(() => {
+  const value = this.spanSelectSignal();
+  const index = this.plotService.getSupportIndex(value); // reads section() internally
+});
+
+// CORRECT — untracked() isolates the signal read
+private readonly spanSelectEffect = effect(() => {
+  const value = this.spanSelectSignal();
+  const index = untracked(() => this.plotService.getSupportIndex(value));
+});
+```
+
+> **Rule**: Use `untracked(() => fn())` to call functions that read signals (e.g. `section()`, `span()`, `support()`) when you do not want those signals to trigger the effect.
+
+---
+
+
+#### Cause 2 — `enable()` without `{ emitEvent: false }` triggers unwanted reactive effects
+
+`AbstractControl.enable()` emits on `valueChanges` by default. If a signal was created with `toSignal(control.valueChanges)`, enabling the control updates the signal with the control's current value (which may be stale), triggering reactive effects at the wrong time.
+
+In the business context, this can impact the selected **span** or the current **support** control.
+
+```typescript
+// INCORRECT — emits on valueChanges, updates the signal with a stale value
+this.form.controls.referenceSpan.enable();
+
+// CORRECT — enables the control for user interaction without triggering the reactive chain
+this.form.controls.referenceSpan.enable({ emitEvent: false });
+```
+
+> **Rule**: Always pass `{ emitEvent: false }` to `enable()` and `disable()` when a `toSignal` signal is subscribed to the control's `valueChanges` (e.g. for a **span** or **support** field), unless the emission is intentional.
+
+---
+
+
+#### Cause 3 — A single `effect` for multiple signals causes data corruption
+
+An `effect()` that reads N signals (for example, several fields related to section, span, or support) will trigger when **any** of them changes, and then processes **all** signals together. If some signals have stale values (because `setValue(..., { emitEvent: false })` does not update them), this can overwrite correct data with incorrect values.
+
+```typescript
+// INCORRECT — a single effect reads all 4 signals; if the span changes,
+// the other 3 fields are still updated with their stale values
+private readonly spanControlsEffect = effect(() => {
+  Object.keys(this.spanControlSignals).forEach((controlName) => {
+    const value = this.spanControlSignals[controlName]();
+    if (value !== undefined) this.onSpanControlChange(controlName, value);
+  });
+});
+
+// CORRECT — one effect per control, each only updates its own field
+private readonly spanPositionEffect = effect(() => {
+  const value = this.spanControlSignals.spanPosition();
+  if (value !== undefined) this.onSpanControlChange('spanPosition', value);
+});
+
+private readonly supportEffect = effect(() => {
+  const value = this.spanControlSignals.support();
+  if (value !== undefined) this.onSpanControlChange('support', value);
+});
+
+// etc.
+```
+
+> **Rule**: Create a separate `effect()` per signal (section, span, support, etc.) when each change should trigger an independent action. Avoid grouping distinct logic in a single effect.
+
+---
+
+### Summary of applied fixes
+
+| # | Problem | Fix |
+|---|---------|-----|
+| 1 | `section()` registered as an unintended dependency | `untracked()` around calls to `getSupportIndex()` and `getSupportOptions()` |
+| 2 | `enable()` triggers reactive effects with stale value | `enable({ emitEvent: false })` on span/support controls |
+| 3 | One effect for N signals overwrites data with stale values | Separate effects for each business signal (section, span, support, etc.) |

--- a/docs-sphinx/source/user_docs/developer_guide/app/index.md
+++ b/docs-sphinx/source/user_docs/developer_guide/app/index.md
@@ -9,4 +9,5 @@ custom_components
 engine_worker
 offline_database
 theme_styles
+angular_signals_pitfalls
 ```

--- a/src/app/ui/pages/studio/loads/span/span.component.spec.ts
+++ b/src/app/ui/pages/studio/loads/span/span.component.spec.ts
@@ -231,6 +231,170 @@ describe('SpanComponent', () => {
     });
   });
 
+  describe('Regression: Bug #447 — App freeze when switching span', () => {
+    /**
+     * Helper creating two distinct span loads used across regression tests.
+     * - support-1: referenceSupport LEFT, type PUNCTUAL, loadWeight 10, loadPosition 2
+     * - support-2: referenceSupport LEFT, type PUNCTUAL, loadWeight 20, loadPosition 5
+     */
+    const createTemporaryLoadDataTwoSpans = (): ChargeData => ({
+      climate: {
+        windPressure: null,
+        cableTemperature: null,
+        symmetryType: SymmetryType.SYMMETRIC,
+        iceThickness: null,
+        frontierSupportNumber: null,
+        iceThicknessBefore: null,
+        iceThicknessAfter: null
+      },
+      spanLoads: [
+        {
+          supportUuid: 'support-1',
+          referenceSupport: 'LEFT' as const,
+          type: LoadType.PUNCTUAL,
+          loadWeight: 10,
+          loadPosition: 2
+        },
+        {
+          supportUuid: 'support-2',
+          referenceSupport: 'LEFT' as const,
+          type: LoadType.PUNCTUAL,
+          loadWeight: 20,
+          loadPosition: 5
+        }
+      ]
+    });
+
+    beforeEach(() => {
+      (mockPlotService['getSupportIndex'] as jest.Mock).mockImplementation((uuid: string) =>
+        uuid === 'support-1' ? 0 : uuid === 'support-2' ? 1 : -1
+      );
+    });
+
+    describe('Bug 1 — spanSelectEffect must not track section() as a reactive dependency', () => {
+      it('should not call plotOptionsChange again when a signal read inside getSupportIndex changes', () => {
+        // Simulate the real PlotService.getSupportIndex which reads section() internally.
+        // Without untracked(), that read would register section() as a dependency of
+        // spanSelectEffect, causing the effect to re-run on every Dexie emission.
+        const internalSignal = signal(0);
+        (mockPlotService['getSupportIndex'] as jest.Mock).mockImplementation(() => {
+          internalSignal(); // reads a signal — simulates reading section()
+          return 0;
+        });
+
+        component.form.controls.spanSelect.setValue('support-1');
+        fixture.detectChanges();
+
+        expect(mockPlotService['plotOptionsChange']).toHaveBeenCalledTimes(1);
+
+        // Simulate a section() change (e.g. a new Dexie emission with a fresh object reference)
+        internalSignal.set(1);
+        fixture.detectChanges();
+
+        // spanSelectEffect must NOT have re-run because getSupportIndex is wrapped in untracked()
+        expect(mockPlotService['plotOptionsChange']).toHaveBeenCalledTimes(1);
+      });
+    });
+
+    describe('Bug 2 — enable() must use { emitEvent: false } to avoid corrupting load data', () => {
+      it('should preserve span A load data when switching back to span A after visiting span B', () => {
+        // Scenario:
+        // 1. Select span A, user sets referenceSupport to 'RIGHT' → signal = 'RIGHT'
+        // 2. Switch to span B → applySelectedLoadValues sets form to 'LEFT' (emitEvent:false)
+        //    signal stays 'RIGHT', but the form control value is now 'LEFT'
+        // 3. Switch back to span A → enable() (already enabled) re-emits 'LEFT' (the current form value)
+        //    Without emitEvent:false: signal 'RIGHT'→'LEFT' → referenceSupportEffect fires
+        //    → onLoadControlChange('referenceSupport', 'LEFT') → span A data corrupted to 'LEFT'
+        const temporaryLoadData = createTemporaryLoadDataTwoSpans();
+        mockPlotService['temporaryLoadData'] = temporaryLoadData;
+
+        // Step 1 — select span A and simulate the user choosing 'RIGHT'
+        component.form.controls.spanSelect.setValue('support-1');
+        fixture.detectChanges();
+        component.form.controls.referenceSupport.setValue('RIGHT');
+        fixture.detectChanges();
+        expect(temporaryLoadData.spanLoads[0].referenceSupport).toBe('RIGHT');
+
+        // Step 2 — switch to span B: form becomes 'LEFT' (span B data), signal stays 'RIGHT'
+        component.form.controls.spanSelect.setValue('support-2');
+        fixture.detectChanges();
+
+        // Step 3 — switch back to span A: enable() would emit 'LEFT' (current form value)
+        // if emitEvent:true, triggering the effect with a stale value
+        component.form.controls.spanSelect.setValue('support-1');
+        fixture.detectChanges();
+
+        // Span A's referenceSupport must remain 'RIGHT', not be overwritten by span B's form value
+        expect(temporaryLoadData.spanLoads[0].referenceSupport).toBe('RIGHT');
+      });
+    });
+
+    describe('Bug 3 — individual effects must not overwrite fields of other controls with stale signal values', () => {
+      it('should not overwrite type or loadWeight of span B when only loadPosition changes', () => {
+        // Scenario:
+        // 1. Select span A, set type to MARKING → type signal = 'marking'
+        // 2. Switch to span B (PUNCTUAL, loadWeight 20) → applySelectedLoadValues sets form.type
+        //    to 'punctual' with emitEvent:false → type signal stays 'marking'
+        // 3. User changes loadPosition on span B
+        //    Old bug (combined effect): type signal 'marking' → onLoadControlChange('type','marking')
+        //    → span B type overwritten to 'marking' AND loadWeight reset to 0
+        //    Fix (separate effects): only loadPositionEffect fires → only loadPosition updated
+        const temporaryLoadData = createTemporaryLoadDataTwoSpans();
+        mockPlotService['temporaryLoadData'] = temporaryLoadData;
+
+        // Step 1 — select span A and set type to MARKING
+        component.form.controls.spanSelect.setValue('support-1');
+        fixture.detectChanges();
+        component.form.controls.type.setValue(LoadType.MARKING);
+        fixture.detectChanges();
+        // type signal is now 'marking'
+
+        // Step 2 — switch to span B: form.type → 'punctual' (emitEvent:false), signal stays 'marking'
+        component.form.controls.spanSelect.setValue('support-2');
+        fixture.detectChanges();
+
+        // Step 3 — user changes only loadPosition on span B
+        component.form.controls.loadPosition.setValue(99);
+        fixture.detectChanges();
+
+        expect(temporaryLoadData.spanLoads[1].type).toBe(LoadType.PUNCTUAL);
+        expect(temporaryLoadData.spanLoads[1].loadWeight).toBe(20);
+        expect(temporaryLoadData.spanLoads[1].loadPosition).toBe(99);
+      });
+
+      it('should not overwrite loadWeight of span B when only referenceSupport changes', () => {
+        // Scenario:
+        // 1. Select span A, user sets loadWeight to 999 → loadWeight signal = 999
+        // 2. Switch to span B (loadWeight 20) → applySelectedLoadValues sets form.loadWeight
+        //    to 20 with emitEvent:false → loadWeight signal stays 999
+        // 3. User changes referenceSupport on span B
+        //    Old bug (combined effect): loadWeight signal 999 → onLoadControlChange('loadWeight',999)
+        //    → span B loadWeight overwritten to 999
+        //    Fix (separate effects): only referenceSupportEffect fires → only referenceSupport updated
+        const temporaryLoadData = createTemporaryLoadDataTwoSpans();
+        mockPlotService['temporaryLoadData'] = temporaryLoadData;
+
+        // Step 1 — select span A and set loadWeight to 999
+        component.form.controls.spanSelect.setValue('support-1');
+        fixture.detectChanges();
+        component.form.controls.loadWeight.setValue(999);
+        fixture.detectChanges();
+        // loadWeight signal is now 999
+
+        // Step 2 — switch to span B: form.loadWeight → 20 (emitEvent:false), signal stays 999
+        component.form.controls.spanSelect.setValue('support-2');
+        fixture.detectChanges();
+
+        // Step 3 — user changes only referenceSupport on span B
+        component.form.controls.referenceSupport.setValue('RIGHT');
+        fixture.detectChanges();
+
+        expect(temporaryLoadData.spanLoads[1].loadWeight).toBe(20);
+        expect(temporaryLoadData.spanLoads[1].referenceSupport).toBe('RIGHT');
+      });
+    });
+  });
+
   describe('UI state', () => {
     it('disables save and calculate buttons when form is invalid', () => {
       const saveButton = getByTestId('save-load') as HTMLButtonElement;

--- a/src/app/ui/pages/studio/loads/span/span.component.ts
+++ b/src/app/ui/pages/studio/loads/span/span.component.ts
@@ -1,4 +1,4 @@
-import { Component, computed, effect, inject, Signal, signal } from '@angular/core';
+import { Component, computed, effect, inject, Signal, signal, untracked } from '@angular/core';
 import { FormBuilder, FormControl, FormsModule, ReactiveFormsModule, Validators } from '@angular/forms';
 import { ButtonComponent } from '@ui/shared/components/atoms/button/button.component';
 import { IconComponent } from '@ui/shared/components/atoms/icon/icon.component';
@@ -84,13 +84,24 @@ export class SpanComponent {
     this.onSpanSelectChange(value ?? null);
   });
 
-  private readonly loadControlsEffect = effect(() => {
-    (Object.keys(this.loadControlSignals) as LoadControlName[]).forEach((controlName) => {
-      const value = this.loadControlSignals[controlName]();
-      if (value !== undefined) {
-        this.onLoadControlChange(controlName, value);
-      }
-    });
+  private readonly loadPositionEffect = effect(() => {
+    const value = this.loadControlSignals.loadPosition();
+    if (value !== undefined) this.onLoadControlChange('loadPosition', value);
+  });
+
+  private readonly loadWeightEffect = effect(() => {
+    const value = this.loadControlSignals.loadWeight();
+    if (value !== undefined) this.onLoadControlChange('loadWeight', value);
+  });
+
+  private readonly typeEffect = effect(() => {
+    const value = this.loadControlSignals.type();
+    if (value !== undefined) this.onLoadControlChange('type', value);
+  });
+
+  private readonly referenceSupportEffect = effect(() => {
+    const value = this.loadControlSignals.referenceSupport();
+    if (value !== undefined) this.onLoadControlChange('referenceSupport', value);
   });
 
   loadTypeOptions = [
@@ -139,13 +150,13 @@ export class SpanComponent {
       return;
     }
 
-    const index = this.plotService.getSupportIndex(supportUuid);
+    const index = untracked(() => this.plotService.getSupportIndex(supportUuid));
     if (index < 0) {
       return;
     }
 
-    this.supportsOptions.set(this.plotService.getSupportOptions(supportUuid));
-    this.form.controls.referenceSupport.enable();
+    this.supportsOptions.set(untracked(() => this.plotService.getSupportOptions(supportUuid)));
+    this.form.controls.referenceSupport.enable({ emitEvent: false });
     this.plotService.plotOptionsChange({
       startSupport: index,
       endSupport: index + 1


### PR DESCRIPTION
Please check if the PR fulfills these requirements
  - Tests for the changes have been added (for bug fixes / features)
  - Docs have been added / updated (for bug fixes / features)                                               
TICKET:  https://github.com/phlowers/phlowers-stellar-app/issues/570  

  Does this PR already have an issue describing the problem?                                                
                                                            
  Fixes #447 (freeze app when switching span in charge)

  Voici la version anglaise de votre document, structurée exactement comme l'image fournie :

What is the current behavior?

The application entirely freezes when the user changes the span selector (spanSelect) value in the loading panel. Three combined issues were causing this behavior:

getSupportIndex() and getSupportOptions() read the section() signal inside the spanSelectEffect body. Angular was therefore registering section() as an unintended reactive dependency of the effect. With every Dexie emission (which returns a new object even if the data is identical), spanSelectEffect would re-trigger, call plotOptionsChange(), which triggered plotOptions.set(), saturating the reactive loop and freezing the UI.

enable() called without { emitEvent: false } was emitting on valueChanges, updating the referenceSupport signal with an obsolete value, which triggered loadControlsEffect with incorrect data during the span change.

A single loadControlsEffect was reading all 4 signals at once. When only one changed, it called onLoadControlChange() for all 4 fields with obsolete signal values (as applySelectedLoadValues uses emitEvent: false and does not update the signals), corrupting the loading data.

What is the new behavior (if this is a feature change)?

untracked() is used around calls to getSupportIndex() and getSupportOptions() in onSpanSelectChange(), preventing section() from being registered as a dependency of spanSelectEffect. The effect no longer re-triggers during Dexie emissions.

enable({ emitEvent: false }) is used to activate the referenceSupport control without emitting on valueChanges, avoiding the trigger of reactive effects with obsolete values.

The single loadControlsEffect is replaced by 4 separate effects (one per control: loadPosition, loadWeight, type, referenceSupport). Each effect only triggers for its own signal and only updates its corresponding field, preventing any data corruption.

Does this PR introduce a breaking change or deprecate an API?

No

Other information:

All existing component tests (span.component.spec.ts) pass without modification. The 16 tests cover cases of span selection, loading existing values, changing type (punctual/marking), reset, and save. Specific unit tests have been added to prevent regressions on the reported bug, specifically ensuring that spanSelectEffect does not track unrelated signals.