### PR TITLE
Fixbug/599/Apply scale settings to 2D views

### DIFF
--- a/src/app/ui/shared/components/studio/section/helpers/createPlot.ts
+++ b/src/app/ui/shared/components/studio/section/helpers/createPlot.ts
@@ -123,6 +123,17 @@ const layout3d = (plotParams: CreatePlotParams): Partial<Layout> => ({
 });
 
 const layout2d: (plotParams: CreatePlotParams) => Partial<Layout> = (plotParams) => {
+  let scaleratio: number | undefined;
+  if (plotParams.axesNorms) {
+    if (plotParams.side === 'face') {
+      scaleratio = plotParams.axesNorms.z / plotParams.axesNorms.y;
+    } else if (plotParams.side === 'profile') {
+      scaleratio = plotParams.axesNorms.z / plotParams.axesNorms.x;
+    }
+  } else {
+    scaleratio = plotParams.side === 'face' ? 0.2 : undefined;
+  }
+
   return {
     autosize: true,
     showlegend: false,
@@ -145,8 +156,8 @@ const layout2d: (plotParams: CreatePlotParams) => Partial<Layout> = (plotParams)
       showticklabels: true,
       showgrid: true,
       showline: true,
-      scaleratio: plotParams.side === 'face' ? 0.2 : undefined,
-      scaleanchor: plotParams.side === 'face' ? 'x' : undefined
+      scaleratio,
+      scaleanchor: scaleratio !== undefined ? 'x' : undefined
     },
     annotations: [...createLoadAnnotations(plotParams), ...createObstaclesAnnotations(plotParams)]
   };


### PR DESCRIPTION
fix scale on 2D

[599](https://github.com/orgs/phlowers/projects/6/views/1?pane=issue&itemId=164309839&issue=phlowers%7Cphlowers-stellar-app%7C599)

Fix: Apply scale settings to 2D views
Problem
Scale configurations ([plan](vscode-file://vscode-app/c:/Users/madrangesfre/AppData/Local/Programs/Microsoft%20VS%20Code/0870c2a0c7/resources/app/out/vs/code/electron-browser/workbench/workbench.html), [geo](vscode-file://vscode-app/c:/Users/madrangesfre/AppData/Local/Programs/Microsoft%20VS%20Code/0870c2a0c7/resources/app/out/vs/code/electron-browser/workbench/workbench.html), [celeste](vscode-file://vscode-app/c:/Users/madrangesfre/AppData/Local/Programs/Microsoft%20VS%20Code/0870c2a0c7/resources/app/out/vs/code/electron-browser/workbench/workbench.html), [auto](vscode-file://vscode-app/c:/Users/madrangesfre/AppData/Local/Programs/Microsoft%20VS%20Code/0870c2a0c7/resources/app/out/vs/code/electron-browser/workbench/workbench.html)) from [ScaleViewComponent](vscode-file://vscode-app/c:/Users/madrangesfre/AppData/Local/Programs/Microsoft%20VS%20Code/0870c2a0c7/resources/app/out/vs/code/electron-browser/workbench/workbench.html) were only applied to 3D views. In 2D, the [scaleratio](vscode-file://vscode-app/c:/Users/madrangesfre/AppData/Local/Programs/Microsoft%20VS%20Code/0870c2a0c7/resources/app/out/vs/code/electron-browser/workbench/workbench.html) was hardcoded to 0.2 for 'face' view only.

Changes
Modified [layout2d()](vscode-file://vscode-app/c:/Users/madrangesfre/AppData/Local/Programs/Microsoft%20VS%20Code/0870c2a0c7/resources/app/out/vs/code/electron-browser/workbench/workbench.html) in [createPlot.ts](vscode-file://vscode-app/c:/Users/madrangesfre/AppData/Local/Programs/Microsoft%20VS%20Code/0870c2a0c7/resources/app/out/vs/code/electron-browser/workbench/workbench.html) to:

Calculate [scaleratio](vscode-file://vscode-app/c:/Users/madrangesfre/AppData/Local/Programs/Microsoft%20VS%20Code/0870c2a0c7/resources/app/out/vs/code/electron-browser/workbench/workbench.html) dynamically from [axesNorms](vscode-file://vscode-app/c:/Users/madrangesfre/AppData/Local/Programs/Microsoft%20VS%20Code/0870c2a0c7/resources/app/out/vs/code/electron-browser/workbench/workbench.html) values
Apply ratio to both 'face' and 'profile' views
Correct axis mapping:
Face view: displays (Y, Z) → [scaleratio = z / y](vscode-file://vscode-app/c:/Users/madrangesfre/AppData/Local/Programs/Microsoft%20VS%20Code/0870c2a0c7/resources/app/out/vs/code/electron-browser/workbench/workbench.html)
Profile view: displays (X, Z) → [scaleratio = z / x](vscode-file://vscode-app/c:/Users/madrangesfre/AppData/Local/Programs/Microsoft%20VS%20Code/0870c2a0c7/resources/app/out/vs/code/electron-browser/workbench/workbench.html)
Result
Scale modes now work in 2D:

'plan' [{x:0.2, y:1, z:1}](vscode-file://vscode-app/c:/Users/madrangesfre/AppData/Local/Programs/Microsoft%20VS%20Code/0870c2a0c7/resources/app/out/vs/code/electron-browser/workbench/workbench.html): optimized for top-down view
'geo' [{x:1, y:1, z:1}](vscode-file://vscode-app/c:/Users/madrangesfre/AppData/Local/Programs/Microsoft%20VS%20Code/0870c2a0c7/resources/app/out/vs/code/electron-browser/workbench/workbench.html): real proportions
'celeste' [{x:1, y:1, z:0.5}](vscode-file://vscode-app/c:/Users/madrangesfre/AppData/Local/Programs/Microsoft%20VS%20Code/0870c2a0c7/resources/app/out/vs/code/electron-browser/workbench/workbench.html): compressed height
'auto': Plotly auto-scaling
Files changed: [createPlot.ts](vscode-file://vscode-app/c:/Users/madrangesfre/AppData/Local/Programs/Microsoft%20VS%20Code/0870c2a0c7/resources/app/out/vs/code/electron-browser/workbench/workbench.html)