### PR TITLE
Feat/583/loading status with calc buttons

### DIFF
--- a/src/app/features/studio/field-measuring/presentation/components/calculus-setting/papoto/papoto.component.html
+++ b/src/app/features/studio/field-measuring/presentation/components/calculus-setting/papoto/papoto.component.html
@@ -250,7 +250,13 @@
 </div>
 
 <div class="text-right">
-  <button app-btn (click)="calculatePapoto()" [disabled]="!isFormValid()" [btnLoading]="isCalculating()" data-testid="calculate-papoto-btn">
+  <button
+    app-btn
+    (click)="calculatePapoto()"
+    [disabled]="!isFormValid()"
+    [btnLoading]="isCalculating()"
+    data-testid="calculate-papoto-btn"
+  >
     <app-icon icon="rocket_launch" />
     <ng-container i18n>Calculate</ng-container>
   </button>

--- a/src/app/features/studio/field-measuring/presentation/components/calculus-setting/papoto/papoto.component.html
+++ b/src/app/features/studio/field-measuring/presentation/components/calculus-setting/papoto/papoto.component.html
@@ -250,7 +250,7 @@
 </div>
 
 <div class="text-right">
-  <button app-btn (click)="calculatePapoto()" [disabled]="!isFormValid()" data-testid="calculate-papoto-btn">
+  <button app-btn (click)="calculatePapoto()" [disabled]="!isFormValid()" [btnLoading]="isCalculating()" data-testid="calculate-papoto-btn">
     <app-icon icon="rocket_launch" />
     <ng-container i18n>Calculate</ng-container>
   </button>

--- a/src/app/features/studio/field-measuring/presentation/components/calculus-setting/papoto/papoto.component.spec.ts
+++ b/src/app/features/studio/field-measuring/presentation/components/calculus-setting/papoto/papoto.component.spec.ts
@@ -101,7 +101,9 @@ describe('Papoto component', () => {
     it('should be true during calculation and false after', async () => {
       let resolveTask!: (value: { result: TaskOutputs[Task.calculatePapoto]; error: TaskError | null }) => void;
       workerPythonServiceMock.runTask.mockReturnValueOnce(
-        new Promise((res) => { resolveTask = res; })
+        new Promise((res) => {
+          resolveTask = res;
+        })
       );
 
       component.updateField('leftSupport', '12');
@@ -121,7 +123,10 @@ describe('Papoto component', () => {
       const calcPromise = component.calculatePapoto();
       expect(component.isCalculating()).toBe(true);
 
-      resolveTask({ result: { parameter: 0, parameter_1_2: 0, parameter_2_3: 0, parameter_1_3: 0, check_validity: true }, error: null });
+      resolveTask({
+        result: { parameter: 0, parameter_1_2: 0, parameter_2_3: 0, parameter_1_3: 0, check_validity: true },
+        error: null
+      });
       await calcPromise;
 
       expect(component.isCalculating()).toBe(false);

--- a/src/app/features/studio/field-measuring/presentation/components/calculus-setting/papoto/papoto.component.spec.ts
+++ b/src/app/features/studio/field-measuring/presentation/components/calculus-setting/papoto/papoto.component.spec.ts
@@ -8,7 +8,7 @@ import { PapotoComponent } from './papoto.component';
 import { createTestMeasureData } from '@features/studio/field-measuring/presentation/helpers';
 import { LEFT_SUPPORT_OPTIONS_MOCK } from '@features/studio/field-measuring/presentation/mock-data';
 import { WorkerPythonService } from '@services/worker_python/worker-python.service';
-import { Task, TaskError, GetSectionOutput } from '@services/worker_python/tasks/types';
+import { Task, TaskError, TaskOutputs, GetSectionOutput } from '@services/worker_python/tasks/types';
 import { PlotService } from '@services/plot/plot.service';
 
 describe('Papoto component', () => {
@@ -91,6 +91,62 @@ describe('Papoto component', () => {
     component.openHelp();
 
     expect(component.papotoHelpDialog()).toBe(true);
+  });
+
+  describe('isCalculating signal', () => {
+    it('should start as false', () => {
+      expect(component.isCalculating()).toBe(false);
+    });
+
+    it('should be true during calculation and false after', async () => {
+      let resolveTask!: (value: { result: TaskOutputs[Task.calculatePapoto]; error: TaskError | null }) => void;
+      workerPythonServiceMock.runTask.mockReturnValueOnce(
+        new Promise((res) => { resolveTask = res; })
+      );
+
+      component.updateField('leftSupport', '12');
+      component.updateField('spanLength', 100);
+      component.updateField('measuredElevationDifference', 5);
+      component.updateField('HL', 10);
+      component.updateField('H1', 20);
+      component.updateField('H2', 30);
+      component.updateField('H3', 40);
+      component.updateField('HR', 50);
+      component.updateField('VL', 15);
+      component.updateField('V1', 25);
+      component.updateField('V2', 35);
+      component.updateField('V3', 45);
+      component.updateField('VR', 55);
+
+      const calcPromise = component.calculatePapoto();
+      expect(component.isCalculating()).toBe(true);
+
+      resolveTask({ result: { parameter: 0, parameter_1_2: 0, parameter_2_3: 0, parameter_1_3: 0, check_validity: true }, error: null });
+      await calcPromise;
+
+      expect(component.isCalculating()).toBe(false);
+    });
+
+    it('should reset to false even when calculation throws', async () => {
+      workerPythonServiceMock.runTask.mockRejectedValue(new Error('unexpected'));
+
+      component.updateField('leftSupport', '12');
+      component.updateField('spanLength', 100);
+      component.updateField('measuredElevationDifference', 5);
+      component.updateField('HL', 10);
+      component.updateField('H1', 20);
+      component.updateField('H2', 30);
+      component.updateField('H3', 40);
+      component.updateField('HR', 50);
+      component.updateField('VL', 15);
+      component.updateField('V1', 25);
+      component.updateField('V2', 35);
+      component.updateField('V3', 45);
+      component.updateField('VR', 55);
+
+      await expect(component.calculatePapoto()).rejects.toThrow('unexpected');
+      expect(component.isCalculating()).toBe(false);
+    });
   });
 
   it('should calculate PAPOTO and show results', async () => {

--- a/src/app/features/studio/field-measuring/presentation/components/calculus-setting/papoto/papoto.component.ts
+++ b/src/app/features/studio/field-measuring/presentation/components/calculus-setting/papoto/papoto.component.ts
@@ -87,6 +87,7 @@ export class PapotoComponent {
   papotoHelpDialog = signal<boolean>(false);
 
   papotoError = signal<boolean>(false);
+  readonly isCalculating = signal(false);
 
   isFormValid = computed(() => {
     const data = this.measureData();
@@ -122,27 +123,31 @@ export class PapotoComponent {
       ...d,
       outputs: { ...d.outputs, papoto: null }
     }));
-    const { result, error } = await this.workerPythonService.runTask(Task.calculatePapoto, {
-      spanLength: data.spanLength || 0,
-      measuredElevationDifference: data.measuredElevationDifference || 0,
-      HL: data.HL || 0,
-      H1: data.H1 || 0,
-      H2: data.H2 || 0,
-      H3: data.H3 || 0,
-      HR: data.HR || 0,
-      VL: data.VL || 0,
-      V1: data.V1 || 0,
-      V2: data.V2 || 0,
-      V3: data.V3 || 0,
-      VR: data.VR || 0
-    });
-    if (error) {
-      this.papotoError.set(true);
+    this.isCalculating.set(true);
+    try {
+      const { result, error } = await this.workerPythonService.runTask(Task.calculatePapoto, {
+        spanLength: data.spanLength || 0,
+        measuredElevationDifference: data.measuredElevationDifference || 0,
+        HL: data.HL || 0,
+        H1: data.H1 || 0,
+        H2: data.H2 || 0,
+        H3: data.H3 || 0,
+        HR: data.HR || 0,
+        VL: data.VL || 0,
+        V1: data.V1 || 0,
+        V2: data.V2 || 0,
+        V3: data.V3 || 0,
+        VR: data.VR || 0
+      });
+      if (error) {
+        this.papotoError.set(true);
+      }
+      this.measureData.update((d) => ({
+        ...d,
+        outputs: { ...d.outputs, papoto: result }
+      }));
+    } finally {
+      this.isCalculating.set(false);
     }
-
-    this.measureData.update((d) => ({
-      ...d,
-      outputs: { ...d.outputs, papoto: result }
-    }));
   }
 }

--- a/src/app/features/studio/field-measuring/presentation/components/parameter-calculation-15-without-wind/parameter-calculation-15-without-wind.component.html
+++ b/src/app/features/studio/field-measuring/presentation/components/parameter-calculation-15-without-wind/parameter-calculation-15-without-wind.component.html
@@ -139,7 +139,7 @@
 </div>
 
 <div class="text-right mt-8">
-  <button app-btn (click)="calculateParameter15C()" [disabled]="!isFormValid()" data-testid="calculate-parameter-btn">
+  <button app-btn (click)="calculateParameter15C()" [disabled]="!isFormValid()" [btnLoading]="isCalculating()" data-testid="calculate-parameter-btn">
     <app-icon icon="rocket_launch" />
     <ng-container i18n>Calculate setting parameter at 15°C</ng-container>
   </button>

--- a/src/app/features/studio/field-measuring/presentation/components/parameter-calculation-15-without-wind/parameter-calculation-15-without-wind.component.html
+++ b/src/app/features/studio/field-measuring/presentation/components/parameter-calculation-15-without-wind/parameter-calculation-15-without-wind.component.html
@@ -139,7 +139,13 @@
 </div>
 
 <div class="text-right mt-8">
-  <button app-btn (click)="calculateParameter15C()" [disabled]="!isFormValid()" [btnLoading]="isCalculating()" data-testid="calculate-parameter-btn">
+  <button
+    app-btn
+    (click)="calculateParameter15C()"
+    [disabled]="!isFormValid()"
+    [btnLoading]="isCalculating()"
+    data-testid="calculate-parameter-btn"
+  >
     <app-icon icon="rocket_launch" />
     <ng-container i18n>Calculate setting parameter at 15°C</ng-container>
   </button>

--- a/src/app/features/studio/field-measuring/presentation/components/parameter-calculation-15-without-wind/parameter-calculation-15-without-wind.component.spec.ts
+++ b/src/app/features/studio/field-measuring/presentation/components/parameter-calculation-15-without-wind/parameter-calculation-15-without-wind.component.spec.ts
@@ -4,6 +4,7 @@ import { ComponentRef } from '@angular/core';
 import { ParameterCalculation15WithoutWindComponent } from './parameter-calculation-15-without-wind.component';
 import { createTestMeasureData } from '@features/studio/field-measuring/presentation/helpers';
 import { WorkerPythonService } from '@services/worker_python/worker-python.service';
+import { Task, TaskError, TaskOutputs } from '@services/worker_python/tasks/types';
 import { MessageService } from 'primeng/api';
 import { SectionService } from '@services/section/section.service';
 import { StudiesService } from '@services/studies/studies.service';
@@ -132,6 +133,46 @@ describe('ParameterCalculation15WithoutWindComponent', () => {
 
     component.updateMeasureData('updateMode15C', 'auto');
     expect(component.measureData().updateMode15C).toBe('auto');
+  });
+
+  describe('isCalculating signal', () => {
+    it('should start as false', () => {
+      expect(component.isCalculating()).toBe(false);
+    });
+
+    it('should be true during calculation and false after', async () => {
+      let resolveTask!: (value: { result: TaskOutputs[Task.calculateParameter15CWithoutWind]; error: TaskError | null }) => void;
+      workerPythonServiceMock.runTask.mockReturnValueOnce(
+        new Promise((res) => { resolveTask = res; })
+      );
+
+      component.updateMeasureData('updateMode15C', 'manual');
+      component.updateManualParameterCalculation15CWithoutWind('parameterPapoto', 1700);
+      component.updateManualParameterCalculation15CWithoutWind('parameterUncertaintyPapoto', 12);
+      component.updateManualParameterCalculation15CWithoutWind('cableTemperatureCalibration', 45);
+      component.updateManualParameterCalculation15CWithoutWind('cableTemperatureCalibrationUncertainty', 3);
+
+      const calcPromise = component.calculateParameter15C();
+      expect(component.isCalculating()).toBe(true);
+
+      resolveTask({ result: { parameter15CMinusUncertainty: 0, parameter15C: 0, parameter15CPlusUncertainty: 0 }, error: null });
+      await calcPromise;
+
+      expect(component.isCalculating()).toBe(false);
+    });
+
+    it('should reset to false even when calculation throws', async () => {
+      workerPythonServiceMock.runTask.mockRejectedValue(new Error('unexpected'));
+
+      component.updateMeasureData('updateMode15C', 'manual');
+      component.updateManualParameterCalculation15CWithoutWind('parameterPapoto', 1700);
+      component.updateManualParameterCalculation15CWithoutWind('parameterUncertaintyPapoto', 12);
+      component.updateManualParameterCalculation15CWithoutWind('cableTemperatureCalibration', 45);
+      component.updateManualParameterCalculation15CWithoutWind('cableTemperatureCalibrationUncertainty', 3);
+
+      await expect(component.calculateParameter15C()).rejects.toThrow('unexpected');
+      expect(component.isCalculating()).toBe(false);
+    });
   });
 
   it('should call workerPythonService with correct parameters when calculating parameter 15C', async () => {

--- a/src/app/features/studio/field-measuring/presentation/components/parameter-calculation-15-without-wind/parameter-calculation-15-without-wind.component.spec.ts
+++ b/src/app/features/studio/field-measuring/presentation/components/parameter-calculation-15-without-wind/parameter-calculation-15-without-wind.component.spec.ts
@@ -141,9 +141,14 @@ describe('ParameterCalculation15WithoutWindComponent', () => {
     });
 
     it('should be true during calculation and false after', async () => {
-      let resolveTask!: (value: { result: TaskOutputs[Task.calculateParameter15CWithoutWind]; error: TaskError | null }) => void;
+      let resolveTask!: (value: {
+        result: TaskOutputs[Task.calculateParameter15CWithoutWind];
+        error: TaskError | null;
+      }) => void;
       workerPythonServiceMock.runTask.mockReturnValueOnce(
-        new Promise((res) => { resolveTask = res; })
+        new Promise((res) => {
+          resolveTask = res;
+        })
       );
 
       component.updateMeasureData('updateMode15C', 'manual');
@@ -155,7 +160,10 @@ describe('ParameterCalculation15WithoutWindComponent', () => {
       const calcPromise = component.calculateParameter15C();
       expect(component.isCalculating()).toBe(true);
 
-      resolveTask({ result: { parameter15CMinusUncertainty: 0, parameter15C: 0, parameter15CPlusUncertainty: 0 }, error: null });
+      resolveTask({
+        result: { parameter15CMinusUncertainty: 0, parameter15C: 0, parameter15CPlusUncertainty: 0 },
+        error: null
+      });
       await calcPromise;
 
       expect(component.isCalculating()).toBe(false);

--- a/src/app/features/studio/field-measuring/presentation/components/parameter-calculation-15-without-wind/parameter-calculation-15-without-wind.component.ts
+++ b/src/app/features/studio/field-measuring/presentation/components/parameter-calculation-15-without-wind/parameter-calculation-15-without-wind.component.ts
@@ -66,6 +66,7 @@ export class ParameterCalculation15WithoutWindComponent {
   });
 
   parameter15CError = signal<boolean>(false);
+  readonly isCalculating = signal(false);
 
   readonly updateModeOptions = [
     { label: $localize`Auto`, value: 'auto' },
@@ -149,18 +150,23 @@ export class ParameterCalculation15WithoutWindComponent {
       cableTemperatureCalibrationUncertainty: data.outputs.cableTemperature?.cableTemperatureUncertainty || null
     };
     const dataToSend = isManual ? manualDataToSend : autoDataToSend;
-    const { result, error } = await this.workerPythonService.runTask(Task.calculateParameter15CWithoutWind, {
-      ...dataToSend,
-      span_index: data.span?.[0] ?? null
-    });
-    if (error) {
-      this.parameter15CError.set(true);
-      return;
+    this.isCalculating.set(true);
+    try {
+      const { result, error } = await this.workerPythonService.runTask(Task.calculateParameter15CWithoutWind, {
+        ...dataToSend,
+        span_index: data.span?.[0] ?? null
+      });
+      if (error) {
+        this.parameter15CError.set(true);
+        return;
+      }
+      this.measureData.update((d) => ({
+        ...d,
+        outputs: { ...d.outputs, parameter15C: result }
+      }));
+    } finally {
+      this.isCalculating.set(false);
     }
-    this.measureData.update((d) => ({
-      ...d,
-      outputs: { ...d.outputs, parameter15C: result }
-    }));
   }
 
   onCreateInitialCondition(type: 'minus' | 'nominal' | 'plus') {

--- a/src/app/features/studio/field-measuring/presentation/components/temperature-calculation/temperature-calculation.component.html
+++ b/src/app/features/studio/field-measuring/presentation/components/temperature-calculation/temperature-calculation.component.html
@@ -128,7 +128,13 @@
 </div>
 
 <div class="text-right">
-  <button app-btn (click)="calculateTemperature()" [disabled]="!isFormValid()" [btnLoading]="isCalculating()" data-testid="calculate-temperature-btn">
+  <button
+    app-btn
+    (click)="calculateTemperature()"
+    [disabled]="!isFormValid()"
+    [btnLoading]="isCalculating()"
+    data-testid="calculate-temperature-btn"
+  >
     <app-icon icon="rocket_launch" />
     <ng-container i18n>Calculate</ng-container>
   </button>

--- a/src/app/features/studio/field-measuring/presentation/components/temperature-calculation/temperature-calculation.component.html
+++ b/src/app/features/studio/field-measuring/presentation/components/temperature-calculation/temperature-calculation.component.html
@@ -128,7 +128,7 @@
 </div>
 
 <div class="text-right">
-  <button app-btn (click)="calculateTemperature()" [disabled]="!isFormValid()" data-testid="calculate-temperature-btn">
+  <button app-btn (click)="calculateTemperature()" [disabled]="!isFormValid()" [btnLoading]="isCalculating()" data-testid="calculate-temperature-btn">
     <app-icon icon="rocket_launch" />
     <ng-container i18n>Calculate</ng-container>
   </button>

--- a/src/app/features/studio/field-measuring/presentation/components/temperature-calculation/temperature-calculation.component.spec.ts
+++ b/src/app/features/studio/field-measuring/presentation/components/temperature-calculation/temperature-calculation.component.spec.ts
@@ -135,7 +135,9 @@ describe('TemperatureCalculationComponent', () => {
     it('should be true during calculation and false after', async () => {
       let resolveTask!: (value: { result: TaskOutputs[Task.temperatureCalculation]; error: TaskError | null }) => void;
       workerPythonServiceMock.runTask.mockReturnValueOnce(
-        new Promise((res) => { resolveTask = res; })
+        new Promise((res) => {
+          resolveTask = res;
+        })
       );
 
       component.updateField('cableName', 'ASTER570');

--- a/src/app/features/studio/field-measuring/presentation/components/temperature-calculation/temperature-calculation.component.spec.ts
+++ b/src/app/features/studio/field-measuring/presentation/components/temperature-calculation/temperature-calculation.component.spec.ts
@@ -4,6 +4,7 @@ import { ComponentRef } from '@angular/core';
 import { TemperatureCalculationComponent } from './temperature-calculation.component';
 import { createTestMeasureData } from '@features/studio/field-measuring/presentation/helpers';
 import { WorkerPythonService } from '@services/worker_python/worker-python.service';
+import { Task, TaskError, TaskOutputs } from '@services/worker_python/tasks/types';
 import {
   WIND_DIRECTION_OPTIONS,
   SKY_COVER_OPTIONS,
@@ -123,6 +124,42 @@ describe('TemperatureCalculationComponent', () => {
     it('should return false when skyCover is null', () => {
       component.updateField('skyCover', null);
       expect(component.isFormValid()).toBe(false);
+    });
+  });
+
+  describe('isCalculating signal', () => {
+    it('should start as false', () => {
+      expect(component.isCalculating()).toBe(false);
+    });
+
+    it('should be true during calculation and false after', async () => {
+      let resolveTask!: (value: { result: TaskOutputs[Task.temperatureCalculation]; error: TaskError | null }) => void;
+      workerPythonServiceMock.runTask.mockReturnValueOnce(
+        new Promise((res) => { resolveTask = res; })
+      );
+
+      component.updateField('cableName', 'ASTER570');
+      component.updateField('transit', 1000);
+      component.updateField('skyCover', 'N5');
+
+      const calcPromise = component.calculateTemperature();
+      expect(component.isCalculating()).toBe(true);
+
+      resolveTask({ result: { cableSolarFlux: 0, cableTemperature: 0, cableTemperatureUncertainty: 0 }, error: null });
+      await calcPromise;
+
+      expect(component.isCalculating()).toBe(false);
+    });
+
+    it('should reset to false even when calculation throws', async () => {
+      workerPythonServiceMock.runTask.mockRejectedValue(new Error('unexpected'));
+
+      component.updateField('cableName', 'ASTER570');
+      component.updateField('transit', 1000);
+      component.updateField('skyCover', 'N5');
+
+      await expect(component.calculateTemperature()).rejects.toThrow('unexpected');
+      expect(component.isCalculating()).toBe(false);
     });
   });
 

--- a/src/app/features/studio/field-measuring/presentation/components/temperature-calculation/temperature-calculation.component.ts
+++ b/src/app/features/studio/field-measuring/presentation/components/temperature-calculation/temperature-calculation.component.ts
@@ -54,6 +54,7 @@ export class TemperatureCalculationComponent {
   measureData = model.required<FieldMeasure>();
 
   temperatureCalculationError = signal<boolean>(false);
+  readonly isCalculating = signal(false);
 
   readonly transitBounds = TRANSIT_BOUNDS;
 
@@ -93,28 +94,33 @@ export class TemperatureCalculationComponent {
       ...d,
       outputs: { ...d.outputs, cableTemperature: null }
     }));
-    const { result, error } = await this.workerPythonService.runTask(Task.temperatureCalculation, {
-      cableName: data.cableName!,
-      ambientTemperature: data.ambientTemperature || 0,
-      longitude: data.longitude || 0,
-      latitude: data.latitude || 0,
-      altitude: data.altitude ?? 0,
-      azimuth: data.azimuth ?? 0,
-      transit: data.transit!,
-      date: data.date ?? null,
-      time: data.time ?? null,
-      windSpeed: data.windSpeed ?? 0,
-      windSpeedUnit: data.windSpeedUnit ?? 'kmh',
-      windDirection: data.windDirection ?? 'North',
-      skyCover: data.skyCover ?? ''
-    });
-    if (error) {
-      this.temperatureCalculationError.set(true);
-      return;
+    this.isCalculating.set(true);
+    try {
+      const { result, error } = await this.workerPythonService.runTask(Task.temperatureCalculation, {
+        cableName: data.cableName!,
+        ambientTemperature: data.ambientTemperature || 0,
+        longitude: data.longitude || 0,
+        latitude: data.latitude || 0,
+        altitude: data.altitude ?? 0,
+        azimuth: data.azimuth ?? 0,
+        transit: data.transit!,
+        date: data.date ?? null,
+        time: data.time ?? null,
+        windSpeed: data.windSpeed ?? 0,
+        windSpeedUnit: data.windSpeedUnit ?? 'kmh',
+        windDirection: data.windDirection ?? 'North',
+        skyCover: data.skyCover ?? ''
+      });
+      if (error) {
+        this.temperatureCalculationError.set(true);
+        return;
+      }
+      this.measureData.update((d) => ({
+        ...d,
+        outputs: { ...d.outputs, cableTemperature: result }
+      }));
+    } finally {
+      this.isCalculating.set(false);
     }
-    this.measureData.update((d) => ({
-      ...d,
-      outputs: { ...d.outputs, cableTemperature: result }
-    }));
   }
 }

--- a/src/app/features/studio/loads/presentation/components/cable-length-change/cable-length-change.html
+++ b/src/app/features/studio/loads/presentation/components/cable-length-change/cable-length-change.html
@@ -116,6 +116,7 @@
       type="submit"
       btnStyle="outlined"
       [disabled]="isFormInvalid() || isLoading() || !isDirtySinceLastSave()"
+      [btnLoading]="isCalculating()"
       data-testid="cable-length-change-save"
     >
       <app-icon icon="save" />
@@ -125,6 +126,7 @@
     <button
       app-btn
       [disabled]="isFormInvalid() || isLoading()"
+      [btnLoading]="isCalculating()"
       type="button"
       (click)="calculate()"
       data-testid="cable-length-change-calculate"

--- a/src/app/features/studio/loads/presentation/components/cable-length-change/cable-length-change.spec.ts
+++ b/src/app/features/studio/loads/presentation/components/cable-length-change/cable-length-change.spec.ts
@@ -45,7 +45,7 @@ describe('CableLengthChangeComponent', () => {
     mockPlotService = {
       section: createSignalMock<Partial<Section> | null>(mockSection),
       study: createSignalMock(null),
-      loading: createSignalMock(false),
+      loading: signal(false),
       litData: createSignalMock(null),
       baseLitData: createSignalMock(null),
       error: createSignalMock(null),
@@ -87,6 +87,25 @@ describe('CableLengthChangeComponent', () => {
 
   it('should be created', () => {
     expect(component).toBeTruthy();
+  });
+
+  describe('isCalculating computed', () => {
+    it('should reflect plotService.loading() as false by default', () => {
+      expect(component.isCalculating()).toBe(false);
+    });
+
+    it('should be true when plotService.loading() is true', () => {
+      mockPlotService.loading.set(true);
+      expect(component.isCalculating()).toBe(true);
+    });
+
+    it('should go back to false when plotService.loading() returns to false', () => {
+      mockPlotService.loading.set(true);
+      expect(component.isCalculating()).toBe(true);
+
+      mockPlotService.loading.set(false);
+      expect(component.isCalculating()).toBe(false);
+    });
   });
 
   // ---------------------------------------------------------------------------

--- a/src/app/features/studio/loads/presentation/components/cable-length-change/cable-length-change.ts
+++ b/src/app/features/studio/loads/presentation/components/cable-length-change/cable-length-change.ts
@@ -34,6 +34,7 @@ export class CableLengthChangeComponent {
   private readonly cableModificationsService = inject(CableModificationsService);
 
   readonly isLoading = signal(false);
+  readonly isCalculating = computed(() => this.plotService.loading());
   readonly error = signal<string | null>(null);
   /** Whether the form has been modified since the last save (RG.LON-CAB.ENR-BTN.1). */
   readonly isDirtySinceLastSave = signal(false);

--- a/src/app/features/studio/loads/presentation/components/climate/climate.component.html
+++ b/src/app/features/studio/loads/presentation/components/climate/climate.component.html
@@ -240,13 +240,21 @@
       btnStyle="outlined"
       (click)="saveForm()"
       [disabled]="!isFormValid()"
+      [btnLoading]="isCalculating()"
       data-testid="save-btn"
     >
       <app-icon icon="save" />
       <ng-container i18n>Save</ng-container>
     </button>
 
-    <button app-btn type="button" (click)="calculateForm()" [disabled]="!isFormValid()" data-testid="calculate-btn">
+    <button
+      app-btn
+      type="button"
+      (click)="calculateForm()"
+      [disabled]="!isFormValid()"
+      [btnLoading]="isCalculating()"
+      data-testid="calculate-btn"
+    >
       <app-icon icon="rocket_launch" />
       <ng-container i18n>Calculate</ng-container>
     </button>

--- a/src/app/features/studio/loads/presentation/components/climate/climate.component.spec.ts
+++ b/src/app/features/studio/loads/presentation/components/climate/climate.component.spec.ts
@@ -104,7 +104,8 @@ describe('ClimateComponent effect edge cases', () => {
     const plotServiceMock = {
       study: signal(null),
       section: signal({ uuid: 'section-uuid-1', supports: [] }),
-      calculateCharge: vi.fn()
+      calculateCharge: vi.fn(),
+      loading: signal(false)
     } as unknown as PlotService;
     const chargesServiceMock = {
       getCharge: vi.fn().mockResolvedValue(mockCharge),
@@ -136,7 +137,8 @@ describe('ClimateComponent effect edge cases', () => {
     const plotServiceMock = {
       study: signal({ uuid: 'study-uuid-1' }),
       section: signal({ uuid: 'section-uuid-1', supports: [] }),
-      calculateCharge: vi.fn()
+      calculateCharge: vi.fn(),
+      loading: signal(false)
     } as unknown as PlotService;
     const chargesServiceMock = {
       getCharge: vi.fn().mockResolvedValue(chargeWithoutData),
@@ -246,6 +248,27 @@ describe('ClimateComponent (Jest)', () => {
     component = fixture.componentInstance;
     fixture.componentRef.setInput('chargeUuid', 'test-charge-uuid');
     fixture.detectChanges();
+  });
+
+  describe('isCalculating computed', () => {
+    it('should reflect plotService.loading() as false by default', () => {
+      expect(component.isCalculating()).toBe(false);
+    });
+
+    it('should be true when plotService.loading() is true', () => {
+      const plotService = TestBed.inject(PlotService);
+      (plotService.loading as ReturnType<typeof signal>).set(true);
+      expect(component.isCalculating()).toBe(true);
+    });
+
+    it('should go back to false when plotService.loading() returns to false', () => {
+      const plotService = TestBed.inject(PlotService);
+      (plotService.loading as ReturnType<typeof signal>).set(true);
+      expect(component.isCalculating()).toBe(true);
+
+      (plotService.loading as ReturnType<typeof signal>).set(false);
+      expect(component.isCalculating()).toBe(false);
+    });
   });
 
   it('should initialize form with default values', () => {

--- a/src/app/features/studio/loads/presentation/components/climate/climate.component.spec.ts
+++ b/src/app/features/studio/loads/presentation/components/climate/climate.component.spec.ts
@@ -169,7 +169,7 @@ describe('ClimateComponent effect edge cases', () => {
   });
 });
 
-describe('ClimateComponent (Jest)', () => {
+describe('ClimateComponent', () => {
   let component: ClimateComponent;
   let fixture: ComponentFixture<ClimateComponent>;
 

--- a/src/app/features/studio/loads/presentation/components/climate/climate.component.ts
+++ b/src/app/features/studio/loads/presentation/components/climate/climate.component.ts
@@ -1,4 +1,4 @@
-import { ChangeDetectionStrategy, Component, DestroyRef, effect, inject, input, signal } from '@angular/core';
+import { ChangeDetectionStrategy, Component, computed, DestroyRef, effect, inject, input, signal } from '@angular/core';
 import {
   AbstractControl,
   FormBuilder,
@@ -97,6 +97,8 @@ export class ClimateComponent {
   private readonly fb = inject(FormBuilder);
   private readonly destroyRef = inject(DestroyRef);
   readonly constraints = climateConstraints;
+
+  readonly isCalculating = computed(() => this.plotService.loading());
 
   form: FormGroup<{
     windPressure: FormControl<number | null>;

--- a/src/app/features/studio/loads/presentation/components/load-marking/load-marking.component.html
+++ b/src/app/features/studio/loads/presentation/components/load-marking/load-marking.component.html
@@ -7,7 +7,7 @@
   </div>
 
   <div class="relative">
-    <div class="flex items-baseline justify-between justify-between mb-0.5">
+    <div class="flex items-baseline justify-between mb-0.5">
       <label for="spanSelect" class="mb-0" i18n>Span</label>
 
       <button
@@ -107,6 +107,7 @@
       btnStyle="outlined"
       (click)="saveLoadCase()"
       [disabled]="isFormInvalid()"
+      [btnLoading]="isCalculating()"
       data-testid="save-load"
     >
       <app-icon icon="save" />
@@ -116,6 +117,7 @@
     <button
       app-btn
       [disabled]="isFormInvalid()"
+      [btnLoading]="isCalculating()"
       type="button"
       (click)="calculateLoadCase()"
       data-testid="calculate-load"

--- a/src/app/features/studio/loads/presentation/components/load-marking/load-marking.component.spec.ts
+++ b/src/app/features/studio/loads/presentation/components/load-marking/load-marking.component.spec.ts
@@ -53,7 +53,8 @@ describe('LoadMarkingComponent', () => {
       getSupportIndex: vi.fn().mockReturnValue(0),
       getSupportOptions: vi.fn().mockReturnValue(mockSupportOptions),
       plotOptionsChange: vi.fn(),
-      temporaryLoadData: null
+      temporaryLoadData: null,
+      loading: signal(false)
     };
 
     mockLoadFormsService = {
@@ -80,6 +81,25 @@ describe('LoadMarkingComponent', () => {
 
   afterEach(() => {
     vi.clearAllMocks();
+  });
+
+  describe('isCalculating computed', () => {
+    it('should reflect plotService.loading() as false by default', () => {
+      expect(component.isCalculating()).toBe(false);
+    });
+
+    it('should be true when plotService.loading() is true', () => {
+      (mockPlotService['loading'] as ReturnType<typeof signal>).set(true);
+      expect(component.isCalculating()).toBe(true);
+    });
+
+    it('should go back to false when plotService.loading() returns to false', () => {
+      (mockPlotService['loading'] as ReturnType<typeof signal>).set(true);
+      expect(component.isCalculating()).toBe(true);
+
+      (mockPlotService['loading'] as ReturnType<typeof signal>).set(false);
+      expect(component.isCalculating()).toBe(false);
+    });
   });
 
   it('creates with default form state', () => {

--- a/src/app/features/studio/loads/presentation/components/load-marking/load-marking.component.ts
+++ b/src/app/features/studio/loads/presentation/components/load-marking/load-marking.component.ts
@@ -58,6 +58,7 @@ export class LoadMarkingComponent {
   readonly spansOptions = computed(() => {
     return this.plotService.getSpanOptions();
   });
+  readonly isCalculating = computed(() => this.plotService.loading());
 
   readonly supportsOptions = signal<SupportOption[]>([]);
 

--- a/src/app/features/studio/obstacles/presentation/components/obstaclesForm/obstaclesForm.component.html
+++ b/src/app/features/studio/obstacles/presentation/components/obstaclesForm/obstaclesForm.component.html
@@ -255,6 +255,7 @@
         type="button"
         (click)="obstacleFormService.calculateAndSave()"
         [disabled]="!obstacleFormService.canCalculateAndSave()"
+        [btnLoading]="isCalculating()"
         data-testid="calculate-save"
       >
         <app-icon icon="rocket_launch" />

--- a/src/app/features/studio/obstacles/presentation/components/obstaclesForm/obstaclesForm.component.spec.ts
+++ b/src/app/features/studio/obstacles/presentation/components/obstaclesForm/obstaclesForm.component.spec.ts
@@ -74,7 +74,8 @@ describe('ObstaclesFormComponent', () => {
   beforeEach(async () => {
     mockPlotService = {
       getSpanOptions: vi.fn().mockReturnValue([{ label: '1 - 2', value: 'support-1' }]),
-      isFreePositioningMode: signal(false)
+      isFreePositioningMode: signal(false),
+      loading: signal(false)
     };
     mockObstacleFormService = new MockObstacleFormService();
     const indexSignal = signal<number | null>(null);
@@ -110,6 +111,25 @@ describe('ObstaclesFormComponent', () => {
 
   afterEach(() => {
     vi.clearAllMocks();
+  });
+
+  describe('isCalculating computed', () => {
+    it('should reflect plotService.loading() as false by default', () => {
+      expect(component.isCalculating()).toBe(false);
+    });
+
+    it('should be true when plotService.loading() is true', () => {
+      (mockPlotService.loading as ReturnType<typeof signal>).set(true);
+      expect(component.isCalculating()).toBe(true);
+    });
+
+    it('should go back to false when plotService.loading() returns to false', () => {
+      (mockPlotService.loading as ReturnType<typeof signal>).set(true);
+      expect(component.isCalculating()).toBe(true);
+
+      (mockPlotService.loading as ReturnType<typeof signal>).set(false);
+      expect(component.isCalculating()).toBe(false);
+    });
   });
 
   describe('HTML rendering - form structure', () => {

--- a/src/app/features/studio/obstacles/presentation/components/obstaclesForm/obstaclesForm.component.spec.ts
+++ b/src/app/features/studio/obstacles/presentation/components/obstaclesForm/obstaclesForm.component.spec.ts
@@ -57,7 +57,12 @@ class MockObstacleFormService {
 describe('ObstaclesFormComponent', () => {
   let component: ObstaclesFormComponent;
   let fixture: ComponentFixture<ObstaclesFormComponent>;
-  let mockPlotService: { getSpanOptions: vi.Mock; isFreePositioningMode: ReturnType<typeof signal> };
+  let mockPlotService: {
+    getSpanOptions: vi.Mock;
+    isFreePositioningMode: ReturnType<typeof signal<boolean>>;
+    loading: ReturnType<typeof signal<boolean>>;
+    section: ReturnType<typeof signal<null>>;
+  };
   let mockObstacleFormService: MockObstacleFormService;
   let obstaclesService: {
     activePointIndex: ReturnType<typeof signal<number | null>>;
@@ -75,7 +80,8 @@ describe('ObstaclesFormComponent', () => {
     mockPlotService = {
       getSpanOptions: vi.fn().mockReturnValue([{ label: '1 - 2', value: 'support-1' }]),
       isFreePositioningMode: signal(false),
-      loading: signal(false)
+      loading: signal(false),
+      section: signal(null)
     };
     mockObstacleFormService = new MockObstacleFormService();
     const indexSignal = signal<number | null>(null);

--- a/src/app/features/studio/obstacles/presentation/components/obstaclesForm/obstaclesForm.component.ts
+++ b/src/app/features/studio/obstacles/presentation/components/obstaclesForm/obstaclesForm.component.ts
@@ -54,6 +54,7 @@ export class ObstaclesFormComponent {
   private readonly destroyRef = inject(DestroyRef);
 
   readonly obstacleTypeOptions = signal<{ label: string; value: string }[]>([]);
+  readonly isCalculating = computed(() => this.plotService.loading());
 
   constructor() {
     this.obstaclesService.ready

--- a/src/app/features/studio/toolbar/presentation/components/vtl-and-guying/vtl-and-guying.component.html
+++ b/src/app/features/studio/toolbar/presentation/components/vtl-and-guying/vtl-and-guying.component.html
@@ -134,6 +134,7 @@
             btnStyle="base"
             type="button"
             [disabled]="!isFormValid()"
+            [btnLoading]="isCalculating()"
             (click)="onCalculate()"
             class="vtl-guying__calculate-btn"
             data-testid="calculate-btn"

--- a/src/app/features/studio/toolbar/presentation/components/vtl-and-guying/vtl-and-guying.component.spec.ts
+++ b/src/app/features/studio/toolbar/presentation/components/vtl-and-guying/vtl-and-guying.component.spec.ts
@@ -6,7 +6,7 @@ import { PlotService } from '@services/plot/plot.service';
 import { WorkerPythonService } from '@services/worker_python/worker-python.service';
 import { provideHttpClientTesting } from '@angular/common/http/testing';
 import { signal } from '@angular/core';
-import { Task, TaskError } from '@services/worker_python/tasks/types';
+import { Task, TaskError, TaskOutputs } from '@services/worker_python/tasks/types';
 import { ButtonComponent } from '@shared/components/atoms/button/button.component';
 import { IconComponent } from '@shared/components/atoms/icon/icon.component';
 import { CardComponent } from '@shared/components/atoms/card/card.component';
@@ -129,6 +129,44 @@ describe('VhlAndGuyingComponent', () => {
     const closeToolSpy = vi.spyOn(toolbarDialogService, 'closeTool');
     component.onVisibleChange(true);
     expect(closeToolSpy).not.toHaveBeenCalled();
+  });
+
+  describe('isCalculating signal', () => {
+    it('should start as false', () => {
+      expect(component.isCalculating()).toBe(false);
+    });
+
+    it('should be true during onCalculate and false after', async () => {
+      let resolveTask!: (value: { result: TaskOutputs[Task.calculateGuying]; error: TaskError | null }) => void;
+      mockWorkerPythonService.runTask.mockReturnValueOnce(
+        new Promise((res) => { resolveTask = res; })
+      );
+
+      component.form.controls.altitude.setValue(10);
+      component.form.controls.horizontalDistance.setValue(5);
+      component.form.controls.selectedSpan.setValue({ index: 0, uuid: 'span-uuid-1' });
+      component.form.controls.selectedSupport.setValue('LEFT');
+
+      const calcPromise = component.onCalculate();
+      expect(component.isCalculating()).toBe(true);
+
+      resolveTask({ result: { tensionInGuy: 0, guyAngle: 0, chargeVUnderConsole: 0, chargeHUnderConsole: 0, chargeLIfPulley: 0 }, error: null });
+      await calcPromise;
+
+      expect(component.isCalculating()).toBe(false);
+    });
+
+    it('should reset to false even when calculation throws', async () => {
+      mockWorkerPythonService.runTask.mockRejectedValue(new Error('unexpected'));
+
+      component.form.controls.altitude.setValue(10);
+      component.form.controls.horizontalDistance.setValue(5);
+      component.form.controls.selectedSpan.setValue({ index: 0, uuid: 'span-uuid-1' });
+      component.form.controls.selectedSupport.setValue('LEFT');
+
+      await expect(component.onCalculate()).rejects.toThrow('unexpected');
+      expect(component.isCalculating()).toBe(false);
+    });
   });
 
   it('should calculate guying when all inputs are provided', async () => {

--- a/src/app/features/studio/toolbar/presentation/components/vtl-and-guying/vtl-and-guying.component.spec.ts
+++ b/src/app/features/studio/toolbar/presentation/components/vtl-and-guying/vtl-and-guying.component.spec.ts
@@ -139,7 +139,9 @@ describe('VhlAndGuyingComponent', () => {
     it('should be true during onCalculate and false after', async () => {
       let resolveTask!: (value: { result: TaskOutputs[Task.calculateGuying]; error: TaskError | null }) => void;
       mockWorkerPythonService.runTask.mockReturnValueOnce(
-        new Promise((res) => { resolveTask = res; })
+        new Promise((res) => {
+          resolveTask = res;
+        })
       );
 
       component.form.controls.altitude.setValue(10);
@@ -150,7 +152,10 @@ describe('VhlAndGuyingComponent', () => {
       const calcPromise = component.onCalculate();
       expect(component.isCalculating()).toBe(true);
 
-      resolveTask({ result: { tensionInGuy: 0, guyAngle: 0, chargeVUnderConsole: 0, chargeHUnderConsole: 0, chargeLIfPulley: 0 }, error: null });
+      resolveTask({
+        result: { tensionInGuy: 0, guyAngle: 0, chargeVUnderConsole: 0, chargeHUnderConsole: 0, chargeLIfPulley: 0 },
+        error: null
+      });
       await calcPromise;
 
       expect(component.isCalculating()).toBe(false);

--- a/src/app/features/studio/toolbar/presentation/components/vtl-and-guying/vtl-and-guying.component.ts
+++ b/src/app/features/studio/toolbar/presentation/components/vtl-and-guying/vtl-and-guying.component.ts
@@ -101,6 +101,7 @@ export class VhlAndGuyingComponent {
   } | null>(null);
 
   readonly loading = computed(() => this.plotService.loading() || !this.plotService.litData());
+  readonly isCalculating = signal(false);
 
   private readonly destroyRef = inject(DestroyRef);
 
@@ -240,18 +241,23 @@ export class VhlAndGuyingComponent {
       return;
     }
     const formValue = this.form.value;
-    const { result, error } = await this.workerPythonService.runTask(Task.calculateGuying, {
-      altitude: formValue.altitude!,
-      horizontalDistance: formValue.horizontalDistance!,
-      hasPulley: formValue.hasPulley ?? false,
-      selectedSpanIndex: formValue.selectedSpan?.index || 0,
-      selectedSupport: formValue.selectedSupport || null
-    });
-    if (error) {
-      console.error(error);
-      return;
+    this.isCalculating.set(true);
+    try {
+      const { result, error } = await this.workerPythonService.runTask(Task.calculateGuying, {
+        altitude: formValue.altitude!,
+        horizontalDistance: formValue.horizontalDistance!,
+        hasPulley: formValue.hasPulley ?? false,
+        selectedSpanIndex: formValue.selectedSpan?.index || 0,
+        selectedSupport: formValue.selectedSupport || null
+      });
+      if (error) {
+        console.error(error);
+        return;
+      }
+      this.results.set(result);
+    } finally {
+      this.isCalculating.set(false);
     }
-    this.results.set(result);
   };
 
   onExportVhl(): void {

--- a/src/app/shared/components/studio/studio.component.html
+++ b/src/app/shared/components/studio/studio.component.html
@@ -1,5 +1,5 @@
 <div class="h-full relative">
-  @if (plotService.loading()) {
+  @if (plotService.loading() && !plotInitialized()) {
     <div class="absolute inset-0 flex justify-center items-center">
       <p-progress-spinner ariaLabel="loading" />
     </div>

--- a/src/app/shared/components/studio/studio.component.spec.ts
+++ b/src/app/shared/components/studio/studio.component.spec.ts
@@ -60,7 +60,9 @@ const mockSection: Section = {
   selected_charge_uuid: null,
   field_measures: [],
   selected_field_measure_uuid: undefined,
-  vtl_and_guying: undefined
+  vtl_and_guying: undefined,
+  cable_modifications: [],
+  selected_cable_modification_uuid: null
 };
 
 const mockLitData: GetSectionOutput = {
@@ -237,8 +239,34 @@ describe('StudioComponent', () => {
     });
   });
 
+  describe('plotInitialized signal', () => {
+    it('should start as false', () => {
+      expect(component.plotInitialized()).toBe(false);
+    });
+
+    it('should become true when litData changes from null to a value', () => {
+      expect(component.plotInitialized()).toBe(false);
+
+      mockPlotService.litData.set(mockLitData);
+      fixture.detectChanges();
+
+      expect(component.plotInitialized()).toBe(true);
+    });
+
+    it('should remain true once set even if litData goes back to null', () => {
+      mockPlotService.litData.set(mockLitData);
+      fixture.detectChanges();
+      expect(component.plotInitialized()).toBe(true);
+
+      mockPlotService.litData.set(null);
+      fixture.detectChanges();
+
+      expect(component.plotInitialized()).toBe(true);
+    });
+  });
+
   describe('Template – loading state', () => {
-    it('should show spinner when loading', () => {
+    it('should show spinner when loading and not yet initialized', () => {
       mockPlotService.loading.set(true);
       fixture.detectChanges();
 
@@ -248,6 +276,18 @@ describe('StudioComponent', () => {
 
     it('should not show spinner when not loading', () => {
       mockPlotService.loading.set(false);
+      fixture.detectChanges();
+
+      const spinner = fixture.nativeElement.querySelector('p-progress-spinner');
+      expect(spinner).toBeFalsy();
+    });
+
+    it('should not show spinner when loading but already initialized', () => {
+      mockPlotService.litData.set(mockLitData);
+      fixture.detectChanges();
+      expect(component.plotInitialized()).toBe(true);
+
+      mockPlotService.loading.set(true);
       fixture.detectChanges();
 
       const spinner = fixture.nativeElement.querySelector('p-progress-spinner');

--- a/src/app/shared/components/studio/studio.component.ts
+++ b/src/app/shared/components/studio/studio.component.ts
@@ -1,4 +1,4 @@
-import { ChangeDetectionStrategy, Component, effect, inject, input, OnDestroy } from '@angular/core';
+import { ChangeDetectionStrategy, Component, effect, inject, input, OnDestroy, signal } from '@angular/core';
 import { SectionPlotComponent } from './section/section-plot.component';
 import { ProgressSpinnerModule } from 'primeng/progressspinner';
 
@@ -25,11 +25,20 @@ export class StudioComponent implements OnDestroy {
   protected readonly plotService = inject(PlotService);
   private readonly notificationService = inject(NotificationService);
 
+  // State
+  readonly plotInitialized = signal(false);
+
   constructor() {
     effect(() => {
       const error = this.plotService.error();
       if (error !== null) {
         this.notificationService.error(formatStudioError(error));
+      }
+    });
+
+    effect(() => {
+      if (this.plotService.litData() !== null) {
+        this.plotInitialized.set(true);
       }
     });
 


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
<!-- please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes -->
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


PR for feature #583 

Add loading state for all studio page's side-tabs calculation and save buttons when plotly is regenarating.
Add loading state for calculation button in measures and "vtl & guying" tools until its calculation task is done (or thrown)
Swap studio loading in studio-page to make it appear only on first init.

**Does this PR introduce a breaking change or deprecate an API?**
- [ ] Yes
- [x] No


