### PR TITLE
Feat/694/base form  cable span manipulation

### DIFF
--- a/assets/i18n/messages.fr.xlf
+++ b/assets/i18n/messages.fr.xlf
@@ -793,12 +793,6 @@
         <target>sélectionner ce canton d&apos;étude</target>
       </segment>
     </unit>
-    <unit id="3411835502741534903">
-      <segment state="initial">
-        <source>loading</source>
-        <target>chargement</target>
-      </segment>
-    </unit>
     <unit id="1724907302012419507">
       <segment state="initial">
         <source>There is no study description</source>
@@ -3621,10 +3615,10 @@
         <target> Charge / Marquage </target>
       </segment>
     </unit>
-    <unit id="1964106600703167330">
+    <unit id="361024812885364180">
       <segment state="initial">
-        <source>Cable manip. at span</source>
-        <target>Manip. câble dans la portée</target>
+        <source> Cable manip. at span </source>
+        <target> Manip. câble dans la portée </target>
       </segment>
     </unit>
     <unit id="314315645942131479">

--- a/assets/i18n/messages.fr.xlf
+++ b/assets/i18n/messages.fr.xlf
@@ -3651,19 +3651,19 @@
         <target>Une erreur s&apos;est produite</target>
       </segment>
     </unit>
-    <unit id="2656270638371326231">
+    <unit id="3016819249974962667">
       <segment state="initial">
         <source>Point alt.</source>
         <target>Alt. point</target>
       </segment>
     </unit>
-    <unit id="5122879481650738554">
+    <unit id="4381478989546864547">
       <segment state="initial">
         <source>Ref. support dist.</source>
         <target>Dist. supp. réf.</target>
       </segment>
     </unit>
-    <unit id="7382072301605955850">
+    <unit id="2702074512037019032">
       <segment state="initial">
         <source>Line axis dist.</source>
         <target>Dist. axe ligne.</target>
@@ -3672,19 +3672,19 @@
     <unit id="4303103723944581948">
       <segment state="translated">
         <source>A solver error occurred.</source>
-        <target>Une erreur de solveur s'est produite.</target>
+        <target>Une erreur de solveur s&apos;est produite.</target>
       </segment>
     </unit>
     <unit id="272496911380424275">
       <segment state="translated">
         <source>The insulator chain is suspected to have reversed (above horizontal position).</source>
-        <target>La chaîne d'isolateurs est suspectée d'avoir basculé (position au-dessus de l'horizontale).</target>
+        <target>La chaîne d&apos;isolateurs est suspectée d&apos;avoir basculé (position au-dessus de l&apos;horizontale).</target>
       </segment>
     </unit>
     <unit id="3239031258153870723">
       <segment state="translated">
         <source>The solver failed to converge.</source>
-        <target>Le solveur n'a pas convergé.</target>
+        <target>Le solveur n&apos;a pas convergé.</target>
       </segment>
     </unit>
     <unit id="4796814092512031875">
@@ -3702,13 +3702,163 @@
     <unit id="8058206957724761513">
       <segment state="translated">
         <source>A balance engine warning was raised.</source>
-        <target>Un avertissement du moteur d'équilibrage a été émis.</target>
+        <target>Un avertissement du moteur d&apos;équilibrage a été émis.</target>
       </segment>
     </unit>
     <unit id="1162997080399948086">
       <segment state="translated">
         <source>RTS catalog data (rts_cable, rts_layer_*) is missing or contains NaN values.</source>
         <target>Les données du catalogue RTS (rts_cable, rts_layer_*) sont absentes ou contiennent des valeurs NaN.</target>
+      </segment>
+    </unit>
+    <unit id="manipulatedSpan">
+      <segment state="initial">
+        <source> Manipulated span </source>
+        <target> Portée manipulée </target>
+      </segment>
+    </unit>
+    <unit id="referenceSupport">
+      <segment state="initial">
+        <source> Reference support </source>
+        <target> Support de référence </target>
+      </segment>
+    </unit>
+    <unit id="manipulatedPointCableDistRefSupport">
+      <segment state="initial">
+        <source> Manipulated point on the cable (Dist. to ref. support) </source>
+        <target> Point manipulé sur le câble (Dist. au supp. réf.) </target>
+      </segment>
+    </unit>
+    <unit id="cableManipType">
+      <segment state="initial">
+        <source> Cable manipulation type </source>
+        <target> Type de manip. du câble </target>
+      </segment>
+    </unit>
+    <unit id="cableManipMethod">
+      <segment state="initial">
+        <source> Cable manipulation method </source>
+        <target> Moyen de manip. du cable </target>
+      </segment>
+    </unit>
+    <unit id="manipFixedPointPosition">
+      <segment state="initial">
+        <source>Manipulation fixed point position</source>
+        <target>Position point fixe manipulation</target>
+      </segment>
+    </unit>
+    <unit id="longitudinalDistance">
+      <segment state="initial">
+        <source> Longitudinal dist. </source>
+        <target> Dist. longitudinale </target>
+      </segment>
+    </unit>
+    <unit id="lateralDistance">
+      <segment state="initial">
+        <source> Lateral dist. </source>
+        <target> Dist. latérale </target>
+      </segment>
+    </unit>
+    <unit id="altitude">
+      <segment state="initial">
+        <source> Altitude </source>
+        <target> Altitude </target>
+      </segment>
+    </unit>
+    <unit id="distCalcBetweenPoints">
+      <segment state="initial">
+        <source>Dist. calc. between points</source>
+        <target>Calcul distance entre points</target>
+      </segment>
+    </unit>
+    <unit id="distance">
+      <segment state="initial">
+        <source>Distance</source>
+        <target>Distance</target>
+      </segment>
+    </unit>
+    <unit id="anchoring">
+      <segment state="initial">
+        <source>Anchoring</source>
+        <target>Accrochage</target>
+      </segment>
+    </unit>
+    <unit id="chainName">
+      <segment state="initial">
+        <source>Chain name</source>
+        <target>Nom de la chaîne</target>
+      </segment>
+    </unit>
+    <unit id="chainLength">
+      <segment state="initial">
+        <source>Chain length</source>
+        <target>Longueur chaîne</target>
+      </segment>
+    </unit>
+    <unit id="chainWeight">
+      <segment state="initial">
+        <source>Chain weight</source>
+        <target>Poids chaîne</target>
+      </segment>
+    </unit>
+    <unit id="chainSurface">
+      <segment state="initial">
+        <source>Chain surface</source>
+        <target>Surface de chaîne</target>
+      </segment>
+    </unit>
+    <unit id="counterWeight">
+      <segment state="initial">
+        <source>Counter weight</source>
+        <target>Contrepoids</target>
+      </segment>
+    </unit>
+    <unit id="slingLength">
+      <segment state="initial">
+        <source>Sling length</source>
+        <target>Longueur de l&apos;élingue</target>
+      </segment>
+    </unit>
+    <unit id="5552885238769285726">
+      <segment state="initial">
+        <source>erase span&apos;s cable manipulation</source>
+        <target>supprimer la manipulation du câble dans la portée</target>
+      </segment>
+    </unit>
+    <unit id="7538726695771189991">
+      <segment state="initial">
+        <source>With a crane</source>
+        <target>À la grue</target>
+      </segment>
+    </unit>
+    <unit id="8935057406125868491">
+      <segment state="initial">
+        <source>Temporary support</source>
+        <target>Support provisoire</target>
+      </segment>
+    </unit>
+    <unit id="6667965603420020393">
+      <segment state="initial">
+        <source>Clamp</source>
+        <target>Pince</target>
+      </segment>
+    </unit>
+    <unit id="4021521782447475905">
+      <segment state="initial">
+        <source>Pulley</source>
+        <target>Poulie</target>
+      </segment>
+    </unit>
+    <unit id="4351133266457573059">
+      <segment state="initial">
+        <source>With sling</source>
+        <target>Avec élingue</target>
+      </segment>
+    </unit>
+    <unit id="4044156232805548048">
+      <segment state="initial">
+        <source>With chain</source>
+        <target>Avec chaîne</target>
       </segment>
     </unit>
   </file>

--- a/assets/i18n/messages.xlf
+++ b/assets/i18n/messages.xlf
@@ -3020,17 +3020,17 @@
         <source>An error occurred</source>
       </segment>
     </unit>
-    <unit id="2656270638371326231">
+    <unit id="3016819249974962667">
       <segment>
         <source>Point alt.</source>
       </segment>
     </unit>
-    <unit id="5122879481650738554">
+    <unit id="4381478989546864547">
       <segment>
         <source>Ref. support dist.</source>
       </segment>
     </unit>
-    <unit id="7382072301605955850">
+    <unit id="2702074512037019032">
       <segment>
         <source>Line axis dist.</source>
       </segment>
@@ -3068,6 +3068,131 @@
     <unit id="1162997080399948086">
       <segment>
         <source>RTS catalog data (rts_cable, rts_layer_*) is missing or contains NaN values.</source>
+      </segment>
+    </unit>
+    <unit id="4021521782447475905">
+      <segment>
+        <source>Pulley</source>
+      </segment>
+    </unit>
+    <unit id="4044156232805548048">
+      <segment>
+        <source>With chain</source>
+      </segment>
+    </unit>
+    <unit id="4351133266457573059">
+      <segment>
+        <source>With sling</source>
+      </segment>
+    </unit>
+    <unit id="5552885238769285726">
+      <segment>
+        <source>erase span&apos;s cable manipulation</source>
+      </segment>
+    </unit>
+    <unit id="6667965603420020393">
+      <segment>
+        <source>Clamp</source>
+      </segment>
+    </unit>
+    <unit id="7538726695771189991">
+      <segment>
+        <source>With a crane</source>
+      </segment>
+    </unit>
+    <unit id="8935057406125868491">
+      <segment>
+        <source>Temporary support</source>
+      </segment>
+    </unit>
+    <unit id="altitude">
+      <segment>
+        <source> Altitude </source>
+      </segment>
+    </unit>
+    <unit id="anchoring">
+      <segment>
+        <source>Anchoring</source>
+      </segment>
+    </unit>
+    <unit id="cableManipMethod">
+      <segment>
+        <source> Cable manipulation method </source>
+      </segment>
+    </unit>
+    <unit id="cableManipType">
+      <segment>
+        <source> Cable manipulation type </source>
+      </segment>
+    </unit>
+    <unit id="chainLength">
+      <segment>
+        <source>Chain length</source>
+      </segment>
+    </unit>
+    <unit id="chainName">
+      <segment>
+        <source>Chain name</source>
+      </segment>
+    </unit>
+    <unit id="chainSurface">
+      <segment>
+        <source>Chain surface</source>
+      </segment>
+    </unit>
+    <unit id="chainWeight">
+      <segment>
+        <source>Chain weight</source>
+      </segment>
+    </unit>
+    <unit id="counterWeight">
+      <segment>
+        <source>Counter weight</source>
+      </segment>
+    </unit>
+    <unit id="distance">
+      <segment>
+        <source>Distance</source>
+      </segment>
+    </unit>
+    <unit id="distCalcBetweenPoints">
+      <segment>
+        <source>Dist. calc. between points</source>
+      </segment>
+    </unit>
+    <unit id="lateralDistance">
+      <segment>
+        <source> Lateral dist. </source>
+      </segment>
+    </unit>
+    <unit id="longitudinalDistance">
+      <segment>
+        <source> Longitudinal dist. </source>
+      </segment>
+    </unit>
+    <unit id="manipFixedPointPosition">
+      <segment>
+        <source>Manipulation fixed point position</source>
+      </segment>
+    </unit>
+    <unit id="manipulatedPointCableDistRefSupport">
+      <segment>
+        <source> Manipulated point on the cable (Dist. to ref. support) </source>
+      </segment>
+    </unit>
+    <unit id="manipulatedSpan">
+      <segment>
+        <source> Manipulated span </source>
+      </segment>
+    </unit>
+    <unit id="referenceSupport">
+      <segment>
+        <source> Reference support </source>
+      </segment>
+    </unit>
+    <unit id="slingLength">
+      <segment>
+        <source>Sling length</source>
       </segment>
     </unit>
   </file>

--- a/assets/i18n/messages.xlf
+++ b/assets/i18n/messages.xlf
@@ -2670,11 +2670,6 @@
         <source>NO VOLTAGE</source>
       </segment>
     </unit>
-    <unit id="3411835502741534903">
-      <segment>
-        <source>loading</source>
-      </segment>
-    </unit>
     <unit id="305142716106924307">
       <segment>
         <source>Author:</source>
@@ -2980,9 +2975,9 @@
         <source>Copy</source>
       </segment>
     </unit>
-    <unit id="1964106600703167330">
+    <unit id="361024812885364180">
       <segment>
-        <source>Cable manip. at span</source>
+        <source> Cable manip. at span </source>
       </segment>
     </unit>
     <unit id="2033387769986799452">

--- a/deadcode.md
+++ b/deadcode.md
@@ -164,7 +164,6 @@
 ---
 
 ## 12. `clearPersistedFormData()` — `src/app/features/studio/loads/presentation/services/cableModifications.service.ts`
-
 - **Type**: method
 - **Reason**: No-op placeholder with no body. Called by `CableLengthChangeComponent.deleteForm()` but has no observable side effects. Component-level tests already verify the call sites; no meaningful unit test can be written for the service method itself until a real implementation is added.
 - **Detected on**: 2026-04-13
@@ -179,3 +178,19 @@
 | Impact suppression | Remove `loadObstacle`, `patchFormFromObstacle`, `findSupportForObstacle`, and `findObstacle` (~30 lines) and their spec coverage |
 | Status | ⏳ PENDING REVIEW |
 | Detected on | 2026-03-26 |
+
+---
+
+## 14. `recheckSpanLoads` — `src/app/features/studio/loads/presentation/helpers.ts`
+
+| | |
+|---|---|
+| 📍 Source | `src/app/features/studio/loads/presentation/helpers.ts` |
+| **Type** | function |
+| 🔍 Preuve | Removed in PR `feat/694/base-form--cable-span-manipulation` as unused/duplicate. No remaining references in the codebase after removal. |
+| ⚠️ Confiance | **HIGH** |
+| Impact suppression | Function deleted from `helpers.ts`; confirm no callers exist before closing the PR |
+| Status | ⏳ PENDING REVIEW |
+| Detected on | 2026-04-13 |
+
+---

--- a/src/app/features/studio/core/presentation/components/side-tabs/side-tabs.component.scss
+++ b/src/app/features/studio/core/presentation/components/side-tabs/side-tabs.component.scss
@@ -173,8 +173,7 @@
       &.active {
         @apply opacity-100 h-full;
         background: $_active-btn-bgc;
-        transition: opacity $_panel-transition-timing $_panel-transition-timing
-          $_panel-transition-effect;
+        transition: opacity $_panel-transition-timing $_panel-transition-timing $_panel-transition-effect;
 
         @starting-style {
           opacity: 0;
@@ -183,6 +182,7 @@
 
       &__header {
         padding: 0.875rem 0.5rem 0.375rem;
+        height: app.$studio-sidetab-header-height;
       }
     }
   }

--- a/src/app/features/studio/core/presentation/pages/studio-page/studio-page.component.html
+++ b/src/app/features/studio/core/presentation/pages/studio-page/studio-page.component.html
@@ -185,7 +185,9 @@
               Cable length change
             </p-tab>
             <p-tab value="3" [disabled]="true" class="cable-support" i18n>Cable manip. at support</p-tab>
-            <p-tab value="4" [disabled]="false" class="cable-span" i18n>Cable manip. at span</p-tab>
+            <p-tab value="4" [disabled]="!plotService.section()?.selected_charge_uuid" class="cable-span" i18n>
+              Cable manip. at span
+            </p-tab>
           </p-tablist>
 
           @if (!plotService.section()?.charges?.length) {

--- a/src/app/features/studio/core/presentation/pages/studio-page/studio-page.component.html
+++ b/src/app/features/studio/core/presentation/pages/studio-page/studio-page.component.html
@@ -185,7 +185,7 @@
               Cable length change
             </p-tab>
             <p-tab value="3" [disabled]="true" class="cable-support" i18n>Cable manip. at support</p-tab>
-            <p-tab value="4" [disabled]="true" class="cable-span" i18n>Cable manip. at span</p-tab>
+            <p-tab value="4" [disabled]="false" class="cable-span" i18n>Cable manip. at span</p-tab>
           </p-tablist>
 
           @if (!plotService.section()?.charges?.length) {
@@ -218,7 +218,7 @@
               </p-tabpanel>
 
               <p-tabpanel value="2">
-                <app-cable-length-change></app-cable-length-change>
+                <app-cable-length-change />
               </p-tabpanel>
 
               <p-tabpanel value="3">
@@ -230,11 +230,7 @@
               </p-tabpanel>
 
               <p-tabpanel value="4">
-                <p class="m-0">
-                  Lorem ipsum, dolor sit amet consectetur adipisicing elit. Cumque consequuntur vero, iste ducimus ipsam
-                  soluta ab libero maxime, excepturi quia, veniam nostrum. Debitis necessitatibus veritatis mollitia
-                  numquam? Optio, minus cum.
-                </p>
+                <app-cable-span-manip />
               </p-tabpanel>
             </p-tabpanels>
           }

--- a/src/app/features/studio/core/presentation/pages/studio-page/studio-page.component.ts
+++ b/src/app/features/studio/core/presentation/pages/studio-page/studio-page.component.ts
@@ -31,6 +31,7 @@ import { StudioMenuBarComponent } from '../../components/menu-bar/menu-bar.compo
 import { SectionPlotCardsComponent } from '../../components/cards/section-plot-cards.component';
 import { SideTabsComponent } from '../../components/side-tabs/side-tabs.component';
 import { SideTabComponent } from '../../components/side-tabs/side-tab/side-tab.component';
+import { FreePositioningComponent } from '../../components/free-positioning/free-positioning.component';
 import { ClimateComponent } from '@features/studio/loads/presentation/components/climate/climate.component';
 import { LoadMarkingComponent } from '@features/studio/loads/presentation/components/load-marking/load-marking.component';
 import { NewChargeModalComponent } from '@shared/components/new-charge-modal/new-charge-modal.component';
@@ -38,10 +39,10 @@ import { ToolbarDialogComponent } from '@features/studio/toolbar/presentation/co
 import { PlotService } from '@services/plot/plot.service';
 import { LoadFormsService } from '@features/studio/loads/presentation/services/loadForms.service';
 import { ObstaclesFormComponent } from '@features/studio/obstacles/presentation/components/obstaclesForm/obstaclesForm.component';
-import { FreePositioningComponent } from '../../components/free-positioning/free-positioning.component';
 import { STUDIO_PLOT_DEBOUNCE_DELAY } from '@shared/components/studio/section/helpers/plot.constants';
 import { CableLengthChangeComponent } from '@features/studio/loads/presentation/components/cable-length-change/cable-length-change';
 import { formatSupportNumber } from '@shared/helpers/formatSupportNumber';
+import { CableSpanManipComponent } from '@features/studio/loads/presentation/components/cable-span-manip/cable-span-manip';
 
 /** Main studio page component orchestrating section visualization, loads, obstacles, and toolbars. */
 @Component({
@@ -68,7 +69,8 @@ import { formatSupportNumber } from '@shared/helpers/formatSupportNumber';
     NewChargeModalComponent,
     ToolbarDialogComponent,
     ObstaclesFormComponent,
-    FreePositioningComponent
+    FreePositioningComponent,
+    CableSpanManipComponent
   ],
   templateUrl: './studio-page.component.html',
   styleUrl: './studio-page.component.scss',

--- a/src/app/features/studio/loads/presentation/components/cable-length-change/cable-length-change.html
+++ b/src/app/features/studio/loads/presentation/components/cable-length-change/cable-length-change.html
@@ -29,7 +29,6 @@
       formControlName="scope"
       optionLabel="label"
       optionValue="value"
-      [filter]="true"
       (onChange)="onScopeChange($event.value)"
       data-testid="cable-length-change-scope"
     />

--- a/src/app/features/studio/loads/presentation/components/cable-length-change/cable-length-change.spec.ts
+++ b/src/app/features/studio/loads/presentation/components/cable-length-change/cable-length-change.spec.ts
@@ -542,7 +542,7 @@ describe('CableLengthChangeComponent', () => {
       expect(mockPlotService.plotOptionsChange).not.toHaveBeenCalled();
     });
 
-    it('should populate supportRefOptions, enable supportRef and call plotOptionsChange for a valid span', () => {
+    it('should populate supportRefOptions and enable supportRef without changing the plot view for a valid span', () => {
       component.onScopeChange('support-uuid-1');
 
       expect(component.supportRefOptions()).toEqual([
@@ -550,7 +550,7 @@ describe('CableLengthChangeComponent', () => {
         { label: '2', value: 'RIGHT' }
       ]);
       expect(component.form.controls.supportRef.enabled).toBe(true);
-      expect(mockPlotService.plotOptionsChange).toHaveBeenCalledWith({ startSupport: 0, endSupport: 1 });
+      expect(mockPlotService.plotOptionsChange).not.toHaveBeenCalled();
     });
 
     it('should load saved modification values when one exists for the span', () => {
@@ -566,7 +566,7 @@ describe('CableLengthChangeComponent', () => {
             distanceSupportRef: 7
           }
         ]
-      });
+      } as unknown as Section);
 
       component.onScopeChange('support-uuid-1');
 
@@ -578,7 +578,7 @@ describe('CableLengthChangeComponent', () => {
     });
 
     it('should reset form to defaults and set hasSavedModification to true when no saved modification exists', () => {
-      mockPlotService.section.set({ ...mockSection, cable_modifications: [] });
+      mockPlotService.section.set({ ...mockSection, cable_modifications: [] } as unknown as Section);
 
       component.onScopeChange('support-uuid-1');
 

--- a/src/app/features/studio/loads/presentation/components/cable-length-change/cable-length-change.ts
+++ b/src/app/features/studio/loads/presentation/components/cable-length-change/cable-length-change.ts
@@ -1,4 +1,4 @@
-import { ChangeDetectionStrategy, Component, computed, effect, inject, signal, untracked } from '@angular/core';
+import { ChangeDetectionStrategy, Component, computed, inject, signal, untracked } from '@angular/core';
 import { FormBuilder, FormControl, ReactiveFormsModule, Validators } from '@angular/forms';
 import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
 import { merge } from 'rxjs';
@@ -69,9 +69,6 @@ export class CableLengthChangeComponent {
     return this.hasSavedModification();
   });
 
-  /** UUID of the section last seen — used to reset the form when the section changes. */
-  private previousSectionUuid: string | null = null;
-
   constructor() {
     // Track dirty state when user edits content fields (RG.LON-CAB.ENR-BTN.1)
     merge(
@@ -84,27 +81,6 @@ export class CableLengthChangeComponent {
       .subscribe(() => {
         this.isDirtySinceLastSave.set(true);
       });
-
-    // Auto-select the currently visible span when section loads or changes (RG.LON-CAB.POR.5)
-    effect(() => {
-      const section = this.plotService.section();
-      if (!section) {
-        untracked(() => {
-          this.resetForm();
-          this.previousSectionUuid = null;
-        });
-        return;
-      }
-      if (section.uuid === this.previousSectionUuid) return;
-      this.previousSectionUuid = section.uuid;
-
-      const startIndex = untracked(() => this.plotService.plotOptions().startSupport);
-      const defaultUuid = section.supports?.[startIndex]?.uuid ?? section.supports?.[0]?.uuid ?? null;
-      untracked(() => {
-        this.form.controls.scope.setValue(defaultUuid, { emitEvent: false });
-        if (defaultUuid) this.onScopeChange(defaultUuid);
-      });
-    });
   }
 
   onScopeChange(uuid: string | null): void {
@@ -121,11 +97,6 @@ export class CableLengthChangeComponent {
     this.supportRefOptions.set(untracked(() => this.plotService.getSupportOptions(uuid)));
     this.form.controls.supportRef.enable({ emitEvent: false });
     this.form.controls.supportRef.setValue('LEFT', { emitEvent: false });
-
-    this.plotService.plotOptionsChange({
-      startSupport: index,
-      endSupport: index + 1
-    });
 
     const savedMod = untracked(() => this.plotService.section()?.cable_modifications?.find((m) => m.spanUuid === uuid));
     if (savedMod) {

--- a/src/app/features/studio/loads/presentation/components/cable-span-manip/cable-span-manip.html
+++ b/src/app/features/studio/loads/presentation/components/cable-span-manip/cable-span-manip.html
@@ -74,16 +74,15 @@
     <p-inputgroup-addon>m</p-inputgroup-addon>
   </p-inputgroup>
   @if (form.controls.distanceToRefSupport.errors?.['min']) {
-    <p-message id="distanceToRefSupport-error-min" severity="error" size="small" variant="simple">
-      <ng-container i18n>Minimum value:</ng-container>
-      {{ distRefSupportMin() }}
-    </p-message>
-  }
-  @if (form.controls.distanceToRefSupport.errors?.['max']) {
-    <p-message id="distanceToRefSupport-error-max" severity="error" size="small" variant="simple">
-      <ng-container i18n>Maximum value:</ng-container>
-      {{ distRefSupportMax() }}
-    </p-message>
+  <p-message id="distanceToRefSupport-error-min" severity="error" size="small" variant="simple">
+    <ng-container i18n>Minimum value:</ng-container>
+    {{ distRefSupportMin() }}
+  </p-message>
+  } @if (form.controls.distanceToRefSupport.errors?.['max']) {
+  <p-message id="distanceToRefSupport-error-max" severity="error" size="small" variant="simple">
+    <ng-container i18n>Maximum value:</ng-container>
+    {{ distRefSupportMax() }}
+  </p-message>
   }
 
   <div class="split-1-line">
@@ -139,18 +138,28 @@
         <p-inputgroup-addon>m</p-inputgroup-addon>
       </p-inputgroup>
       @if (form.controls.longitudinalDistance.errors?.['min']) {
-        <p-message id="longitudinalDistance-error-min" severity="error" size="small" variant="simple" class="third-1-line__error-1">
-          <ng-container i18n>Minimum value:</ng-container>
-          -100
-        </p-message>
-      }
-      @if (form.controls.longitudinalDistance.errors?.['max']) {
-        <p-message id="longitudinalDistance-error-max" severity="error" size="small" variant="simple" class="third-1-line__error-1">
-          <ng-container i18n>Maximum value:</ng-container>
-          5000
-        </p-message>
-      }
-      } @else {
+      <p-message
+        id="longitudinalDistance-error-min"
+        severity="error"
+        size="small"
+        variant="simple"
+        class="third-1-line__error-1"
+      >
+        <ng-container i18n>Minimum value:</ng-container>
+        -100
+      </p-message>
+      } @if (form.controls.longitudinalDistance.errors?.['max']) {
+      <p-message
+        id="longitudinalDistance-error-max"
+        severity="error"
+        size="small"
+        variant="simple"
+        class="third-1-line__error-1"
+      >
+        <ng-container i18n>Maximum value:</ng-container>
+        5000
+      </p-message>
+      } } @else {
       <dl class="contents">
         <dt class="label" i18n="@@longitudinalDistance" class="third-1-line__label-1">Longitudinal dist.</dt>
         <dd
@@ -181,16 +190,27 @@
         <p-inputgroup-addon>m</p-inputgroup-addon>
       </p-inputgroup>
       @if (form.controls.lateralDistance.errors?.['min']) {
-        <p-message id="lateralDistance-error-min" severity="error" size="small" variant="simple" class="third-1-line__error-2">
-          <ng-container i18n>Minimum value:</ng-container>
-          -100
-        </p-message>
-      }
-      @if (form.controls.lateralDistance.errors?.['max']) {
-        <p-message id="lateralDistance-error-max" severity="error" size="small" variant="simple" class="third-1-line__error-2">
-          <ng-container i18n>Maximum value:</ng-container>
-          100
-        </p-message>
+      <p-message
+        id="lateralDistance-error-min"
+        severity="error"
+        size="small"
+        variant="simple"
+        class="third-1-line__error-2"
+      >
+        <ng-container i18n>Minimum value:</ng-container>
+        -100
+      </p-message>
+      } @if (form.controls.lateralDistance.errors?.['max']) {
+      <p-message
+        id="lateralDistance-error-max"
+        severity="error"
+        size="small"
+        variant="simple"
+        class="third-1-line__error-2"
+      >
+        <ng-container i18n>Maximum value:</ng-container>
+        100
+      </p-message>
       }
 
       <label for="altitude" i18n="@@altitude" class="third-1-line__label-3"> Altitude </label>
@@ -211,16 +231,15 @@
         <p-inputgroup-addon>m</p-inputgroup-addon>
       </p-inputgroup>
       @if (form.controls.altitude.errors?.['min']) {
-        <p-message id="altitude-error-min" severity="error" size="small" variant="simple" class="third-1-line__error-3">
-          <ng-container i18n>Minimum value:</ng-container>
-          -100
-        </p-message>
-      }
-      @if (form.controls.altitude.errors?.['max']) {
-        <p-message id="altitude-error-max" severity="error" size="small" variant="simple" class="third-1-line__error-3">
-          <ng-container i18n>Maximum value:</ng-container>
-          9000
-        </p-message>
+      <p-message id="altitude-error-min" severity="error" size="small" variant="simple" class="third-1-line__error-3">
+        <ng-container i18n>Minimum value:</ng-container>
+        -100
+      </p-message>
+      } @if (form.controls.altitude.errors?.['max']) {
+      <p-message id="altitude-error-max" severity="error" size="small" variant="simple" class="third-1-line__error-3">
+        <ng-container i18n>Maximum value:</ng-container>
+        9000
+      </p-message>
       }
     </div>
 
@@ -336,18 +355,16 @@
     <p-inputgroup-addon>m</p-inputgroup-addon>
   </p-inputgroup>
   @if (form.controls.slingLength.errors?.['min']) {
-    <p-message id="slingLength-error-min" severity="error" size="small" variant="simple">
-      <ng-container i18n>Minimum value:</ng-container>
-      0
-    </p-message>
-  }
-  @if (form.controls.slingLength.errors?.['max']) {
-    <p-message id="slingLength-error-max" severity="error" size="small" variant="simple">
-      <ng-container i18n>Maximum value:</ng-container>
-      99
-    </p-message>
-  }
-  }
+  <p-message id="slingLength-error-min" severity="error" size="small" variant="simple">
+    <ng-container i18n>Minimum value:</ng-container>
+    0
+  </p-message>
+  } @if (form.controls.slingLength.errors?.['max']) {
+  <p-message id="slingLength-error-max" severity="error" size="small" variant="simple">
+    <ng-container i18n>Maximum value:</ng-container>
+    99
+  </p-message>
+  } }
 
   <div class="footer-btns">
     <button

--- a/src/app/features/studio/loads/presentation/components/cable-span-manip/cable-span-manip.html
+++ b/src/app/features/studio/loads/presentation/components/cable-span-manip/cable-span-manip.html
@@ -68,9 +68,23 @@
       (input)="truncateDecimals($event)"
       formControlName="distanceToRefSupport"
       data-testid="cable-span-manip-dist-ref-support"
+      [attr.aria-invalid]="form.controls.distanceToRefSupport.invalid || null"
+      [attr.aria-errormessage]="getErrorIds('distanceToRefSupport', ['min', 'max'])"
     />
     <p-inputgroup-addon>m</p-inputgroup-addon>
   </p-inputgroup>
+  @if (form.controls.distanceToRefSupport.errors?.['min']) {
+    <p-message id="distanceToRefSupport-error-min" severity="error" size="small" variant="simple">
+      <ng-container i18n>Minimum value:</ng-container>
+      {{ distRefSupportMin() }}
+    </p-message>
+  }
+  @if (form.controls.distanceToRefSupport.errors?.['max']) {
+    <p-message id="distanceToRefSupport-error-max" severity="error" size="small" variant="simple">
+      <ng-container i18n>Maximum value:</ng-container>
+      {{ distRefSupportMax() }}
+    </p-message>
+  }
 
   <div class="split-1-line">
     <label for="cableManipType" i18n="@@cableManipType" class="split-1-line__label-1"> Cable manipulation type </label>
@@ -114,12 +128,28 @@
           pInputText
           id="longitudinalDistance"
           step="0.01"
+          min="-100"
+          max="5000"
           (input)="truncateDecimals($event)"
           formControlName="longitudinalDistance"
           data-testid="cable-span-manip-longitudinal-dist"
+          [attr.aria-invalid]="form.controls.longitudinalDistance.invalid || null"
+          [attr.aria-errormessage]="getErrorIds('longitudinalDistance', ['min', 'max'])"
         />
         <p-inputgroup-addon>m</p-inputgroup-addon>
       </p-inputgroup>
+      @if (form.controls.longitudinalDistance.errors?.['min']) {
+        <p-message id="longitudinalDistance-error-min" severity="error" size="small" variant="simple" class="third-1-line__error-1">
+          <ng-container i18n>Minimum value:</ng-container>
+          -100
+        </p-message>
+      }
+      @if (form.controls.longitudinalDistance.errors?.['max']) {
+        <p-message id="longitudinalDistance-error-max" severity="error" size="small" variant="simple" class="third-1-line__error-1">
+          <ng-container i18n>Maximum value:</ng-container>
+          5000
+        </p-message>
+      }
       } @else {
       <dl class="contents">
         <dt class="label" i18n="@@longitudinalDistance" class="third-1-line__label-1">Longitudinal dist.</dt>
@@ -145,9 +175,23 @@
           (input)="truncateDecimals($event)"
           formControlName="lateralDistance"
           data-testid="cable-span-manip-lateral-dist"
+          [attr.aria-invalid]="form.controls.lateralDistance.invalid || null"
+          [attr.aria-errormessage]="getErrorIds('lateralDistance', ['min', 'max'])"
         />
         <p-inputgroup-addon>m</p-inputgroup-addon>
       </p-inputgroup>
+      @if (form.controls.lateralDistance.errors?.['min']) {
+        <p-message id="lateralDistance-error-min" severity="error" size="small" variant="simple" class="third-1-line__error-2">
+          <ng-container i18n>Minimum value:</ng-container>
+          -100
+        </p-message>
+      }
+      @if (form.controls.lateralDistance.errors?.['max']) {
+        <p-message id="lateralDistance-error-max" severity="error" size="small" variant="simple" class="third-1-line__error-2">
+          <ng-container i18n>Maximum value:</ng-container>
+          100
+        </p-message>
+      }
 
       <label for="altitude" i18n="@@altitude" class="third-1-line__label-3"> Altitude </label>
       <p-inputgroup class="third-1-line__input-3">
@@ -161,9 +205,23 @@
           (input)="truncateDecimals($event)"
           formControlName="altitude"
           data-testid="cable-span-manip-altitude"
+          [attr.aria-invalid]="form.controls.altitude.invalid || null"
+          [attr.aria-errormessage]="getErrorIds('altitude', ['min', 'max'])"
         />
         <p-inputgroup-addon>m</p-inputgroup-addon>
       </p-inputgroup>
+      @if (form.controls.altitude.errors?.['min']) {
+        <p-message id="altitude-error-min" severity="error" size="small" variant="simple" class="third-1-line__error-3">
+          <ng-container i18n>Minimum value:</ng-container>
+          -100
+        </p-message>
+      }
+      @if (form.controls.altitude.errors?.['max']) {
+        <p-message id="altitude-error-max" severity="error" size="small" variant="simple" class="third-1-line__error-3">
+          <ng-container i18n>Maximum value:</ng-container>
+          9000
+        </p-message>
+      }
     </div>
 
     <div class="distance-calc-line">
@@ -272,9 +330,23 @@
       (input)="truncateDecimals($event)"
       formControlName="slingLength"
       data-testid="cable-span-manip-sling-length"
+      [attr.aria-invalid]="form.controls.slingLength.invalid || null"
+      [attr.aria-errormessage]="getErrorIds('slingLength', ['min', 'max'])"
     />
     <p-inputgroup-addon>m</p-inputgroup-addon>
   </p-inputgroup>
+  @if (form.controls.slingLength.errors?.['min']) {
+    <p-message id="slingLength-error-min" severity="error" size="small" variant="simple">
+      <ng-container i18n>Minimum value:</ng-container>
+      0
+    </p-message>
+  }
+  @if (form.controls.slingLength.errors?.['max']) {
+    <p-message id="slingLength-error-max" severity="error" size="small" variant="simple">
+      <ng-container i18n>Maximum value:</ng-container>
+      99
+    </p-message>
+  }
   }
 
   <div class="footer-btns">

--- a/src/app/features/studio/loads/presentation/components/cable-span-manip/cable-span-manip.html
+++ b/src/app/features/studio/loads/presentation/components/cable-span-manip/cable-span-manip.html
@@ -72,12 +72,6 @@
     <p-inputgroup-addon>m</p-inputgroup-addon>
   </p-inputgroup>
 
-  <p>
-    min: {{distRefSupportMin()}}
-    <br />
-    max: {{distRefSupportMax()}}
-  </p>
-
   <div class="split-1-line">
     <label for="cableManipType" i18n="@@cableManipType" class="split-1-line__label-1"> Cable manipulation type </label>
     <p-select

--- a/src/app/features/studio/loads/presentation/components/cable-span-manip/cable-span-manip.html
+++ b/src/app/features/studio/loads/presentation/components/cable-span-manip/cable-span-manip.html
@@ -28,10 +28,7 @@
   </div>
 
   <div class="split-1-line">
-    <label for="scope" i18n="@@manipulatedSpan" class="split-1-line__label-1">
-      Manipulated span
-      <!-- Portée manipulée -->
-    </label>
+    <label for="scope" i18n="@@manipulatedSpan" class="split-1-line__label-1"> Manipulated span </label>
     <p-select
       inputId="scope"
       fluid
@@ -44,10 +41,7 @@
       class="split-1-line__input-1"
     />
 
-    <label for="referenceSupport" i18n="@@referenceSupport" class="split-1-line__label-2">
-      Reference support
-      <!-- Support de référence -->
-    </label>
+    <label for="referenceSupport" i18n="@@referenceSupport" class="split-1-line__label-2"> Reference support </label>
     <p-select
       inputId="referenceSupport"
       fluid
@@ -62,7 +56,6 @@
 
   <label for="distanceToRefSupport" i18n="@@manipulatedPointCableDistRefSupport">
     Manipulated point on the cable (Dist. to ref. support)
-    <!-- Point manipulé sur le câble (Dist. au supp. réf.) -->
   </label>
   <p-inputgroup>
     <input
@@ -79,10 +72,7 @@
   </p-inputgroup>
 
   <div class="split-1-line">
-    <label for="cableManipType" i18n="@@cableManipType" class="split-1-line__label-1">
-      Cable manipulation type
-      <!-- Type de manip. du câble -->
-    </label>
+    <label for="cableManipType" i18n="@@cableManipType" class="split-1-line__label-1"> Cable manipulation type </label>
     <p-select
       inputId="cableManipType"
       fluid
@@ -96,7 +86,6 @@
 
     <label for="cableManipMethod" i18n="@@cableManipMethod" class="split-1-line__label-2">
       Cable manipulation method
-      <!-- Moyen de manip. du câble -->
     </label>
     <p-select
       inputId="cableManipMethod"
@@ -112,13 +101,11 @@
 
   <fieldset>
     <legend i18n="@@manipFixedPointPosition" class="legend">Manipulation fixed point position</legend>
-    <!-- Position du point fixe de manipulation -->
 
     <div class="third-1-line">
       @if (isWithCrane()) {
       <label for="longitudinalDistance" i18n="@@longitudinalDistance" class="third-1-line__label-1">
         Longitudinal dist.
-        <!-- Dist. longitudinale -->
       </label>
       <p-inputgroup class="third-1-line__input-1">
         <input
@@ -144,10 +131,7 @@
       </dl>
       }
 
-      <label for="lateralDistance" i18n="@@lateralDistance" class="third-1-line__label-2">
-        Lateral dist.
-        <!-- Dist. latérale -->
-      </label>
+      <label for="lateralDistance" i18n="@@lateralDistance" class="third-1-line__label-2"> Lateral dist. </label>
       <p-inputgroup class="third-1-line__input-2">
         <input
           type="number"
@@ -162,10 +146,7 @@
         <p-inputgroup-addon>m</p-inputgroup-addon>
       </p-inputgroup>
 
-      <label for="altitude" i18n="@@altitude" class="third-1-line__label-3">
-        Altitude
-        <!-- Altitude -->
-      </label>
+      <label for="altitude" i18n="@@altitude" class="third-1-line__label-3"> Altitude </label>
       <p-inputgroup class="third-1-line__input-3">
         <input
           type="number"
@@ -185,7 +166,6 @@
       <button app-btn type="button" disabled aria-disabled="true" data-testid="cable-span-manip-dist-calc-btn">
         <app-icon icon="rocket_launch" />
         <ng-container i18n="@@distCalcBetweenPoints">Dist. calc. between points</ng-container>
-        <!-- Calcul distance entre points -->
       </button>
 
       <dl>
@@ -196,7 +176,6 @@
   </fieldset>
 
   <label for="anchoring" i18n="@@anchoring">Anchoring</label>
-  <!-- Accrochage -->
   <p-select
     inputId="anchoring"
     fluid
@@ -274,7 +253,6 @@
   </div>
   } @else if (isWithSling()) {
   <label for="slingLength" i18n="@@slingLength">Sling length</label>
-  <!-- longueur de l'élingue -->
   <p-inputgroup>
     <input
       type="number"

--- a/src/app/features/studio/loads/presentation/components/cable-span-manip/cable-span-manip.html
+++ b/src/app/features/studio/loads/presentation/components/cable-span-manip/cable-span-manip.html
@@ -1,10 +1,5 @@
-<form
-  [formGroup]="form"
-  [attr.aria-busy]="isLoading()"
-  (ngSubmit)="saveForm()"
-  data-testid="cable-span-manip-form"
->
-  <div>
+<form [formGroup]="form" [attr.aria-busy]="isLoading()" (ngSubmit)="saveForm()" data-testid="cable-span-manip-form">
+  <div class="header-btns">
     <button
       app-btn
       type="button"
@@ -32,9 +27,11 @@
     </button>
   </div>
 
-  <div>
-    <label for="scope" i18n="@@manipulatedSpan">Manipulated span</label>
-    <!-- Portée manipulée -->
+  <div class="split-1-line">
+    <label for="scope" i18n="@@manipulatedSpan" class="split-1-line__label-1">
+      Manipulated span
+      <!-- Portée manipulée -->
+    </label>
     <p-select
       inputId="scope"
       fluid
@@ -42,13 +39,15 @@
       formControlName="scope"
       optionLabel="label"
       optionValue="value"
-      [filter]="true"
       (onChange)="onScopeChange($event.value)"
       data-testid="cable-span-manip-scope"
+      class="split-1-line__input-1"
     />
 
-    <label for="referenceSupport" i18n="@@referenceSupport">Reference support</label>
-    <!-- Support de référence -->
+    <label for="referenceSupport" i18n="@@referenceSupport" class="split-1-line__label-2">
+      Reference support
+      <!-- Support de référence -->
+    </label>
     <p-select
       inputId="referenceSupport"
       fluid
@@ -57,32 +56,33 @@
       optionLabel="label"
       optionValue="value"
       data-testid="cable-span-manip-reference-support"
+      class="split-1-line__input-2"
     />
   </div>
 
-  <div>
-    <label for="distanceToRefSupport" i18n="@@manipulatedPointCableDistRefSupport">
-      Manipulated point on the cable (Dist. to ref. support)
-      <!-- Point manipulé sur le câble (Dist. au supp. réf.) -->
-    </label>
-    <p-inputgroup>
-      <input
-        id="distanceToRefSupport"
-        type="number"
-        pInputText
-        step="0.01"
-        [attr.min]="distRefSupportMin()"
-        [attr.max]="distRefSupportMax()"
-        formControlName="distanceToRefSupport"
-        data-testid="cable-span-manip-dist-ref-support"
-      />
-      <p-inputgroup-addon>m</p-inputgroup-addon>
-    </p-inputgroup>
-  </div>
+  <label for="distanceToRefSupport" i18n="@@manipulatedPointCableDistRefSupport">
+    Manipulated point on the cable (Dist. to ref. support)
+    <!-- Point manipulé sur le câble (Dist. au supp. réf.) -->
+  </label>
+  <p-inputgroup>
+    <input
+      id="distanceToRefSupport"
+      type="number"
+      pInputText
+      step="0.01"
+      [attr.min]="distRefSupportMin()"
+      [attr.max]="distRefSupportMax()"
+      formControlName="distanceToRefSupport"
+      data-testid="cable-span-manip-dist-ref-support"
+    />
+    <p-inputgroup-addon>m</p-inputgroup-addon>
+  </p-inputgroup>
 
-  <div>
-    <label for="cableManipType" i18n="@@cableManipType">Cable manipulation type</label>
-    <!-- Type de manip. du câble -->
+  <div class="split-1-line">
+    <label for="cableManipType" i18n="@@cableManipType" class="split-1-line__label-1">
+      Cable manipulation type
+      <!-- Type de manip. du câble -->
+    </label>
     <p-select
       inputId="cableManipType"
       fluid
@@ -91,10 +91,13 @@
       optionLabel="label"
       optionValue="value"
       data-testid="cable-span-manip-type"
+      class="split-1-line__input-1"
     />
 
-    <label for="cableManipMethod" i18n="@@cableManipMethod">Cable manipulation method</label>
-    <!-- Moyen de manip. du câble -->
+    <label for="cableManipMethod" i18n="@@cableManipMethod" class="split-1-line__label-2">
+      Cable manipulation method
+      <!-- Moyen de manip. du câble -->
+    </label>
     <p-select
       inputId="cableManipMethod"
       fluid
@@ -103,38 +106,49 @@
       optionLabel="label"
       optionValue="value"
       data-testid="cable-span-manip-method"
+      class="split-1-line__input-2"
     />
   </div>
 
   <fieldset>
-    <legend i18n="@@manipFixedPointPosition">Manipulation fixed point position</legend>
+    <legend i18n="@@manipFixedPointPosition" class="legend">Manipulation fixed point position</legend>
     <!-- Position du point fixe de manipulation -->
 
-    <div>
+    <div class="third-1-line">
       @if (isWithCrane()) {
-        <label for="longitudinalDistance" i18n="@@longitudinalDistance">Longitudinal dist.</label>
+      <label for="longitudinalDistance" i18n="@@longitudinalDistance" class="third-1-line__label-1">
+        Longitudinal dist.
         <!-- Dist. longitudinale -->
-        <p-inputgroup>
-          <input
-            type="number"
-            pInputText
-            id="longitudinalDistance"
-            step="0.01"
-            formControlName="longitudinalDistance"
-            data-testid="cable-span-manip-longitudinal-dist"
-          />
-          <p-inputgroup-addon>m</p-inputgroup-addon>
-        </p-inputgroup>
+      </label>
+      <p-inputgroup class="third-1-line__input-1">
+        <input
+          type="number"
+          pInputText
+          id="longitudinalDistance"
+          step="0.01"
+          formControlName="longitudinalDistance"
+          data-testid="cable-span-manip-longitudinal-dist"
+        />
+        <p-inputgroup-addon>m</p-inputgroup-addon>
+      </p-inputgroup>
       } @else {
-        <dl>
-          <dt class="label" i18n="@@longitudinalDistance">Longitudinal dist.</dt>
-          <dd class="read-only-info" data-testid="cable-span-manip-longitudinal-dist-readonly">- m</dd>
-        </dl>
+      <dl class="contents">
+        <dt class="label" i18n="@@longitudinalDistance" class="third-1-line__label-1">Longitudinal dist.</dt>
+        <dd
+          data-testid="cable-span-manip-longitudinal-dist-readonly"
+          class="third-1-line__input-1 read-only-info"
+          aria-live="assertive"
+        >
+          - m
+        </dd>
+      </dl>
       }
 
-      <label for="lateralDistance" i18n="@@lateralDistance">Lateral dist.</label>
-      <!-- Dist. latérale -->
-      <p-inputgroup>
+      <label for="lateralDistance" i18n="@@lateralDistance" class="third-1-line__label-2">
+        Lateral dist.
+        <!-- Dist. latérale -->
+      </label>
+      <p-inputgroup class="third-1-line__input-2">
         <input
           type="number"
           pInputText
@@ -148,9 +162,11 @@
         <p-inputgroup-addon>m</p-inputgroup-addon>
       </p-inputgroup>
 
-      <label for="altitude" i18n="@@altitude">Altitude</label>
-      <!-- Altitude -->
-      <p-inputgroup>
+      <label for="altitude" i18n="@@altitude" class="third-1-line__label-3">
+        Altitude
+        <!-- Altitude -->
+      </label>
+      <p-inputgroup class="third-1-line__input-3">
         <input
           type="number"
           pInputText
@@ -165,16 +181,10 @@
       </p-inputgroup>
     </div>
 
-    <div>
-      <button
-        app-btn
-        type="button"
-        disabled
-        aria-disabled="true"
-        data-testid="cable-span-manip-dist-calc-btn"
-      >
+    <div class="distance-calc-line">
+      <button app-btn type="button" disabled aria-disabled="true" data-testid="cable-span-manip-dist-calc-btn">
         <app-icon icon="rocket_launch" />
-        <ng-container i18n="@@distCalcBetweenPoints">Distance calculation between points</ng-container>
+        <ng-container i18n="@@distCalcBetweenPoints">Dist. calc. between points</ng-container>
         <!-- Calcul distance entre points -->
       </button>
 
@@ -198,89 +208,89 @@
   />
 
   @if (isWithChain()) {
-    <label for="chainName" i18n="@@chainName">Chain name</label>
-    <p-select
-      inputId="chainName"
-      fluid
-      [options]="chainNameOptions()"
-      formControlName="chainName"
-      optionLabel="label"
-      optionValue="value"
-      data-testid="cable-span-manip-chain-name"
-    />
+  <label for="chainName" i18n="@@chainName">Chain name</label>
+  <p-select
+    inputId="chainName"
+    fluid
+    [options]="chainNameOptions()"
+    formControlName="chainName"
+    optionLabel="label"
+    optionValue="value"
+    data-testid="cable-span-manip-chain-name"
+  />
 
-    <div>
-      <label for="chainLength" i18n="@@chainLength">Chain length</label>
-      <p-inputgroup>
-        <input
-          type="number"
-          pInputText
-          id="chainLength"
-          step="0.01"
-          formControlName="chainLength"
-          data-testid="cable-span-manip-chain-length"
-        />
-        <p-inputgroup-addon>m</p-inputgroup-addon>
-      </p-inputgroup>
-
-      <label for="chainWeight" i18n="@@chainWeight">Chain weight</label>
-      <p-inputgroup>
-        <input
-          type="number"
-          pInputText
-          id="chainWeight"
-          step="0.01"
-          formControlName="chainWeight"
-          data-testid="cable-span-manip-chain-weight"
-        />
-        <p-inputgroup-addon>kg</p-inputgroup-addon>
-      </p-inputgroup>
-
-      <label for="chainSurface" i18n="@@chainSurface">Chain surface</label>
-      <p-inputgroup>
-        <input
-          type="number"
-          pInputText
-          id="chainSurface"
-          step="0.01"
-          formControlName="chainSurface"
-          data-testid="cable-span-manip-chain-surface"
-        />
-        <p-inputgroup-addon>m²</p-inputgroup-addon>
-      </p-inputgroup>
-
-      <label for="counterWeight" i18n="@@counterWeight">Counter weight</label>
-      <p-inputgroup>
-        <input
-          type="number"
-          pInputText
-          id="counterWeight"
-          step="0.01"
-          formControlName="counterWeight"
-          data-testid="cable-span-manip-counter-weight"
-        />
-        <p-inputgroup-addon>kg</p-inputgroup-addon>
-      </p-inputgroup>
-    </div>
-  } @else if (isWithSling()) {
-    <label for="slingLength" i18n="@@slingLength">Sling length</label>
-    <!-- longueur de l'élingue -->
-    <p-inputgroup>
+  <div class="split-2-line">
+    <label for="chainLength" i18n="@@chainLength" class="split-2-line__label-1">Chain length</label>
+    <p-inputgroup class="split-2-line__input-1">
       <input
         type="number"
         pInputText
-        id="slingLength"
+        id="chainLength"
         step="0.01"
-        min="0"
-        max="99"
-        formControlName="slingLength"
-        data-testid="cable-span-manip-sling-length"
+        formControlName="chainLength"
+        data-testid="cable-span-manip-chain-length"
       />
       <p-inputgroup-addon>m</p-inputgroup-addon>
     </p-inputgroup>
+
+    <label for="chainWeight" i18n="@@chainWeight" class="split-2-line__label-2">Chain weight</label>
+    <p-inputgroup class="split-2-line__input-2">
+      <input
+        type="number"
+        pInputText
+        id="chainWeight"
+        step="0.01"
+        formControlName="chainWeight"
+        data-testid="cable-span-manip-chain-weight"
+      />
+      <p-inputgroup-addon>kg</p-inputgroup-addon>
+    </p-inputgroup>
+
+    <label for="chainSurface" i18n="@@chainSurface" class="split-2-line__label-3">Chain surface</label>
+    <p-inputgroup class="split-2-line__input-3">
+      <input
+        type="number"
+        pInputText
+        id="chainSurface"
+        step="0.01"
+        formControlName="chainSurface"
+        data-testid="cable-span-manip-chain-surface"
+      />
+      <p-inputgroup-addon>m²</p-inputgroup-addon>
+    </p-inputgroup>
+
+    <label for="counterWeight" i18n="@@counterWeight" class="split-2-line__label-4">Counter weight</label>
+    <p-inputgroup class="split-2-line__input-4">
+      <input
+        type="number"
+        pInputText
+        id="counterWeight"
+        step="0.01"
+        formControlName="counterWeight"
+        data-testid="cable-span-manip-counter-weight"
+      />
+      <p-inputgroup-addon>kg</p-inputgroup-addon>
+    </p-inputgroup>
+  </div>
+  } @else if (isWithSling()) {
+  <label for="slingLength" i18n="@@slingLength">Sling length</label>
+  <!-- longueur de l'élingue -->
+  <p-inputgroup>
+    <input
+      type="number"
+      pInputText
+      id="slingLength"
+      step="0.01"
+      min="0"
+      max="99"
+      formControlName="slingLength"
+      data-testid="cable-span-manip-sling-length"
+    />
+    <p-inputgroup-addon>m</p-inputgroup-addon>
+  </p-inputgroup>
   }
 
-  <div>
+  <div class="footer-btns">
     <button
       app-btn
       btnStyle="danger"

--- a/src/app/features/studio/loads/presentation/components/cable-span-manip/cable-span-manip.html
+++ b/src/app/features/studio/loads/presentation/components/cable-span-manip/cable-span-manip.html
@@ -28,7 +28,7 @@
   </div>
 
   <div class="split-1-line">
-    <label for="scope" i18n="@@manipulatedSpan" class="split-1-line__label-1"> Manipulated span </label>
+    <label for="scope" i18n="@@manipulatedSpan" class="split-1-line__label-1">Manipulated span</label>
     <p-select
       inputId="scope"
       fluid
@@ -41,7 +41,7 @@
       class="split-1-line__input-1"
     />
 
-    <label for="referenceSupport" i18n="@@referenceSupport" class="split-1-line__label-2"> Reference support </label>
+    <label for="referenceSupport" i18n="@@referenceSupport" class="split-1-line__label-2">Reference support</label>
     <p-select
       inputId="referenceSupport"
       fluid
@@ -86,7 +86,7 @@
   }
 
   <div class="split-1-line">
-    <label for="cableManipType" i18n="@@cableManipType" class="split-1-line__label-1"> Cable manipulation type </label>
+    <label for="cableManipType" i18n="@@cableManipType" class="split-1-line__label-1">Cable manipulation type</label>
     <p-select
       inputId="cableManipType"
       fluid
@@ -161,7 +161,7 @@
       </p-message>
       } } @else {
       <dl class="contents">
-        <dt class="label" i18n="@@longitudinalDistance" class="third-1-line__label-1">Longitudinal dist.</dt>
+        <dt class="label third-1-line__label-1" i18n="@@longitudinalDistance">Longitudinal dist.</dt>
         <dd
           data-testid="cable-span-manip-longitudinal-dist-readonly"
           class="third-1-line__input-1 read-only-info"
@@ -172,7 +172,7 @@
       </dl>
       }
 
-      <label for="lateralDistance" i18n="@@lateralDistance" class="third-1-line__label-2"> Lateral dist. </label>
+      <label for="lateralDistance" i18n="@@lateralDistance" class="third-1-line__label-2">Lateral dist.</label>
       <p-inputgroup class="third-1-line__input-2">
         <input
           type="number"
@@ -213,7 +213,7 @@
       </p-message>
       }
 
-      <label for="altitude" i18n="@@altitude" class="third-1-line__label-3"> Altitude </label>
+      <label for="altitude" i18n="@@altitude" class="third-1-line__label-3">Altitude</label>
       <p-inputgroup class="third-1-line__input-3">
         <input
           type="number"
@@ -374,7 +374,7 @@
       aria-label="erase span's cable manipulation"
       i18n-aria-label
       (click)="deleteForm()"
-      [disabled]="hasSavedManipulation() || isLoading()"
+      [disabled]="!hasSavedManipulation() || isLoading()"
       data-testid="cable-span-manip-delete"
     >
       <app-icon icon="delete" />

--- a/src/app/features/studio/loads/presentation/components/cable-span-manip/cable-span-manip.html
+++ b/src/app/features/studio/loads/presentation/components/cable-span-manip/cable-span-manip.html
@@ -78,7 +78,7 @@
     <ng-container i18n>Minimum value:</ng-container>
     {{ distRefSupportMin() }}
   </p-message>
-  } @if (form.controls.distanceToRefSupport.errors?.['max']) {
+  } @else if (form.controls.distanceToRefSupport.errors?.['max']) {
   <p-message id="distanceToRefSupport-error-max" severity="error" size="small" variant="simple">
     <ng-container i18n>Maximum value:</ng-container>
     {{ distRefSupportMax() }}
@@ -148,7 +148,7 @@
         <ng-container i18n>Minimum value:</ng-container>
         -100
       </p-message>
-      } @if (form.controls.longitudinalDistance.errors?.['max']) {
+      } @else if (form.controls.longitudinalDistance.errors?.['max']) {
       <p-message
         id="longitudinalDistance-error-max"
         severity="error"
@@ -200,7 +200,7 @@
         <ng-container i18n>Minimum value:</ng-container>
         -100
       </p-message>
-      } @if (form.controls.lateralDistance.errors?.['max']) {
+      } @else if (form.controls.lateralDistance.errors?.['max']) {
       <p-message
         id="lateralDistance-error-max"
         severity="error"
@@ -235,7 +235,7 @@
         <ng-container i18n>Minimum value:</ng-container>
         -100
       </p-message>
-      } @if (form.controls.altitude.errors?.['max']) {
+      } @else if (form.controls.altitude.errors?.['max']) {
       <p-message id="altitude-error-max" severity="error" size="small" variant="simple" class="third-1-line__error-3">
         <ng-container i18n>Maximum value:</ng-container>
         9000
@@ -359,7 +359,7 @@
     <ng-container i18n>Minimum value:</ng-container>
     0
   </p-message>
-  } @if (form.controls.slingLength.errors?.['max']) {
+  } @else if (form.controls.slingLength.errors?.['max']) {
   <p-message id="slingLength-error-max" severity="error" size="small" variant="simple">
     <ng-container i18n>Maximum value:</ng-container>
     99

--- a/src/app/features/studio/loads/presentation/components/cable-span-manip/cable-span-manip.html
+++ b/src/app/features/studio/loads/presentation/components/cable-span-manip/cable-span-manip.html
@@ -1,0 +1,321 @@
+<form
+  [formGroup]="form"
+  [attr.aria-busy]="isLoading()"
+  (ngSubmit)="saveForm()"
+  data-testid="cable-span-manip-form"
+>
+  <div>
+    <button
+      app-btn
+      type="button"
+      btnStyle="outlined"
+      btnSize="s"
+      (click)="zoomToSpan()"
+      [disabled]="isLoading()"
+      data-testid="cable-span-manip-zoom"
+    >
+      <app-icon icon="filter_center_focus" />
+      <ng-container i18n>Zoom</ng-container>
+    </button>
+
+    <button
+      app-btn
+      type="button"
+      btnStyle="outlined"
+      btnSize="s"
+      (click)="resetForm()"
+      [disabled]="isLoading()"
+      data-testid="cable-span-manip-reset"
+    >
+      <app-icon icon="refresh" />
+      <ng-container i18n>Reset</ng-container>
+    </button>
+  </div>
+
+  <div>
+    <label for="scope" i18n="@@manipulatedSpan">Manipulated span</label>
+    <!-- Portée manipulée -->
+    <p-select
+      inputId="scope"
+      fluid
+      [options]="spansOptions()"
+      formControlName="scope"
+      optionLabel="label"
+      optionValue="value"
+      [filter]="true"
+      (onChange)="onScopeChange($event.value)"
+      data-testid="cable-span-manip-scope"
+    />
+
+    <label for="referenceSupport" i18n="@@referenceSupport">Reference support</label>
+    <!-- Support de référence -->
+    <p-select
+      inputId="referenceSupport"
+      fluid
+      [options]="supportRefOptions()"
+      formControlName="referenceSupport"
+      optionLabel="label"
+      optionValue="value"
+      data-testid="cable-span-manip-reference-support"
+    />
+  </div>
+
+  <div>
+    <label for="distanceToRefSupport" i18n="@@manipulatedPointCableDistRefSupport">
+      Manipulated point on the cable (Dist. to ref. support)
+      <!-- Point manipulé sur le câble (Dist. au supp. réf.) -->
+    </label>
+    <p-inputgroup>
+      <input
+        id="distanceToRefSupport"
+        type="number"
+        pInputText
+        step="0.01"
+        [attr.min]="distRefSupportMin()"
+        [attr.max]="distRefSupportMax()"
+        formControlName="distanceToRefSupport"
+        data-testid="cable-span-manip-dist-ref-support"
+      />
+      <p-inputgroup-addon>m</p-inputgroup-addon>
+    </p-inputgroup>
+  </div>
+
+  <div>
+    <label for="cableManipType" i18n="@@cableManipType">Cable manipulation type</label>
+    <!-- Type de manip. du câble -->
+    <p-select
+      inputId="cableManipType"
+      fluid
+      [options]="cableManipTypeOptions"
+      formControlName="cableManipType"
+      optionLabel="label"
+      optionValue="value"
+      data-testid="cable-span-manip-type"
+    />
+
+    <label for="cableManipMethod" i18n="@@cableManipMethod">Cable manipulation method</label>
+    <!-- Moyen de manip. du câble -->
+    <p-select
+      inputId="cableManipMethod"
+      fluid
+      [options]="cableManipMethodOptions"
+      formControlName="cableManipMethod"
+      optionLabel="label"
+      optionValue="value"
+      data-testid="cable-span-manip-method"
+    />
+  </div>
+
+  <fieldset>
+    <legend i18n="@@manipFixedPointPosition">Manipulation fixed point position</legend>
+    <!-- Position du point fixe de manipulation -->
+
+    <div>
+      @if (isWithCrane()) {
+        <label for="longitudinalDistance" i18n="@@longitudinalDistance">Longitudinal dist.</label>
+        <!-- Dist. longitudinale -->
+        <p-inputgroup>
+          <input
+            type="number"
+            pInputText
+            id="longitudinalDistance"
+            step="0.01"
+            formControlName="longitudinalDistance"
+            data-testid="cable-span-manip-longitudinal-dist"
+          />
+          <p-inputgroup-addon>m</p-inputgroup-addon>
+        </p-inputgroup>
+      } @else {
+        <dl>
+          <dt class="label" i18n="@@longitudinalDistance">Longitudinal dist.</dt>
+          <dd class="read-only-info" data-testid="cable-span-manip-longitudinal-dist-readonly">- m</dd>
+        </dl>
+      }
+
+      <label for="lateralDistance" i18n="@@lateralDistance">Lateral dist.</label>
+      <!-- Dist. latérale -->
+      <p-inputgroup>
+        <input
+          type="number"
+          pInputText
+          id="lateralDistance"
+          step="0.01"
+          min="-100"
+          max="100"
+          formControlName="lateralDistance"
+          data-testid="cable-span-manip-lateral-dist"
+        />
+        <p-inputgroup-addon>m</p-inputgroup-addon>
+      </p-inputgroup>
+
+      <label for="altitude" i18n="@@altitude">Altitude</label>
+      <!-- Altitude -->
+      <p-inputgroup>
+        <input
+          type="number"
+          pInputText
+          id="altitude"
+          step="0.01"
+          min="-100"
+          max="9000"
+          formControlName="altitude"
+          data-testid="cable-span-manip-altitude"
+        />
+        <p-inputgroup-addon>m</p-inputgroup-addon>
+      </p-inputgroup>
+    </div>
+
+    <div>
+      <button
+        app-btn
+        type="button"
+        disabled
+        aria-disabled="true"
+        data-testid="cable-span-manip-dist-calc-btn"
+      >
+        <app-icon icon="rocket_launch" />
+        <ng-container i18n="@@distCalcBetweenPoints">Distance calculation between points</ng-container>
+        <!-- Calcul distance entre points -->
+      </button>
+
+      <dl>
+        <dt class="label" i18n="@@distance">Distance</dt>
+        <dd class="read-only-info" data-testid="cable-span-manip-dist-result">- m</dd>
+      </dl>
+    </div>
+  </fieldset>
+
+  <label for="anchoring" i18n="@@anchoring">Anchoring</label>
+  <!-- Accrochage -->
+  <p-select
+    inputId="anchoring"
+    fluid
+    [options]="anchoringOptions"
+    formControlName="anchoring"
+    optionLabel="label"
+    optionValue="value"
+    data-testid="cable-span-manip-anchoring"
+  />
+
+  @if (isWithChain()) {
+    <label for="chainName" i18n="@@chainName">Chain name</label>
+    <p-select
+      inputId="chainName"
+      fluid
+      [options]="chainNameOptions()"
+      formControlName="chainName"
+      optionLabel="label"
+      optionValue="value"
+      data-testid="cable-span-manip-chain-name"
+    />
+
+    <div>
+      <label for="chainLength" i18n="@@chainLength">Chain length</label>
+      <p-inputgroup>
+        <input
+          type="number"
+          pInputText
+          id="chainLength"
+          step="0.01"
+          formControlName="chainLength"
+          data-testid="cable-span-manip-chain-length"
+        />
+        <p-inputgroup-addon>m</p-inputgroup-addon>
+      </p-inputgroup>
+
+      <label for="chainWeight" i18n="@@chainWeight">Chain weight</label>
+      <p-inputgroup>
+        <input
+          type="number"
+          pInputText
+          id="chainWeight"
+          step="0.01"
+          formControlName="chainWeight"
+          data-testid="cable-span-manip-chain-weight"
+        />
+        <p-inputgroup-addon>kg</p-inputgroup-addon>
+      </p-inputgroup>
+
+      <label for="chainSurface" i18n="@@chainSurface">Chain surface</label>
+      <p-inputgroup>
+        <input
+          type="number"
+          pInputText
+          id="chainSurface"
+          step="0.01"
+          formControlName="chainSurface"
+          data-testid="cable-span-manip-chain-surface"
+        />
+        <p-inputgroup-addon>m²</p-inputgroup-addon>
+      </p-inputgroup>
+
+      <label for="counterWeight" i18n="@@counterWeight">Counter weight</label>
+      <p-inputgroup>
+        <input
+          type="number"
+          pInputText
+          id="counterWeight"
+          step="0.01"
+          formControlName="counterWeight"
+          data-testid="cable-span-manip-counter-weight"
+        />
+        <p-inputgroup-addon>kg</p-inputgroup-addon>
+      </p-inputgroup>
+    </div>
+  } @else if (isWithSling()) {
+    <label for="slingLength" i18n="@@slingLength">Sling length</label>
+    <!-- longueur de l'élingue -->
+    <p-inputgroup>
+      <input
+        type="number"
+        pInputText
+        id="slingLength"
+        step="0.01"
+        min="0"
+        max="99"
+        formControlName="slingLength"
+        data-testid="cable-span-manip-sling-length"
+      />
+      <p-inputgroup-addon>m</p-inputgroup-addon>
+    </p-inputgroup>
+  }
+
+  <div>
+    <button
+      app-btn
+      btnStyle="danger"
+      type="button"
+      aria-label="erase span's cable manipulation"
+      i18n-aria-label
+      (click)="deleteForm()"
+      [disabled]="hasSavedManipulation() || isLoading()"
+      data-testid="cable-span-manip-delete"
+    >
+      <app-icon icon="delete" />
+    </button>
+
+    <button
+      app-btn
+      type="submit"
+      btnStyle="outlined"
+      [disabled]="isFormInvalid() || isLoading() || !isDirtySinceLastSave()"
+      [btnLoading]="isCalculating()"
+      data-testid="cable-span-manip-save"
+    >
+      <app-icon icon="save" />
+      <ng-container i18n>Save</ng-container>
+    </button>
+
+    <button
+      app-btn
+      type="button"
+      [disabled]="isFormInvalid() || isLoading()"
+      [btnLoading]="isCalculating()"
+      (click)="calculate()"
+      data-testid="cable-span-manip-calculate"
+    >
+      <app-icon icon="rocket_launch" />
+      <ng-container i18n>Calculate</ng-container>
+    </button>
+  </div>
+</form>

--- a/src/app/features/studio/loads/presentation/components/cable-span-manip/cable-span-manip.html
+++ b/src/app/features/studio/loads/presentation/components/cable-span-manip/cable-span-manip.html
@@ -65,11 +65,18 @@
       step="0.01"
       [attr.min]="distRefSupportMin()"
       [attr.max]="distRefSupportMax()"
+      (input)="truncateDecimals($event)"
       formControlName="distanceToRefSupport"
       data-testid="cable-span-manip-dist-ref-support"
     />
     <p-inputgroup-addon>m</p-inputgroup-addon>
   </p-inputgroup>
+
+  <p>
+    min: {{distRefSupportMin()}}
+    <br />
+    max: {{distRefSupportMax()}}
+  </p>
 
   <div class="split-1-line">
     <label for="cableManipType" i18n="@@cableManipType" class="split-1-line__label-1"> Cable manipulation type </label>
@@ -113,6 +120,7 @@
           pInputText
           id="longitudinalDistance"
           step="0.01"
+          (input)="truncateDecimals($event)"
           formControlName="longitudinalDistance"
           data-testid="cable-span-manip-longitudinal-dist"
         />
@@ -140,6 +148,7 @@
           step="0.01"
           min="-100"
           max="100"
+          (input)="truncateDecimals($event)"
           formControlName="lateralDistance"
           data-testid="cable-span-manip-lateral-dist"
         />
@@ -155,6 +164,7 @@
           step="0.01"
           min="-100"
           max="9000"
+          (input)="truncateDecimals($event)"
           formControlName="altitude"
           data-testid="cable-span-manip-altitude"
         />
@@ -206,6 +216,7 @@
         pInputText
         id="chainLength"
         step="0.01"
+        (input)="truncateDecimals($event)"
         formControlName="chainLength"
         data-testid="cable-span-manip-chain-length"
       />
@@ -219,6 +230,7 @@
         pInputText
         id="chainWeight"
         step="0.01"
+        (input)="truncateDecimals($event)"
         formControlName="chainWeight"
         data-testid="cable-span-manip-chain-weight"
       />
@@ -232,6 +244,7 @@
         pInputText
         id="chainSurface"
         step="0.01"
+        (input)="truncateDecimals($event)"
         formControlName="chainSurface"
         data-testid="cable-span-manip-chain-surface"
       />
@@ -245,6 +258,7 @@
         pInputText
         id="counterWeight"
         step="0.01"
+        (input)="truncateDecimals($event)"
         formControlName="counterWeight"
         data-testid="cable-span-manip-counter-weight"
       />
@@ -261,6 +275,7 @@
       step="0.01"
       min="0"
       max="99"
+      (input)="truncateDecimals($event)"
       formControlName="slingLength"
       data-testid="cable-span-manip-sling-length"
     />

--- a/src/app/features/studio/loads/presentation/components/cable-span-manip/cable-span-manip.interfaces.ts
+++ b/src/app/features/studio/loads/presentation/components/cable-span-manip/cable-span-manip.interfaces.ts
@@ -1,0 +1,36 @@
+import { FormControl } from '@angular/forms';
+import { AnchoringType, CableManipMethod, CableManipType } from '@shared/domain';
+
+/** Typed form controls for the cable span manipulation form. */
+export interface CableSpanManipFormControls {
+  /** Selected span UUID. */
+  scope: FormControl<string | null>;
+  /** Reference support side. */
+  referenceSupport: FormControl<'LEFT' | 'RIGHT' | null>;
+  /** Distance from the reference support to the manipulated point (meters). */
+  distanceToRefSupport: FormControl<number | null>;
+  /** Type of cable manipulation. Always 'with_a_crane' until re-enabled. */
+  cableManipType: FormControl<CableManipType | null>;
+  /** Method of cable manipulation. Always 'clamp' until re-enabled. */
+  cableManipMethod: FormControl<CableManipMethod | null>;
+  /** Longitudinal distance of the fixed point (meters). Relevant for 'with_a_crane' only. */
+  longitudinalDistance: FormControl<number | null>;
+  /** Lateral distance of the fixed point (meters). */
+  lateralDistance: FormControl<number | null>;
+  /** Altitude of the fixed point (meters). */
+  altitude: FormControl<number | null>;
+  /** Anchoring type. Always 'with_sling' until re-enabled. */
+  anchoring: FormControl<AnchoringType | null>;
+  /** Chain name (for 'with_chain' anchoring). */
+  chainName: FormControl<string | null>;
+  /** Chain length in meters (for 'with_chain' anchoring). */
+  chainLength: FormControl<number | null>;
+  /** Chain weight in kg (for 'with_chain' anchoring). */
+  chainWeight: FormControl<number | null>;
+  /** Chain surface in m² (for 'with_chain' anchoring). */
+  chainSurface: FormControl<number | null>;
+  /** Counter weight in kg (for 'with_chain' anchoring). */
+  counterWeight: FormControl<number | null>;
+  /** Sling length in meters (for 'with_sling' anchoring). Default 5. */
+  slingLength: FormControl<number | null>;
+}

--- a/src/app/features/studio/loads/presentation/components/cable-span-manip/cable-span-manip.interfaces.ts
+++ b/src/app/features/studio/loads/presentation/components/cable-span-manip/cable-span-manip.interfaces.ts
@@ -1,6 +1,23 @@
 import { FormControl } from '@angular/forms';
 import { AnchoringType, CableManipMethod, CableManipType } from '@shared/domain';
 
+export const CABLE_SPAN_MANIP_DEFAULTS = {
+  referenceSupport: 'LEFT' as 'LEFT' | 'RIGHT',
+  distanceToRefSupport: 0,
+  cableManipType: 'with_a_crane' as CableManipType,
+  cableManipMethod: 'clamp' as CableManipMethod,
+  longitudinalDistance: 0,
+  lateralDistance: 0,
+  altitude: 0,
+  anchoring: 'with_sling' as AnchoringType,
+  chainName: null as string | null,
+  chainLength: null as number | null,
+  chainWeight: null as number | null,
+  chainSurface: null as number | null,
+  counterWeight: null as number | null,
+  slingLength: 5
+};
+
 /** Typed form controls for the cable span manipulation form. */
 export interface CableSpanManipFormControls {
   /** Selected span UUID. */

--- a/src/app/features/studio/loads/presentation/components/cable-span-manip/cable-span-manip.scss
+++ b/src/app/features/studio/loads/presentation/components/cable-span-manip/cable-span-manip.scss
@@ -5,6 +5,10 @@ p-inputgroup {
   @apply mb-3;
 }
 
+p-message {
+  @apply relative bottom-3;
+}
+
 .header-btns {
   @apply flex justify-between items-center mb-3;
 }
@@ -43,7 +47,8 @@ p-inputgroup {
   column-gap: 0.625rem;
   grid-template-areas:
     'label1 label2 label3'
-    'input1 input2 input3';
+    'input1 input2 input3'
+    'error1 error2 error3';
 
   &__label-1 {
     grid-area: label1;
@@ -63,6 +68,18 @@ p-inputgroup {
 
   &__input-3 {
     grid-area: input3;
+  }
+
+  &__error-1 {
+    grid-area: error1;
+  }
+
+  &__error-2 {
+    grid-area: error2;
+  }
+
+  &__error-3 {
+    grid-area: error3;
   }
 }
 

--- a/src/app/features/studio/loads/presentation/components/cable-span-manip/cable-span-manip.scss
+++ b/src/app/features/studio/loads/presentation/components/cable-span-manip/cable-span-manip.scss
@@ -1,0 +1,117 @@
+@use 'abstract.extracts' as app;
+
+p-select,
+p-inputgroup {
+  @apply mb-3;
+}
+
+.header-btns {
+  @apply flex justify-between items-center mb-3;
+}
+
+.split-1-line {
+  @apply grid grid-cols-2;
+  column-gap: 0.625rem;
+  grid-template-areas:
+    'label1 label2'
+    'input1 input2';
+
+  &__label-1 {
+    grid-area: label1;
+  }
+
+  &__label-2 {
+    grid-area: label2;
+  }
+
+  &__input-1 {
+    grid-area: input1;
+  }
+
+  &__input-2 {
+    grid-area: input2;
+  }
+}
+
+.legend {
+  @extend %heading-2xs;
+  @apply mb-3;
+}
+
+.third-1-line {
+  @apply grid grid-cols-3;
+  column-gap: 0.625rem;
+  grid-template-areas:
+    'label1 label2 label3'
+    'input1 input2 input3';
+
+  &__label-1 {
+    grid-area: label1;
+  }
+
+  &__label-2 {
+    grid-area: label2;
+  }
+
+  &__input-1 {
+    grid-area: input1;
+  }
+
+  &__input-2 {
+    grid-area: input2;
+  }
+
+  &__input-3 {
+    grid-area: input3;
+  }
+}
+
+.distance-calc-line {
+  @apply flex items-start gap-3 mb-2;
+}
+
+.split-2-line {
+  @apply grid grid-cols-2;
+  column-gap: 0.625rem;
+  grid-template-areas:
+    'label1 label2'
+    'input1 input2'
+    'label3 label4'
+    'input3 input4';
+
+  &__label-1 {
+    grid-area: label1;
+  }
+
+  &__input-1 {
+    grid-area: input1;
+  }
+
+  &__label-2 {
+    grid-area: label2;
+  }
+
+  &__input-2 {
+    grid-area: input2;
+  }
+
+  &__label-3 {
+    grid-area: label3;
+  }
+
+  &__input-3 {
+    grid-area: input3;
+  }
+
+  &__label-4 {
+    grid-area: label4;
+  }
+
+  &__input-4 {
+    grid-area: input4;
+  }
+}
+
+.footer-btns {
+  @apply flex justify-end items-center gap-4 pt-5 pr-2;
+}

--- a/src/app/features/studio/loads/presentation/components/cable-span-manip/cable-span-manip.spec.ts
+++ b/src/app/features/studio/loads/presentation/components/cable-span-manip/cable-span-manip.spec.ts
@@ -1,0 +1,568 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { provideNoopAnimations } from '@angular/platform-browser/animations';
+import { vi } from 'vitest';
+import { signal } from '@angular/core';
+import { CableSpanManipComponent } from './cable-span-manip';
+import { PlotService } from '@services/plot/plot.service';
+import { CableSpanManipService } from '../../services/cableSpanManip.service';
+import { ChainsService } from '@shared/catalog/services/chains.service';
+import { Section } from '@shared/domain';
+
+function createSignalMock<T>(initialValue: T) {
+  let value = initialValue;
+  const fn = vi.fn(() => value) as vi.Mock & { set: vi.Mock };
+  fn.set = vi.fn((v: T) => {
+    value = v;
+  });
+  return fn;
+}
+
+const mockSection: Partial<Section> = {
+  uuid: 'section-uuid-1',
+  supports: [
+    { uuid: 'support-uuid-1', number: 'PA1', armLength: 2, spanLength: 100 } as Section['supports'][0],
+    { uuid: 'support-uuid-2', number: 'PA2', armLength: 3, spanLength: null } as Section['supports'][0]
+  ],
+  cable_span_manipulations: [],
+  selected_cable_span_manipulation_uuid: null
+};
+
+describe('CableSpanManipComponent', () => {
+  let component: CableSpanManipComponent;
+  let fixture: ComponentFixture<CableSpanManipComponent>;
+  let mockPlotService: vi.Mocked<PlotService>;
+  let mockCableSpanManipService: vi.Mocked<CableSpanManipService>;
+  let mockChainsService: { getChains: vi.Mock };
+
+  const getByTestId = (testId: string): HTMLElement | null =>
+    fixture.nativeElement.querySelector(`[data-testid="${testId}"]`);
+
+  beforeEach(async () => {
+    mockPlotService = {
+      section: createSignalMock<Partial<Section> | null>(mockSection),
+      study: createSignalMock(null),
+      loading: signal(false),
+      plotOptions: createSignalMock({ startSupport: 0, endSupport: 1 }),
+      getSupportIndex: vi.fn().mockReturnValue(0),
+      getSupportOptions: vi.fn().mockReturnValue([
+        { label: 'PA1', value: 'LEFT' },
+        { label: 'PA2', value: 'RIGHT' }
+      ]),
+      plotOptionsChange: vi.fn(),
+      getSpanOptions: signal([{ label: 'PA1 - PA2', value: 'support-uuid-1' }])
+    } as unknown as vi.Mocked<PlotService>;
+
+    mockCableSpanManipService = {
+      save: vi.fn().mockResolvedValue(undefined),
+      delete: vi.fn().mockResolvedValue(undefined),
+      clearPersistedFormData: vi.fn(),
+      studiesService: { getStudy: vi.fn().mockResolvedValue(null) }
+    } as unknown as vi.Mocked<CableSpanManipService>;
+
+    mockChainsService = {
+      getChains: vi.fn().mockResolvedValue([])
+    };
+
+    await TestBed.configureTestingModule({
+      imports: [CableSpanManipComponent],
+      providers: [
+        provideNoopAnimations(),
+        { provide: PlotService, useValue: mockPlotService },
+        { provide: CableSpanManipService, useValue: mockCableSpanManipService },
+        { provide: ChainsService, useValue: mockChainsService }
+      ]
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(CableSpanManipComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('should be created', () => {
+    expect(component).toBeTruthy();
+  });
+
+  describe('isCalculating computed', () => {
+    it('should reflect plotService.loading() as false by default', () => {
+      expect(component.isCalculating()).toBe(false);
+    });
+
+    it('should be true when plotService.loading() is true', () => {
+      mockPlotService.loading.set(true);
+      expect(component.isCalculating()).toBe(true);
+    });
+  });
+
+  // ---------------------------------------------------------------------------
+  // HTML rendering — form structure
+  // ---------------------------------------------------------------------------
+  describe('HTML rendering - form structure', () => {
+    it('should render the form', () => {
+      const form = getByTestId('cable-span-manip-form');
+      expect(form).toBeTruthy();
+      expect(form?.tagName).toBe('FORM');
+    });
+
+    it('should render the zoom button', () => {
+      const btn = getByTestId('cable-span-manip-zoom');
+      expect(btn).toBeTruthy();
+      expect(btn?.tagName).toBe('BUTTON');
+    });
+
+    it('should render the reset button', () => {
+      const btn = getByTestId('cable-span-manip-reset');
+      expect(btn).toBeTruthy();
+      expect(btn?.tagName).toBe('BUTTON');
+    });
+
+    it('should render the span select', () => {
+      const select = getByTestId('cable-span-manip-scope');
+      expect(select).toBeTruthy();
+    });
+
+    it('should render the reference support select', () => {
+      const select = getByTestId('cable-span-manip-reference-support');
+      expect(select).toBeTruthy();
+    });
+
+    it('should render the distance to ref support input', () => {
+      const input = getByTestId('cable-span-manip-dist-ref-support') as HTMLInputElement;
+      expect(input).toBeTruthy();
+      expect(input?.tagName).toBe('INPUT');
+    });
+
+    it('should render the cable manip type select', () => {
+      const select = getByTestId('cable-span-manip-type');
+      expect(select).toBeTruthy();
+    });
+
+    it('should render the cable manip method select', () => {
+      const select = getByTestId('cable-span-manip-method');
+      expect(select).toBeTruthy();
+    });
+
+    it('should render the lateral distance input', () => {
+      const input = getByTestId('cable-span-manip-lateral-dist') as HTMLInputElement;
+      expect(input).toBeTruthy();
+      expect(input?.tagName).toBe('INPUT');
+    });
+
+    it('should render the altitude input', () => {
+      const input = getByTestId('cable-span-manip-altitude') as HTMLInputElement;
+      expect(input).toBeTruthy();
+      expect(input?.tagName).toBe('INPUT');
+    });
+
+    it('should render the distance calculation button as disabled', () => {
+      const btn = getByTestId('cable-span-manip-dist-calc-btn') as HTMLButtonElement;
+      expect(btn).toBeTruthy();
+      expect(btn.disabled).toBe(true);
+    });
+
+    it('should render the distance result read-only field', () => {
+      const dd = getByTestId('cable-span-manip-dist-result');
+      expect(dd).toBeTruthy();
+      expect(dd?.textContent?.trim()).toBe('- m');
+    });
+
+    it('should render the anchoring select', () => {
+      const select = getByTestId('cable-span-manip-anchoring');
+      expect(select).toBeTruthy();
+    });
+
+    it('should render the save button', () => {
+      const btn = getByTestId('cable-span-manip-save');
+      expect(btn).toBeTruthy();
+      expect(btn?.tagName).toBe('BUTTON');
+    });
+
+    it('should render the delete button', () => {
+      const btn = getByTestId('cable-span-manip-delete');
+      expect(btn).toBeTruthy();
+      expect(btn?.tagName).toBe('BUTTON');
+    });
+
+    it('should render the calculate button', () => {
+      const btn = getByTestId('cable-span-manip-calculate');
+      expect(btn).toBeTruthy();
+      expect(btn?.tagName).toBe('BUTTON');
+    });
+  });
+
+  // ---------------------------------------------------------------------------
+  // HTML rendering — conditional sections
+  // ---------------------------------------------------------------------------
+  describe('HTML rendering - conditional anchoring sections', () => {
+    it('should render sling length when anchoring is with_sling', () => {
+      expect(getByTestId('cable-span-manip-sling-length')).toBeTruthy();
+    });
+
+    it('should not render chain fields when anchoring is with_sling', () => {
+      expect(getByTestId('cable-span-manip-chain-name')).toBeNull();
+      expect(getByTestId('cable-span-manip-chain-length')).toBeNull();
+    });
+  });
+
+  describe('HTML rendering - isWithCrane conditional', () => {
+    it('should render the longitudinal distance input when cableManipType is with_a_crane', () => {
+      expect(getByTestId('cable-span-manip-longitudinal-dist')).toBeTruthy();
+      expect(getByTestId('cable-span-manip-longitudinal-dist-readonly')).toBeNull();
+    });
+  });
+
+  // ---------------------------------------------------------------------------
+  // HTML rendering — button states
+  // ---------------------------------------------------------------------------
+  describe('HTML rendering - button states', () => {
+    it('should disable save button when form is invalid', () => {
+      const btn = getByTestId('cable-span-manip-save') as HTMLButtonElement;
+      expect(btn.disabled).toBe(true);
+    });
+
+    it('should disable calculate button when form is invalid', () => {
+      component.form.controls.scope.setValue(null);
+      component.form.controls.referenceSupport.setValue(null);
+      fixture.detectChanges();
+      const btn = getByTestId('cable-span-manip-calculate') as HTMLButtonElement;
+      expect(btn.disabled).toBe(true);
+    });
+
+    it('should disable save button when form is valid but not dirty', () => {
+      component.form.patchValue({ scope: 'support-uuid-1', distanceToRefSupport: 0, lateralDistance: 0, altitude: 0, slingLength: 5 });
+      component.form.controls.referenceSupport.enable();
+      component.form.controls.referenceSupport.setValue('LEFT');
+      component.isDirtySinceLastSave.set(false);
+      fixture.detectChanges();
+      const btn = getByTestId('cable-span-manip-save') as HTMLButtonElement;
+      expect(btn.disabled).toBe(true);
+    });
+
+    it('should enable save button when form is valid and dirty', () => {
+      component.form.patchValue({ scope: 'support-uuid-1', distanceToRefSupport: 0, lateralDistance: 0, altitude: 0, slingLength: 5 });
+      component.form.controls.referenceSupport.enable();
+      component.form.controls.referenceSupport.setValue('LEFT');
+      component.isDirtySinceLastSave.set(true);
+      fixture.detectChanges();
+      const btn = getByTestId('cable-span-manip-save') as HTMLButtonElement;
+      expect(btn.disabled).toBe(false);
+    });
+
+    it('should disable delete button when no manipulation is saved for the span', () => {
+      const btn = getByTestId('cable-span-manip-delete') as HTMLButtonElement;
+      expect(btn.disabled).toBe(true);
+    });
+
+    it('should enable delete button when a manipulation is saved', () => {
+      component.hasSavedManipulation.set(false);
+      fixture.detectChanges();
+      const btn = getByTestId('cable-span-manip-delete') as HTMLButtonElement;
+      expect(btn.disabled).toBe(false);
+    });
+
+    it('should disable buttons when isLoading is true', () => {
+      component.form.patchValue({ scope: 'support-uuid-1', distanceToRefSupport: 0, lateralDistance: 0, altitude: 0, slingLength: 5 });
+      component.form.controls.referenceSupport.enable();
+      component.form.controls.referenceSupport.setValue('LEFT');
+      component.isDirtySinceLastSave.set(true);
+      component.isLoading.set(true);
+      fixture.detectChanges();
+
+      const save = getByTestId('cable-span-manip-save') as HTMLButtonElement;
+      const calculate = getByTestId('cable-span-manip-calculate') as HTMLButtonElement;
+      const reset = getByTestId('cable-span-manip-reset') as HTMLButtonElement;
+      const zoom = getByTestId('cable-span-manip-zoom') as HTMLButtonElement;
+
+      expect(save.disabled).toBe(true);
+      expect(calculate.disabled).toBe(true);
+      expect(reset.disabled).toBe(true);
+      expect(zoom.disabled).toBe(true);
+    });
+  });
+
+  // ---------------------------------------------------------------------------
+  // HTML rendering — accessibility
+  // ---------------------------------------------------------------------------
+  describe('HTML rendering - accessibility', () => {
+    it('should not set aria-busy when not loading', () => {
+      const form = getByTestId('cable-span-manip-form');
+      expect(form?.getAttribute('aria-busy')).toBe('false');
+    });
+
+    it('should set aria-busy when loading', () => {
+      component.isLoading.set(true);
+      fixture.detectChanges();
+      const form = getByTestId('cable-span-manip-form');
+      expect(form?.getAttribute('aria-busy')).toBe('true');
+    });
+  });
+
+  // ---------------------------------------------------------------------------
+  // onScopeChange()
+  // ---------------------------------------------------------------------------
+  describe('onScopeChange()', () => {
+    it('should disable referenceSupport and clear options when uuid is null', () => {
+      component.form.controls.referenceSupport.enable();
+      component.onScopeChange(null);
+      expect(component.form.controls.referenceSupport.disabled).toBe(true);
+      expect(component.supportRefOptions()).toHaveLength(0);
+    });
+
+    it('should enable referenceSupport and set options when valid uuid is given', () => {
+      component.onScopeChange('support-uuid-1');
+      expect(component.form.controls.referenceSupport.enabled).toBe(true);
+      expect(component.supportRefOptions().length).toBeGreaterThan(0);
+    });
+
+    it('should update distRefSupportMin and distRefSupportMax from support data', () => {
+      component.onScopeChange('support-uuid-1');
+      // armLength = 2, spanLength = 100 → min = -2, max = 102
+      expect(component.distRefSupportMin()).toBe(-2);
+      expect(component.distRefSupportMax()).toBe(102);
+    });
+
+    it('should not call plotOptionsChange when scope changes (zoom is explicit)', () => {
+      vi.clearAllMocks();
+      component.onScopeChange('support-uuid-1');
+      expect(mockPlotService.plotOptionsChange).not.toHaveBeenCalled();
+    });
+
+    it('should set isDirtySinceLastSave to true for a new manipulation (no saved data)', () => {
+      component.isDirtySinceLastSave.set(false);
+      component.onScopeChange('support-uuid-1');
+      expect(component.isDirtySinceLastSave()).toBe(true);
+    });
+
+    it('should set isDirtySinceLastSave to false when loading an existing manipulation', () => {
+      mockPlotService.section.set({
+        ...mockSection,
+        cable_span_manipulations: [
+          {
+            uuid: 'manip-uuid-1',
+            spanUuid: 'support-uuid-1',
+            referenceSupport: 'LEFT',
+            distanceToRefSupport: 0,
+            cableManipType: 'with_a_crane',
+            cableManipMethod: 'clamp',
+            longitudinalDistance: 5,
+            lateralDistance: 0,
+            altitude: 0,
+            anchoring: 'with_sling',
+            chainName: null,
+            chainLength: null,
+            chainWeight: null,
+            chainSurface: null,
+            counterWeight: null,
+            slingLength: 5
+          }
+        ]
+      } as unknown as Section);
+      component.isDirtySinceLastSave.set(true);
+      component.onScopeChange('support-uuid-1');
+      expect(component.isDirtySinceLastSave()).toBe(false);
+    });
+
+    it('should load saved manipulation values when one exists for the span', () => {
+      mockPlotService.section.set({
+        ...mockSection,
+        cable_span_manipulations: [
+          {
+            uuid: 'manip-uuid-1',
+            spanUuid: 'support-uuid-1',
+            referenceSupport: 'RIGHT',
+            distanceToRefSupport: 10,
+            cableManipType: 'with_a_crane',
+            cableManipMethod: 'clamp',
+            longitudinalDistance: 5,
+            lateralDistance: 2,
+            altitude: 100,
+            anchoring: 'with_sling',
+            chainName: null,
+            chainLength: null,
+            chainWeight: null,
+            chainSurface: null,
+            counterWeight: null,
+            slingLength: 3
+          }
+        ]
+      } as unknown as Section);
+
+      component.onScopeChange('support-uuid-1');
+
+      expect(component.form.controls.referenceSupport.value).toBe('RIGHT');
+      expect(component.form.controls.distanceToRefSupport.value).toBe(10);
+      expect(component.form.controls.slingLength.value).toBe(3);
+      expect(component.hasSavedManipulation()).toBe(false);
+    });
+  });
+
+  // ---------------------------------------------------------------------------
+  // resetForm()
+  // ---------------------------------------------------------------------------
+  describe('resetForm()', () => {
+    it('should reset content fields to defaults', () => {
+      component.form.controls.lateralDistance.setValue(50);
+      component.form.controls.altitude.setValue(200);
+      component.form.controls.slingLength.setValue(10);
+      component.resetForm();
+      expect(component.form.controls.lateralDistance.value).toBe(0);
+      expect(component.form.controls.altitude.value).toBe(0);
+      expect(component.form.controls.slingLength.value).toBe(5);
+    });
+
+    it('should reset isDirtySinceLastSave to false', () => {
+      component.isDirtySinceLastSave.set(true);
+      component.resetForm();
+      expect(component.isDirtySinceLastSave()).toBe(false);
+    });
+
+    it('should preserve the current scope', () => {
+      component.form.controls.scope.setValue('support-uuid-1', { emitEvent: false });
+      component.resetForm();
+      expect(component.form.controls.scope.value).toBe('support-uuid-1');
+    });
+  });
+
+  // ---------------------------------------------------------------------------
+  // zoomToSpan()
+  // ---------------------------------------------------------------------------
+  describe('zoomToSpan()', () => {
+    it('should not call plotOptionsChange when no scope is selected', () => {
+      component.form.controls.scope.setValue(null);
+      vi.clearAllMocks();
+      component.zoomToSpan();
+      expect(mockPlotService.plotOptionsChange).not.toHaveBeenCalled();
+    });
+
+    it('should call plotOptionsChange with span index when scope is selected', () => {
+      component.form.controls.scope.setValue('support-uuid-1');
+      component.zoomToSpan();
+      expect(mockPlotService.plotOptionsChange).toHaveBeenCalledWith({ startSupport: 0, endSupport: 1 });
+    });
+  });
+
+  // ---------------------------------------------------------------------------
+  // saveForm()
+  // ---------------------------------------------------------------------------
+  describe('saveForm()', () => {
+    beforeEach(() => {
+      component.form.patchValue({ scope: 'support-uuid-1', distanceToRefSupport: 5, lateralDistance: 0, altitude: 0, slingLength: 5 });
+      component.form.controls.referenceSupport.enable();
+      component.form.controls.referenceSupport.setValue('LEFT');
+      component.form.controls.distanceToRefSupport.setValidators([]);
+      component.form.controls.distanceToRefSupport.updateValueAndValidity({ emitEvent: false });
+    });
+
+    it('should not call save service if form is invalid', async () => {
+      component.form.controls.scope.setValue(null);
+      await component.saveForm();
+      expect(mockCableSpanManipService.save).not.toHaveBeenCalled();
+    });
+
+    it('should call cableSpanManipService.save with form values', async () => {
+      await component.saveForm();
+      expect(mockCableSpanManipService.save).toHaveBeenCalledWith(
+        expect.objectContaining({
+          spanUuid: 'support-uuid-1',
+          referenceSupport: 'LEFT',
+          distanceToRefSupport: 5,
+          lateralDistance: 0,
+          altitude: 0,
+          slingLength: 5
+        })
+      );
+    });
+
+    it('should reset isDirtySinceLastSave after save', async () => {
+      component.isDirtySinceLastSave.set(true);
+      await component.saveForm();
+      expect(component.isDirtySinceLastSave()).toBe(false);
+    });
+
+    it('should set hasSavedManipulation to false after save', async () => {
+      await component.saveForm();
+      expect(component.hasSavedManipulation()).toBe(false);
+    });
+  });
+
+  // ---------------------------------------------------------------------------
+  // deleteForm()
+  // ---------------------------------------------------------------------------
+  describe('deleteForm()', () => {
+    it('should call delete service when a manipulation exists for the selected span', () => {
+      component.form.controls.scope.setValue('support-uuid-1');
+      mockPlotService.section.set({
+        ...mockSection,
+        cable_span_manipulations: [
+          {
+            uuid: 'manip-uuid-1',
+            spanUuid: 'support-uuid-1',
+            referenceSupport: 'LEFT',
+            distanceToRefSupport: 0,
+            cableManipType: 'with_a_crane',
+            cableManipMethod: 'clamp',
+            longitudinalDistance: null,
+            lateralDistance: 0,
+            altitude: 0,
+            anchoring: 'with_sling',
+            chainName: null,
+            chainLength: null,
+            chainWeight: null,
+            chainSurface: null,
+            counterWeight: null,
+            slingLength: 5
+          }
+        ]
+      } as unknown as Section);
+
+      component.deleteForm();
+
+      expect(mockCableSpanManipService.delete).toHaveBeenCalledWith('manip-uuid-1');
+    });
+
+    it('should not call delete when no manipulation exists for the selected span', () => {
+      component.form.controls.scope.setValue('support-uuid-1');
+      mockPlotService.section.set({ ...mockSection, cable_span_manipulations: [] } as unknown as Section);
+
+      component.deleteForm();
+
+      expect(mockCableSpanManipService.delete).not.toHaveBeenCalled();
+    });
+
+    it('should set hasSavedManipulation to true after deletion', () => {
+      component.hasSavedManipulation.set(false);
+      component.deleteForm();
+      expect(component.hasSavedManipulation()).toBe(true);
+    });
+
+    it('should reset form fields to defaults after deletion', () => {
+      component.form.controls.lateralDistance.setValue(50);
+      component.form.controls.slingLength.setValue(10);
+      component.deleteForm();
+      expect(component.form.controls.lateralDistance.value).toBe(0);
+      expect(component.form.controls.slingLength.value).toBe(5);
+    });
+  });
+
+  // ---------------------------------------------------------------------------
+  // isFormInvalid()
+  // ---------------------------------------------------------------------------
+  describe('isFormInvalid()', () => {
+    it('should return true when scope is null', () => {
+      component.form.controls.scope.setValue(null);
+      expect(component.isFormInvalid()).toBe(true);
+    });
+
+    it('should return false when all required fields are valid', () => {
+      component.form.patchValue({ scope: 'support-uuid-1', distanceToRefSupport: 0, lateralDistance: 0, altitude: 0, slingLength: 5 });
+      component.form.controls.referenceSupport.enable();
+      component.form.controls.referenceSupport.setValue('LEFT');
+      component.form.controls.distanceToRefSupport.setValidators([]);
+      component.form.controls.distanceToRefSupport.updateValueAndValidity({ emitEvent: false });
+      expect(component.isFormInvalid()).toBe(false);
+    });
+  });
+});

--- a/src/app/features/studio/loads/presentation/components/cable-span-manip/cable-span-manip.spec.ts
+++ b/src/app/features/studio/loads/presentation/components/cable-span-manip/cable-span-manip.spec.ts
@@ -336,6 +336,9 @@ describe('CableSpanManipComponent', () => {
     });
 
     it('should update distRefSupportMin and distRefSupportMax from support data', () => {
+      // distRefSupportMin/Max are computed from the scope form control value and section signal,
+      // so both must be updated (as the real p-select does via formControlName + onChange).
+      component.form.controls.scope.setValue('support-uuid-1');
       component.onScopeChange('support-uuid-1');
       // armLength = 2, spanLength = 100 → min = -2, max = 102
       expect(component.distRefSupportMin()).toBe(-2);

--- a/src/app/features/studio/loads/presentation/components/cable-span-manip/cable-span-manip.spec.ts
+++ b/src/app/features/studio/loads/presentation/components/cable-span-manip/cable-span-manip.spec.ts
@@ -513,6 +513,26 @@ describe('CableSpanManipComponent', () => {
       await component.saveForm();
       expect(component.hasSavedManipulation()).toBe(true);
     });
+
+    it('should not set hasSavedManipulation to true when save rejects', async () => {
+      mockCableSpanManipService.save.mockRejectedValue(new Error('save failed'));
+      component.hasSavedManipulation.set(false);
+      await component.saveForm().catch((_err: unknown) => undefined);
+      expect(component.hasSavedManipulation()).toBe(false);
+    });
+
+    it('should always clear isLoading even when save rejects', async () => {
+      mockCableSpanManipService.save.mockRejectedValue(new Error('save failed'));
+      await component.saveForm().catch((_err: unknown) => undefined);
+      expect(component.isLoading()).toBe(false);
+    });
+
+    it('should not reset isDirtySinceLastSave when save rejects', async () => {
+      mockCableSpanManipService.save.mockRejectedValue(new Error('save failed'));
+      component.isDirtySinceLastSave.set(true);
+      await component.saveForm().catch((_err: unknown) => undefined);
+      expect(component.isDirtySinceLastSave()).toBe(true);
+    });
   });
 
   // ---------------------------------------------------------------------------

--- a/src/app/features/studio/loads/presentation/components/cable-span-manip/cable-span-manip.spec.ts
+++ b/src/app/features/studio/loads/presentation/components/cable-span-manip/cable-span-manip.spec.ts
@@ -56,7 +56,7 @@ describe('CableSpanManipComponent', () => {
       save: vi.fn().mockResolvedValue(undefined),
       delete: vi.fn().mockResolvedValue(undefined),
       clearPersistedFormData: vi.fn(),
-      studiesService: { getStudy: vi.fn().mockResolvedValue(null) }
+      reloadSection: vi.fn().mockResolvedValue(undefined)
     } as unknown as vi.Mocked<CableSpanManipService>;
 
     mockChainsService = {
@@ -269,7 +269,7 @@ describe('CableSpanManipComponent', () => {
     });
 
     it('should enable delete button when a manipulation is saved', () => {
-      component.hasSavedManipulation.set(false);
+      component.hasSavedManipulation.set(true);
       fixture.detectChanges();
       const btn = getByTestId('cable-span-manip-delete') as HTMLButtonElement;
       expect(btn.disabled).toBe(false);
@@ -416,7 +416,7 @@ describe('CableSpanManipComponent', () => {
       expect(component.form.controls.referenceSupport.value).toBe('RIGHT');
       expect(component.form.controls.distanceToRefSupport.value).toBe(10);
       expect(component.form.controls.slingLength.value).toBe(3);
-      expect(component.hasSavedManipulation()).toBe(false);
+      expect(component.hasSavedManipulation()).toBe(true);
     });
   });
 
@@ -509,9 +509,9 @@ describe('CableSpanManipComponent', () => {
       expect(component.isDirtySinceLastSave()).toBe(false);
     });
 
-    it('should set hasSavedManipulation to false after save', async () => {
+    it('should set hasSavedManipulation to true after save', async () => {
       await component.saveForm();
-      expect(component.hasSavedManipulation()).toBe(false);
+      expect(component.hasSavedManipulation()).toBe(true);
     });
   });
 
@@ -559,10 +559,10 @@ describe('CableSpanManipComponent', () => {
       expect(mockCableSpanManipService.delete).not.toHaveBeenCalled();
     });
 
-    it('should set hasSavedManipulation to true after deletion', () => {
-      component.hasSavedManipulation.set(false);
+    it('should set hasSavedManipulation to false after deletion', () => {
+      component.hasSavedManipulation.set(true);
       component.deleteForm();
-      expect(component.hasSavedManipulation()).toBe(true);
+      expect(component.hasSavedManipulation()).toBe(false);
     });
 
     it('should reset form fields to defaults after deletion', () => {

--- a/src/app/features/studio/loads/presentation/components/cable-span-manip/cable-span-manip.spec.ts
+++ b/src/app/features/studio/loads/presentation/components/cable-span-manip/cable-span-manip.spec.ts
@@ -232,7 +232,13 @@ describe('CableSpanManipComponent', () => {
     });
 
     it('should disable save button when form is valid but not dirty', () => {
-      component.form.patchValue({ scope: 'support-uuid-1', distanceToRefSupport: 0, lateralDistance: 0, altitude: 0, slingLength: 5 });
+      component.form.patchValue({
+        scope: 'support-uuid-1',
+        distanceToRefSupport: 0,
+        lateralDistance: 0,
+        altitude: 0,
+        slingLength: 5
+      });
       component.form.controls.referenceSupport.enable();
       component.form.controls.referenceSupport.setValue('LEFT');
       component.isDirtySinceLastSave.set(false);
@@ -242,7 +248,13 @@ describe('CableSpanManipComponent', () => {
     });
 
     it('should enable save button when form is valid and dirty', () => {
-      component.form.patchValue({ scope: 'support-uuid-1', distanceToRefSupport: 0, lateralDistance: 0, altitude: 0, slingLength: 5 });
+      component.form.patchValue({
+        scope: 'support-uuid-1',
+        distanceToRefSupport: 0,
+        lateralDistance: 0,
+        altitude: 0,
+        slingLength: 5
+      });
       component.form.controls.referenceSupport.enable();
       component.form.controls.referenceSupport.setValue('LEFT');
       component.isDirtySinceLastSave.set(true);
@@ -264,7 +276,13 @@ describe('CableSpanManipComponent', () => {
     });
 
     it('should disable buttons when isLoading is true', () => {
-      component.form.patchValue({ scope: 'support-uuid-1', distanceToRefSupport: 0, lateralDistance: 0, altitude: 0, slingLength: 5 });
+      component.form.patchValue({
+        scope: 'support-uuid-1',
+        distanceToRefSupport: 0,
+        lateralDistance: 0,
+        altitude: 0,
+        slingLength: 5
+      });
       component.form.controls.referenceSupport.enable();
       component.form.controls.referenceSupport.setValue('LEFT');
       component.isDirtySinceLastSave.set(true);
@@ -449,7 +467,13 @@ describe('CableSpanManipComponent', () => {
   // ---------------------------------------------------------------------------
   describe('saveForm()', () => {
     beforeEach(() => {
-      component.form.patchValue({ scope: 'support-uuid-1', distanceToRefSupport: 5, lateralDistance: 0, altitude: 0, slingLength: 5 });
+      component.form.patchValue({
+        scope: 'support-uuid-1',
+        distanceToRefSupport: 5,
+        lateralDistance: 0,
+        altitude: 0,
+        slingLength: 5
+      });
       component.form.controls.referenceSupport.enable();
       component.form.controls.referenceSupport.setValue('LEFT');
       component.form.controls.distanceToRefSupport.setValidators([]);
@@ -557,7 +581,13 @@ describe('CableSpanManipComponent', () => {
     });
 
     it('should return false when all required fields are valid', () => {
-      component.form.patchValue({ scope: 'support-uuid-1', distanceToRefSupport: 0, lateralDistance: 0, altitude: 0, slingLength: 5 });
+      component.form.patchValue({
+        scope: 'support-uuid-1',
+        distanceToRefSupport: 0,
+        lateralDistance: 0,
+        altitude: 0,
+        slingLength: 5
+      });
       component.form.controls.referenceSupport.enable();
       component.form.controls.referenceSupport.setValue('LEFT');
       component.form.controls.distanceToRefSupport.setValidators([]);

--- a/src/app/features/studio/loads/presentation/components/cable-span-manip/cable-span-manip.ts
+++ b/src/app/features/studio/loads/presentation/components/cable-span-manip/cable-span-manip.ts
@@ -13,6 +13,7 @@ import { ChainsService } from '@shared/catalog/services/chains.service';
 import { AnchoringType, CableManipMethod, CableManipType } from '@shared/domain';
 import { CableSpanManipService } from '../../services/cableSpanManip.service';
 import { CableSpanManipFormControls } from './cable-span-manip.interfaces';
+import { truncateDecimals } from '@shared/helpers/truncateDecimals';
 
 @Component({
   selector: 'app-cable-span-manip',
@@ -104,6 +105,8 @@ export class CableSpanManipComponent {
   readonly isWithCrane = computed(() => this.cableManipTypeSignal() === 'with_a_crane');
   readonly isWithChain = computed(() => this.anchoringSignal() === 'with_chain');
   readonly isWithSling = computed(() => this.anchoringSignal() === 'with_sling');
+
+  readonly truncateDecimals = truncateDecimals;
 
   constructor() {
     // Track dirty state when user edits content fields

--- a/src/app/features/studio/loads/presentation/components/cable-span-manip/cable-span-manip.ts
+++ b/src/app/features/studio/loads/presentation/components/cable-span-manip/cable-span-manip.ts
@@ -8,6 +8,7 @@ import { InputGroupModule } from 'primeng/inputgroup';
 import { InputGroupAddonModule } from 'primeng/inputgroupaddon';
 import { InputText } from 'primeng/inputtext';
 import { SelectModule } from 'primeng/select';
+import { MessageModule } from 'primeng/message';
 import { PlotService } from '@services/plot/plot.service';
 import { ChainsService } from '@shared/catalog/services/chains.service';
 import { AnchoringType, CableManipMethod, CableManipType } from '@shared/domain';
@@ -24,6 +25,7 @@ import { truncateDecimals } from '@shared/helpers/truncateDecimals';
     InputGroupModule,
     InputGroupAddonModule,
     SelectModule,
+    MessageModule,
     ButtonComponent,
     IconComponent
   ],
@@ -400,7 +402,7 @@ export class CableSpanManipComponent {
   private updateLongitudinalDistanceValidators(type: CableManipType | null): void {
     const ctrl = this.form.controls.longitudinalDistance;
     if (type === 'with_a_crane') {
-      ctrl.setValidators([Validators.required]);
+      ctrl.setValidators([Validators.required, Validators.min(-100), Validators.max(5000)]);
     } else {
       ctrl.clearValidators();
     }
@@ -424,6 +426,13 @@ export class CableSpanManipComponent {
       this.form.controls.slingLength.setValidators([Validators.required, Validators.min(0), Validators.max(99)]);
       this.form.controls.slingLength.updateValueAndValidity({ emitEvent: false });
     }
+  }
+
+  getErrorIds(controlName: keyof CableSpanManipFormControls, errorTypes: string[]): string | null {
+    const control = this.form.get(controlName);
+    if (!control?.errors) return null;
+    const ids = errorTypes.filter((type) => control.errors?.[type]).map((type) => `${controlName}-error-${type}`);
+    return ids.length > 0 ? ids.join(' ') : null;
   }
 
   private async reloadSectionFromDb(): Promise<void> {

--- a/src/app/features/studio/loads/presentation/components/cable-span-manip/cable-span-manip.ts
+++ b/src/app/features/studio/loads/presentation/components/cable-span-manip/cable-span-manip.ts
@@ -1,4 +1,4 @@
-import { ChangeDetectionStrategy, Component, computed, inject, signal, untracked } from '@angular/core';
+import { ChangeDetectionStrategy, Component, computed, effect, inject, signal, untracked } from '@angular/core';
 import { FormBuilder, FormControl, ReactiveFormsModule, Validators } from '@angular/forms';
 import { takeUntilDestroyed, toSignal } from '@angular/core/rxjs-interop';
 import { merge, of } from 'rxjs';
@@ -45,11 +45,6 @@ export class CableSpanManipComponent {
   /** Whether a saved manipulation exists for the currently selected span. */
   readonly hasSavedManipulation = signal(true);
 
-  /** Dynamic min for distanceToRefSupport — updated on scope change. */
-  readonly distRefSupportMin = signal(0);
-  /** Dynamic max for distanceToRefSupport — updated on scope change. */
-  readonly distRefSupportMax = signal(0);
-
   readonly form = this.fb.group<CableSpanManipFormControls>({
     scope: new FormControl<string | null>(null, { validators: [Validators.required] }),
     referenceSupport: new FormControl<'LEFT' | 'RIGHT' | null>(
@@ -73,6 +68,27 @@ export class CableSpanManipComponent {
     chainSurface: new FormControl<number | null>(null),
     counterWeight: new FormControl<number | null>(null),
     slingLength: new FormControl<number | null>(5)
+  });
+
+  private readonly scopeValueSignal = toSignal(this.form.controls.scope.valueChanges, {
+    initialValue: this.form.controls.scope.value
+  });
+
+  /** Support data for the currently selected span's left support, reactive to section changes. */
+  private readonly selectedSupportData = computed(() => {
+    const uuid = this.scopeValueSignal();
+    if (!uuid) return null;
+    const supports = this.plotService.section()?.supports ?? [];
+    const index = supports.findIndex((s) => s.uuid === uuid);
+    return index >= 0 ? supports[index] : null;
+  });
+
+  /** Dynamic min for distanceToRefSupport — reactive to section and scope changes. */
+  readonly distRefSupportMin = computed(() => -Math.abs(this.selectedSupportData()?.armLength ?? 0));
+  /** Dynamic max for distanceToRefSupport — reactive to section and scope changes. */
+  readonly distRefSupportMax = computed(() => {
+    const support = this.selectedSupportData();
+    return (support?.spanLength ?? 0) + Math.abs(support?.armLength ?? 0);
   });
 
   readonly spansOptions = this.plotService.getSpanOptions;
@@ -128,6 +144,18 @@ export class CableSpanManipComponent {
         this.isDirtySinceLastSave.set(true);
       });
 
+    // Keep distanceToRefSupport validators in sync with the selected span's support data
+    effect(() => {
+      const min = this.distRefSupportMin();
+      const max = this.distRefSupportMax();
+      this.form.controls.distanceToRefSupport.setValidators([
+        Validators.required,
+        Validators.min(min),
+        Validators.max(max)
+      ]);
+      this.form.controls.distanceToRefSupport.updateValueAndValidity({ emitEvent: false });
+    });
+
     // Conditional validators: longitudinalDistance required only when using a crane
     merge(of(this.form.controls.cableManipType.value), this.form.controls.cableManipType.valueChanges)
       .pipe(takeUntilDestroyed())
@@ -161,22 +189,6 @@ export class CableSpanManipComponent {
 
     const index = untracked(() => this.plotService.getSupportIndex(uuid));
     if (index < 0) return;
-
-    const supports = untracked(() => this.plotService.section()?.supports ?? []);
-    const support = supports[index];
-    const armLength = Math.abs(support?.armLength ?? 0);
-    const spanLength = support?.spanLength ?? 0;
-    const min = -armLength;
-    const max = spanLength + armLength;
-
-    this.distRefSupportMin.set(min);
-    this.distRefSupportMax.set(max);
-    this.form.controls.distanceToRefSupport.setValidators([
-      Validators.required,
-      Validators.min(min),
-      Validators.max(max)
-    ]);
-    this.form.controls.distanceToRefSupport.updateValueAndValidity({ emitEvent: false });
 
     this.supportRefOptions.set(untracked(() => this.plotService.getSupportOptions(uuid)));
     this.form.controls.referenceSupport.enable({ emitEvent: false });

--- a/src/app/features/studio/loads/presentation/components/cable-span-manip/cable-span-manip.ts
+++ b/src/app/features/studio/loads/presentation/components/cable-span-manip/cable-span-manip.ts
@@ -1,0 +1,425 @@
+import { ChangeDetectionStrategy, Component, computed, inject, signal, untracked } from '@angular/core';
+import { FormBuilder, FormControl, ReactiveFormsModule, Validators } from '@angular/forms';
+import { takeUntilDestroyed, toSignal } from '@angular/core/rxjs-interop';
+import { merge, of } from 'rxjs';
+import { ButtonComponent } from '@shared/components/atoms/button/button.component';
+import { IconComponent } from '@shared/components/atoms/icon/icon.component';
+import { InputGroupModule } from 'primeng/inputgroup';
+import { InputGroupAddonModule } from 'primeng/inputgroupaddon';
+import { InputText } from 'primeng/inputtext';
+import { SelectModule } from 'primeng/select';
+import { PlotService } from '@services/plot/plot.service';
+import { ChainsService } from '@shared/catalog/services/chains.service';
+import { AnchoringType, CableManipMethod, CableManipType } from '@shared/domain';
+import { CableSpanManipService } from '../../services/cableSpanManip.service';
+import { CableSpanManipFormControls } from './cable-span-manip.interfaces';
+
+@Component({
+  selector: 'app-cable-span-manip',
+  standalone: true,
+  imports: [
+    ReactiveFormsModule,
+    InputText,
+    InputGroupModule,
+    InputGroupAddonModule,
+    SelectModule,
+    ButtonComponent,
+    IconComponent
+  ],
+  templateUrl: './cable-span-manip.html',
+  styleUrl: './cable-span-manip.scss',
+  changeDetection: ChangeDetectionStrategy.OnPush
+})
+/** Component for configuring cable span manipulations (crane or temporary support) on a span. */
+export class CableSpanManipComponent {
+  private readonly fb = inject(FormBuilder);
+  private readonly plotService = inject(PlotService);
+  private readonly cableSpanManipService = inject(CableSpanManipService);
+  private readonly chainsService = inject(ChainsService);
+
+  readonly isLoading = signal(false);
+  readonly isCalculating = computed(() => this.plotService.loading());
+  /** Whether the form has been modified since the last save. */
+  readonly isDirtySinceLastSave = signal(false);
+  /** Whether a saved manipulation exists for the currently selected span. */
+  readonly hasSavedManipulation = signal(true);
+
+  /** Dynamic min for distanceToRefSupport — updated on scope change. */
+  readonly distRefSupportMin = signal(0);
+  /** Dynamic max for distanceToRefSupport — updated on scope change. */
+  readonly distRefSupportMax = signal(0);
+
+  readonly form = this.fb.group<CableSpanManipFormControls>({
+    scope: new FormControl<string | null>(null, { validators: [Validators.required] }),
+    referenceSupport: new FormControl<'LEFT' | 'RIGHT' | null>(
+      { value: null, disabled: true },
+      { validators: [Validators.required] }
+    ),
+    distanceToRefSupport: new FormControl<number | null>(0, { validators: [Validators.required] }),
+    cableManipType: new FormControl<CableManipType | null>({ value: 'with_a_crane', disabled: true }),
+    cableManipMethod: new FormControl<CableManipMethod | null>({ value: 'clamp', disabled: true }),
+    longitudinalDistance: new FormControl<number | null>(0),
+    lateralDistance: new FormControl<number | null>(0, {
+      validators: [Validators.required, Validators.min(-100), Validators.max(100)]
+    }),
+    altitude: new FormControl<number | null>(0, {
+      validators: [Validators.required, Validators.min(-100), Validators.max(9000)]
+    }),
+    anchoring: new FormControl<AnchoringType | null>({ value: 'with_sling', disabled: true }),
+    chainName: new FormControl<string | null>(null),
+    chainLength: new FormControl<number | null>(null),
+    chainWeight: new FormControl<number | null>(null),
+    chainSurface: new FormControl<number | null>(null),
+    counterWeight: new FormControl<number | null>(null),
+    slingLength: new FormControl<number | null>(5)
+  });
+
+  readonly spansOptions = this.plotService.getSpanOptions;
+  readonly supportRefOptions = signal<{ label: string; value: 'LEFT' | 'RIGHT' }[]>([]);
+  readonly chainNameOptions = signal<{ label: string; value: string }[]>([]);
+
+  readonly cableManipTypeOptions = [
+    { label: $localize`With a crane`, value: 'with_a_crane' as CableManipType },
+    { label: $localize`Temporary support`, value: 'temporary_support' as CableManipType }
+  ];
+
+  readonly cableManipMethodOptions = [
+    { label: $localize`Clamp`, value: 'clamp' as CableManipMethod },
+    { label: $localize`Pulley`, value: 'pulley' as CableManipMethod }
+  ];
+
+  readonly anchoringOptions = [
+    { label: $localize`With sling`, value: 'with_sling' as AnchoringType },
+    { label: $localize`With chain`, value: 'with_chain' as AnchoringType }
+  ];
+
+  // Signals derived from form values to drive conditional template rendering
+  private readonly cableManipTypeSignal = toSignal(this.form.controls.cableManipType.valueChanges, {
+    initialValue: this.form.controls.cableManipType.value
+  });
+  private readonly anchoringSignal = toSignal(this.form.controls.anchoring.valueChanges, {
+    initialValue: this.form.controls.anchoring.value
+  });
+
+  readonly isWithCrane = computed(() => this.cableManipTypeSignal() === 'with_a_crane');
+  readonly isWithChain = computed(() => this.anchoringSignal() === 'with_chain');
+  readonly isWithSling = computed(() => this.anchoringSignal() === 'with_sling');
+
+  constructor() {
+    // Track dirty state when user edits content fields
+    merge(
+      this.form.controls.referenceSupport.valueChanges,
+      this.form.controls.distanceToRefSupport.valueChanges,
+      this.form.controls.longitudinalDistance.valueChanges,
+      this.form.controls.lateralDistance.valueChanges,
+      this.form.controls.altitude.valueChanges,
+      this.form.controls.slingLength.valueChanges,
+      this.form.controls.chainName.valueChanges,
+      this.form.controls.chainLength.valueChanges,
+      this.form.controls.chainWeight.valueChanges,
+      this.form.controls.chainSurface.valueChanges,
+      this.form.controls.counterWeight.valueChanges
+    )
+      .pipe(takeUntilDestroyed())
+      .subscribe(() => {
+        this.isDirtySinceLastSave.set(true);
+      });
+
+    // Conditional validators: longitudinalDistance required only when using a crane
+    merge(of(this.form.controls.cableManipType.value), this.form.controls.cableManipType.valueChanges)
+      .pipe(takeUntilDestroyed())
+      .subscribe((type) => this.updateLongitudinalDistanceValidators(type));
+
+    // Conditional validators: chain fields required when with_chain; slingLength required when with_sling
+    merge(of(this.form.controls.anchoring.value), this.form.controls.anchoring.valueChanges)
+      .pipe(takeUntilDestroyed())
+      .subscribe((anchoring) => this.updateAnchoringValidators(anchoring));
+
+    this.loadChains();
+  }
+
+  private async loadChains(): Promise<void> {
+    const chains = (await this.chainsService.getChains()) ?? [];
+    this.chainNameOptions.set(
+      chains
+        .sort((a, b) => a.chain_name.localeCompare(b.chain_name))
+        .map((c) => ({ label: c.chain_name, value: c.chain_name }))
+    );
+  }
+
+  onScopeChange(uuid: string | null): void {
+    if (!uuid) {
+      this.supportRefOptions.set([]);
+      this.form.controls.referenceSupport.reset();
+      this.form.controls.referenceSupport.disable({ emitEvent: false });
+      this.isDirtySinceLastSave.set(false);
+      return;
+    }
+
+    const index = untracked(() => this.plotService.getSupportIndex(uuid));
+    if (index < 0) return;
+
+    const supports = untracked(() => this.plotService.section()?.supports ?? []);
+    const support = supports[index];
+    const armLength = Math.abs(support?.armLength ?? 0);
+    const spanLength = support?.spanLength ?? 0;
+    const min = -armLength;
+    const max = spanLength + armLength;
+
+    this.distRefSupportMin.set(min);
+    this.distRefSupportMax.set(max);
+    this.form.controls.distanceToRefSupport.setValidators([
+      Validators.required,
+      Validators.min(min),
+      Validators.max(max)
+    ]);
+    this.form.controls.distanceToRefSupport.updateValueAndValidity({ emitEvent: false });
+
+    this.supportRefOptions.set(untracked(() => this.plotService.getSupportOptions(uuid)));
+    this.form.controls.referenceSupport.enable({ emitEvent: false });
+    this.form.controls.referenceSupport.setValue('LEFT', { emitEvent: false });
+
+    const savedManip = untracked(() =>
+      this.plotService.section()?.cable_span_manipulations?.find((m) => m.spanUuid === uuid)
+    );
+
+    if (savedManip) {
+      this.hasSavedManipulation.set(false);
+      this.form.patchValue(
+        {
+          referenceSupport: savedManip.referenceSupport,
+          distanceToRefSupport: savedManip.distanceToRefSupport,
+          longitudinalDistance: savedManip.longitudinalDistance ?? 0,
+          lateralDistance: savedManip.lateralDistance,
+          altitude: savedManip.altitude,
+          chainName: savedManip.chainName,
+          chainLength: savedManip.chainLength,
+          chainWeight: savedManip.chainWeight,
+          chainSurface: savedManip.chainSurface,
+          counterWeight: savedManip.counterWeight,
+          slingLength: savedManip.slingLength
+        },
+        { emitEvent: false }
+      );
+    } else {
+      this.form.patchValue(
+        {
+          referenceSupport: 'LEFT',
+          distanceToRefSupport: 0,
+          longitudinalDistance: 0,
+          lateralDistance: 0,
+          altitude: 0,
+          chainName: null,
+          chainLength: null,
+          chainWeight: null,
+          chainSurface: null,
+          counterWeight: null,
+          slingLength: 5
+        },
+        { emitEvent: false }
+      );
+      this.hasSavedManipulation.set(true);
+    }
+
+    this.statesFormControls();
+    // New manipulation: allow saving defaults immediately. Existing: require a change first.
+    this.isDirtySinceLastSave.set(savedManip == null);
+  }
+
+  resetForm(): void {
+    const currentScope = this.form.controls.scope.value;
+    this.form.patchValue(
+      {
+        referenceSupport: 'LEFT',
+        distanceToRefSupport: 0,
+        longitudinalDistance: 0,
+        lateralDistance: 0,
+        altitude: 0,
+        chainName: null,
+        chainLength: null,
+        chainWeight: null,
+        chainSurface: null,
+        counterWeight: null,
+        slingLength: 5
+      },
+      { emitEvent: false }
+    );
+    if (currentScope) {
+      this.form.controls.scope.setValue(currentScope, { emitEvent: false });
+    }
+    this.statesFormControls();
+    this.isDirtySinceLastSave.set(false);
+  }
+
+  zoomToSpan(): void {
+    const uuid = this.form.controls.scope.value;
+    if (!uuid) return;
+    const index = this.plotService.getSupportIndex(uuid);
+    if (index < 0) return;
+    this.plotService.plotOptionsChange({ startSupport: index, endSupport: index + 1 });
+  }
+
+  async saveForm(): Promise<void> {
+    if (this.form.invalid) return;
+    const raw = this.form.getRawValue();
+    const {
+      scope,
+      referenceSupport,
+      distanceToRefSupport,
+      longitudinalDistance,
+      lateralDistance,
+      altitude,
+      chainName,
+      chainLength,
+      chainWeight,
+      chainSurface,
+      counterWeight,
+      slingLength
+    } = raw;
+    if (
+      !scope ||
+      !referenceSupport ||
+      distanceToRefSupport === null ||
+      lateralDistance === null ||
+      altitude === null ||
+      slingLength === null ||
+      !raw.cableManipType ||
+      !raw.cableManipMethod ||
+      !raw.anchoring
+    )
+      return;
+
+    this.isLoading.set(true);
+    await this.cableSpanManipService
+      .save({
+        spanUuid: scope,
+        referenceSupport,
+        distanceToRefSupport,
+        cableManipType: raw.cableManipType,
+        cableManipMethod: raw.cableManipMethod,
+        longitudinalDistance,
+        lateralDistance,
+        altitude,
+        anchoring: raw.anchoring,
+        chainName,
+        chainLength,
+        chainWeight,
+        chainSurface,
+        counterWeight,
+        slingLength
+      })
+      .finally(() => {
+        this.isLoading.set(false);
+        this.hasSavedManipulation.set(false);
+      });
+    await this.reloadSectionFromDb();
+    this.isDirtySinceLastSave.set(false);
+  }
+
+  deleteForm(): void {
+    const spanUuid = this.form.controls.scope.value;
+    const uuid = spanUuid
+      ? (this.plotService.section()?.cable_span_manipulations?.find((m) => m.spanUuid === spanUuid)?.uuid ?? null)
+      : null;
+
+    if (uuid) {
+      this.cableSpanManipService.delete(uuid).then(async () => {
+        await this.reloadSectionFromDb();
+        if (spanUuid) {
+          this.cableSpanManipService.clearPersistedFormData(spanUuid);
+        }
+      });
+    } else if (spanUuid) {
+      this.cableSpanManipService.clearPersistedFormData(spanUuid);
+    }
+
+    this.form.patchValue(
+      {
+        referenceSupport: 'LEFT',
+        distanceToRefSupport: 0,
+        longitudinalDistance: 0,
+        lateralDistance: 0,
+        altitude: 0,
+        chainName: null,
+        chainLength: null,
+        chainWeight: null,
+        chainSurface: null,
+        counterWeight: null,
+        slingLength: 5
+      },
+      { emitEvent: false }
+    );
+    this.hasSavedManipulation.set(true);
+  }
+
+  calculate(): void {
+    // No Python task implemented yet — placeholder for future calculation.
+    if (this.isFormInvalid()) return;
+  }
+
+  isFormInvalid(): boolean {
+    return this.form.invalid;
+  }
+
+  private statesFormControls(): void {
+    const controls: (keyof CableSpanManipFormControls)[] = [
+      'referenceSupport',
+      'distanceToRefSupport',
+      'longitudinalDistance',
+      'lateralDistance',
+      'altitude',
+      'chainName',
+      'chainLength',
+      'chainWeight',
+      'chainSurface',
+      'counterWeight',
+      'slingLength'
+    ];
+    for (const name of controls) {
+      const control = this.form.controls[name];
+      control.markAsPristine();
+      control.markAsUntouched();
+    }
+  }
+
+  private updateLongitudinalDistanceValidators(type: CableManipType | null): void {
+    const ctrl = this.form.controls.longitudinalDistance;
+    if (type === 'with_a_crane') {
+      ctrl.setValidators([Validators.required]);
+    } else {
+      ctrl.clearValidators();
+    }
+    ctrl.updateValueAndValidity({ emitEvent: false });
+  }
+
+  private updateAnchoringValidators(anchoring: AnchoringType | null): void {
+    const chainFields = ['chainName', 'chainLength', 'chainWeight', 'chainSurface', 'counterWeight'] as const;
+    if (anchoring === 'with_chain') {
+      for (const field of chainFields) {
+        this.form.controls[field].setValidators([Validators.required]);
+        this.form.controls[field].updateValueAndValidity({ emitEvent: false });
+      }
+      this.form.controls.slingLength.clearValidators();
+      this.form.controls.slingLength.updateValueAndValidity({ emitEvent: false });
+    } else {
+      for (const field of chainFields) {
+        this.form.controls[field].clearValidators();
+        this.form.controls[field].updateValueAndValidity({ emitEvent: false });
+      }
+      this.form.controls.slingLength.setValidators([Validators.required, Validators.min(0), Validators.max(99)]);
+      this.form.controls.slingLength.updateValueAndValidity({ emitEvent: false });
+    }
+  }
+
+  private async reloadSectionFromDb(): Promise<void> {
+    const studyUuid = this.plotService.study()?.uuid;
+    const sectionUuid = this.plotService.section()?.uuid;
+    if (!studyUuid || !sectionUuid) return;
+    const study = await this.cableSpanManipService['studiesService'].getStudy(studyUuid);
+    if (!study) return;
+    const section = study.sections.find((s) => s?.uuid === sectionUuid);
+    if (section) {
+      this.plotService.section.set(section);
+    }
+  }
+}

--- a/src/app/features/studio/loads/presentation/components/cable-span-manip/cable-span-manip.ts
+++ b/src/app/features/studio/loads/presentation/components/cable-span-manip/cable-span-manip.ts
@@ -12,25 +12,8 @@ import { PlotService } from '@services/plot/plot.service';
 import { ChainsService } from '@shared/catalog/services/chains.service';
 import { AnchoringType, CableManipMethod, CableManipType } from '@shared/domain';
 import { CableSpanManipService } from '../../services/cableSpanManip.service';
-import { CableSpanManipFormControls } from './cable-span-manip.interfaces';
+import { CABLE_SPAN_MANIP_DEFAULTS, CableSpanManipFormControls } from './cable-span-manip.interfaces';
 import { truncateDecimals } from '@shared/helpers/truncateDecimals';
-
-const CABLE_SPAN_MANIP_DEFAULTS = {
-  referenceSupport: 'LEFT' as 'LEFT' | 'RIGHT',
-  distanceToRefSupport: 0,
-  cableManipType: 'with_a_crane' as CableManipType,
-  cableManipMethod: 'clamp' as CableManipMethod,
-  longitudinalDistance: 0,
-  lateralDistance: 0,
-  altitude: 0,
-  anchoring: 'with_sling' as AnchoringType,
-  chainName: null as string | null,
-  chainLength: null as number | null,
-  chainWeight: null as number | null,
-  chainSurface: null as number | null,
-  counterWeight: null as number | null,
-  slingLength: 5
-};
 
 @Component({
   selector: 'app-cable-span-manip',

--- a/src/app/features/studio/loads/presentation/components/cable-span-manip/cable-span-manip.ts
+++ b/src/app/features/studio/loads/presentation/components/cable-span-manip/cable-span-manip.ts
@@ -1,7 +1,6 @@
-import { ChangeDetectionStrategy, Component, computed, effect, inject, signal, untracked } from '@angular/core';
+import { ChangeDetectionStrategy, Component, computed, effect, inject, OnInit, signal, untracked } from '@angular/core';
 import { FormBuilder, FormControl, ReactiveFormsModule, Validators } from '@angular/forms';
 import { takeUntilDestroyed, toSignal } from '@angular/core/rxjs-interop';
-import { merge, of } from 'rxjs';
 import { ButtonComponent } from '@shared/components/atoms/button/button.component';
 import { IconComponent } from '@shared/components/atoms/icon/icon.component';
 import { InputGroupModule } from 'primeng/inputgroup';
@@ -15,6 +14,23 @@ import { AnchoringType, CableManipMethod, CableManipType } from '@shared/domain'
 import { CableSpanManipService } from '../../services/cableSpanManip.service';
 import { CableSpanManipFormControls } from './cable-span-manip.interfaces';
 import { truncateDecimals } from '@shared/helpers/truncateDecimals';
+
+const CABLE_SPAN_MANIP_DEFAULTS = {
+  referenceSupport: 'LEFT' as 'LEFT' | 'RIGHT',
+  distanceToRefSupport: 0,
+  cableManipType: 'with_a_crane' as CableManipType,
+  cableManipMethod: 'clamp' as CableManipMethod,
+  longitudinalDistance: 0,
+  lateralDistance: 0,
+  altitude: 0,
+  anchoring: 'with_sling' as AnchoringType,
+  chainName: null as string | null,
+  chainLength: null as number | null,
+  chainWeight: null as number | null,
+  chainSurface: null as number | null,
+  counterWeight: null as number | null,
+  slingLength: 5
+};
 
 @Component({
   selector: 'app-cable-span-manip',
@@ -34,7 +50,7 @@ import { truncateDecimals } from '@shared/helpers/truncateDecimals';
   changeDetection: ChangeDetectionStrategy.OnPush
 })
 /** Component for configuring cable span manipulations (crane or temporary support) on a span. */
-export class CableSpanManipComponent {
+export class CableSpanManipComponent implements OnInit {
   private readonly fb = inject(FormBuilder);
   private readonly plotService = inject(PlotService);
   private readonly cableSpanManipService = inject(CableSpanManipService);
@@ -45,7 +61,7 @@ export class CableSpanManipComponent {
   /** Whether the form has been modified since the last save. */
   readonly isDirtySinceLastSave = signal(false);
   /** Whether a saved manipulation exists for the currently selected span. */
-  readonly hasSavedManipulation = signal(true);
+  readonly hasSavedManipulation = signal(false);
 
   readonly form = this.fb.group<CableSpanManipFormControls>({
     scope: new FormControl<string | null>(null, { validators: [Validators.required] }),
@@ -53,7 +69,7 @@ export class CableSpanManipComponent {
       { value: null, disabled: true },
       { validators: [Validators.required] }
     ),
-    distanceToRefSupport: new FormControl<number | null>(0, { validators: [Validators.required] }),
+    distanceToRefSupport: new FormControl<number | null>(0),
     cableManipType: new FormControl<CableManipType | null>({ value: 'with_a_crane', disabled: true }),
     cableManipMethod: new FormControl<CableManipMethod | null>({ value: 'clamp', disabled: true }),
     longitudinalDistance: new FormControl<number | null>(0),
@@ -127,57 +143,63 @@ export class CableSpanManipComponent {
   readonly truncateDecimals = truncateDecimals;
 
   constructor() {
-    // Track dirty state when user edits content fields
-    merge(
-      this.form.controls.referenceSupport.valueChanges,
-      this.form.controls.distanceToRefSupport.valueChanges,
-      this.form.controls.longitudinalDistance.valueChanges,
-      this.form.controls.lateralDistance.valueChanges,
-      this.form.controls.altitude.valueChanges,
-      this.form.controls.slingLength.valueChanges,
-      this.form.controls.chainName.valueChanges,
-      this.form.controls.chainLength.valueChanges,
-      this.form.controls.chainWeight.valueChanges,
-      this.form.controls.chainSurface.valueChanges,
-      this.form.controls.counterWeight.valueChanges
-    )
-      .pipe(takeUntilDestroyed())
-      .subscribe(() => {
-        this.isDirtySinceLastSave.set(true);
-      });
-
-    // Keep distanceToRefSupport validators in sync with the selected span's support data
-    effect(() => {
-      const min = this.distRefSupportMin();
-      const max = this.distRefSupportMax();
-      this.form.controls.distanceToRefSupport.setValidators([
-        Validators.required,
-        Validators.min(min),
-        Validators.max(max)
-      ]);
-      this.form.controls.distanceToRefSupport.updateValueAndValidity({ emitEvent: false });
+    // Track dirty state whenever any enabled form field changes.
+    // scope changes are corrected immediately by onScopeChange().
+    this.form.valueChanges.pipe(takeUntilDestroyed()).subscribe(() => {
+      this.isDirtySinceLastSave.set(true);
     });
 
-    // Conditional validators: longitudinalDistance required only when using a crane
-    merge(of(this.form.controls.cableManipType.value), this.form.controls.cableManipType.valueChanges)
-      .pipe(takeUntilDestroyed())
-      .subscribe((type) => this.updateLongitudinalDistanceValidators(type));
+    // Dynamic range validators that read min/max from signals on each validation run.
+    // updateValueAndValidity() is called explicitly in onScopeChange() to re-validate
+    // when the selected span changes.
+    this.form.controls.distanceToRefSupport.setValidators([
+      Validators.required,
+      (ctrl) => Validators.min(this.distRefSupportMin())(ctrl),
+      (ctrl) => Validators.max(this.distRefSupportMax())(ctrl)
+    ]);
 
-    // Conditional validators: chain fields required when with_chain; slingLength required when with_sling
-    merge(of(this.form.controls.anchoring.value), this.form.controls.anchoring.valueChanges)
-      .pipe(takeUntilDestroyed())
-      .subscribe((anchoring) => this.updateAnchoringValidators(anchoring));
+    // Dynamic validators for longitudinalDistance — required only when using a crane
+    this.form.controls.longitudinalDistance.setValidators([
+      (ctrl) => (this.cableManipTypeSignal() === 'with_a_crane' ? Validators.required(ctrl) : null),
+      (ctrl) => (this.cableManipTypeSignal() === 'with_a_crane' ? Validators.min(-100)(ctrl) : null),
+      (ctrl) => (this.cableManipTypeSignal() === 'with_a_crane' ? Validators.max(5000)(ctrl) : null)
+    ]);
+    effect(() => {
+      this.cableManipTypeSignal();
+      untracked(() => this.form.controls.longitudinalDistance.updateValueAndValidity({ emitEvent: false }));
+    });
 
+    // Dynamic validators for anchoring-dependent fields
+    const chainFields = ['chainName', 'chainLength', 'chainWeight', 'chainSurface', 'counterWeight'] as const;
+    for (const field of chainFields) {
+      this.form.controls[field].setValidators([
+        (ctrl) => (this.anchoringSignal() === 'with_chain' ? Validators.required(ctrl) : null)
+      ]);
+    }
+    this.form.controls.slingLength.setValidators([
+      (ctrl) => (this.anchoringSignal() === 'with_sling' ? Validators.required(ctrl) : null),
+      (ctrl) => (this.anchoringSignal() === 'with_sling' ? Validators.min(0)(ctrl) : null),
+      (ctrl) => (this.anchoringSignal() === 'with_sling' ? Validators.max(99)(ctrl) : null)
+    ]);
+    effect(() => {
+      this.anchoringSignal();
+      untracked(() => {
+        for (const field of chainFields) {
+          this.form.controls[field].updateValueAndValidity({ emitEvent: false });
+        }
+        this.form.controls.slingLength.updateValueAndValidity({ emitEvent: false });
+      });
+    });
+  }
+
+  ngOnInit(): void {
     this.loadChains();
   }
 
   private async loadChains(): Promise<void> {
     const chains = (await this.chainsService.getChains()) ?? [];
-    this.chainNameOptions.set(
-      chains
-        .sort((a, b) => a.chain_name.localeCompare(b.chain_name))
-        .map((c) => ({ label: c.chain_name, value: c.chain_name }))
-    );
+    chains.sort((a, b) => a.chain_name.localeCompare(b.chain_name));
+    this.chainNameOptions.set(chains.map((c) => ({ label: c.chain_name, value: c.chain_name })));
   }
 
   onScopeChange(uuid: string | null): void {
@@ -189,21 +211,20 @@ export class CableSpanManipComponent {
       return;
     }
 
-    const index = untracked(() => this.plotService.getSupportIndex(uuid));
+    const index = this.plotService.getSupportIndex(uuid);
     if (index < 0) return;
 
-    this.supportRefOptions.set(untracked(() => this.plotService.getSupportOptions(uuid)));
+    this.supportRefOptions.set(this.plotService.getSupportOptions(uuid));
     this.form.controls.referenceSupport.enable({ emitEvent: false });
-    this.form.controls.referenceSupport.setValue('LEFT', { emitEvent: false });
 
-    const savedManip = untracked(() =>
-      this.plotService.section()?.cable_span_manipulations?.find((m) => m.spanUuid === uuid)
-    );
+    const savedManip = this.plotService.section()?.cable_span_manipulations?.find((m) => m.spanUuid === uuid);
 
     if (savedManip) {
-      this.hasSavedManipulation.set(false);
-      this.form.patchValue(
+      this.hasSavedManipulation.set(true);
+      this.form.reset(
         {
+          ...CABLE_SPAN_MANIP_DEFAULTS,
+          scope: uuid,
           referenceSupport: savedManip.referenceSupport,
           distanceToRefSupport: savedManip.distanceToRefSupport,
           longitudinalDistance: savedManip.longitudinalDistance ?? 0,
@@ -219,52 +240,17 @@ export class CableSpanManipComponent {
         { emitEvent: false }
       );
     } else {
-      this.form.patchValue(
-        {
-          referenceSupport: 'LEFT',
-          distanceToRefSupport: 0,
-          longitudinalDistance: 0,
-          lateralDistance: 0,
-          altitude: 0,
-          chainName: null,
-          chainLength: null,
-          chainWeight: null,
-          chainSurface: null,
-          counterWeight: null,
-          slingLength: 5
-        },
-        { emitEvent: false }
-      );
-      this.hasSavedManipulation.set(true);
+      this.form.reset({ ...CABLE_SPAN_MANIP_DEFAULTS, scope: uuid }, { emitEvent: false });
+      this.hasSavedManipulation.set(false);
     }
 
-    this.statesFormControls();
+    this.form.controls.distanceToRefSupport.updateValueAndValidity({ emitEvent: false });
     // New manipulation: allow saving defaults immediately. Existing: require a change first.
     this.isDirtySinceLastSave.set(savedManip == null);
   }
 
   resetForm(): void {
-    const currentScope = this.form.controls.scope.value;
-    this.form.patchValue(
-      {
-        referenceSupport: 'LEFT',
-        distanceToRefSupport: 0,
-        longitudinalDistance: 0,
-        lateralDistance: 0,
-        altitude: 0,
-        chainName: null,
-        chainLength: null,
-        chainWeight: null,
-        chainSurface: null,
-        counterWeight: null,
-        slingLength: 5
-      },
-      { emitEvent: false }
-    );
-    if (currentScope) {
-      this.form.controls.scope.setValue(currentScope, { emitEvent: false });
-    }
-    this.statesFormControls();
+    this.form.reset({ ...CABLE_SPAN_MANIP_DEFAULTS, scope: this.form.controls.scope.value }, { emitEvent: false });
     this.isDirtySinceLastSave.set(false);
   }
 
@@ -279,57 +265,32 @@ export class CableSpanManipComponent {
   async saveForm(): Promise<void> {
     if (this.form.invalid) return;
     const raw = this.form.getRawValue();
-    const {
-      scope,
-      referenceSupport,
-      distanceToRefSupport,
-      longitudinalDistance,
-      lateralDistance,
-      altitude,
-      chainName,
-      chainLength,
-      chainWeight,
-      chainSurface,
-      counterWeight,
-      slingLength
-    } = raw;
-    if (
-      !scope ||
-      !referenceSupport ||
-      distanceToRefSupport === null ||
-      lateralDistance === null ||
-      altitude === null ||
-      slingLength === null ||
-      !raw.cableManipType ||
-      !raw.cableManipMethod ||
-      !raw.anchoring
-    )
-      return;
-
+    // form.invalid guard above ensures required fields are non-null;
+    // disabled controls (cableManipType, cableManipMethod, anchoring) are always initialised.
     this.isLoading.set(true);
     await this.cableSpanManipService
       .save({
-        spanUuid: scope,
-        referenceSupport,
-        distanceToRefSupport,
-        cableManipType: raw.cableManipType,
-        cableManipMethod: raw.cableManipMethod,
-        longitudinalDistance,
-        lateralDistance,
-        altitude,
-        anchoring: raw.anchoring,
-        chainName,
-        chainLength,
-        chainWeight,
-        chainSurface,
-        counterWeight,
-        slingLength
+        spanUuid: raw.scope!,
+        referenceSupport: raw.referenceSupport!,
+        distanceToRefSupport: raw.distanceToRefSupport!,
+        cableManipType: raw.cableManipType!,
+        cableManipMethod: raw.cableManipMethod!,
+        longitudinalDistance: raw.longitudinalDistance,
+        lateralDistance: raw.lateralDistance!,
+        altitude: raw.altitude!,
+        anchoring: raw.anchoring!,
+        chainName: raw.chainName,
+        chainLength: raw.chainLength,
+        chainWeight: raw.chainWeight,
+        chainSurface: raw.chainSurface,
+        counterWeight: raw.counterWeight,
+        slingLength: raw.slingLength!
       })
       .finally(() => {
         this.isLoading.set(false);
-        this.hasSavedManipulation.set(false);
+        this.hasSavedManipulation.set(true);
       });
-    await this.reloadSectionFromDb();
+    await this.cableSpanManipService.reloadSection();
     this.isDirtySinceLastSave.set(false);
   }
 
@@ -341,7 +302,7 @@ export class CableSpanManipComponent {
 
     if (uuid) {
       this.cableSpanManipService.delete(uuid).then(async () => {
-        await this.reloadSectionFromDb();
+        await this.cableSpanManipService.reloadSection();
         if (spanUuid) {
           this.cableSpanManipService.clearPersistedFormData(spanUuid);
         }
@@ -350,23 +311,8 @@ export class CableSpanManipComponent {
       this.cableSpanManipService.clearPersistedFormData(spanUuid);
     }
 
-    this.form.patchValue(
-      {
-        referenceSupport: 'LEFT',
-        distanceToRefSupport: 0,
-        longitudinalDistance: 0,
-        lateralDistance: 0,
-        altitude: 0,
-        chainName: null,
-        chainLength: null,
-        chainWeight: null,
-        chainSurface: null,
-        counterWeight: null,
-        slingLength: 5
-      },
-      { emitEvent: false }
-    );
-    this.hasSavedManipulation.set(true);
+    this.form.reset({ ...CABLE_SPAN_MANIP_DEFAULTS, scope: this.form.controls.scope.value }, { emitEvent: false });
+    this.hasSavedManipulation.set(false);
   }
 
   calculate(): void {
@@ -378,72 +324,10 @@ export class CableSpanManipComponent {
     return this.form.invalid;
   }
 
-  private statesFormControls(): void {
-    const controls: (keyof CableSpanManipFormControls)[] = [
-      'referenceSupport',
-      'distanceToRefSupport',
-      'longitudinalDistance',
-      'lateralDistance',
-      'altitude',
-      'chainName',
-      'chainLength',
-      'chainWeight',
-      'chainSurface',
-      'counterWeight',
-      'slingLength'
-    ];
-    for (const name of controls) {
-      const control = this.form.controls[name];
-      control.markAsPristine();
-      control.markAsUntouched();
-    }
-  }
-
-  private updateLongitudinalDistanceValidators(type: CableManipType | null): void {
-    const ctrl = this.form.controls.longitudinalDistance;
-    if (type === 'with_a_crane') {
-      ctrl.setValidators([Validators.required, Validators.min(-100), Validators.max(5000)]);
-    } else {
-      ctrl.clearValidators();
-    }
-    ctrl.updateValueAndValidity({ emitEvent: false });
-  }
-
-  private updateAnchoringValidators(anchoring: AnchoringType | null): void {
-    const chainFields = ['chainName', 'chainLength', 'chainWeight', 'chainSurface', 'counterWeight'] as const;
-    if (anchoring === 'with_chain') {
-      for (const field of chainFields) {
-        this.form.controls[field].setValidators([Validators.required]);
-        this.form.controls[field].updateValueAndValidity({ emitEvent: false });
-      }
-      this.form.controls.slingLength.clearValidators();
-      this.form.controls.slingLength.updateValueAndValidity({ emitEvent: false });
-    } else {
-      for (const field of chainFields) {
-        this.form.controls[field].clearValidators();
-        this.form.controls[field].updateValueAndValidity({ emitEvent: false });
-      }
-      this.form.controls.slingLength.setValidators([Validators.required, Validators.min(0), Validators.max(99)]);
-      this.form.controls.slingLength.updateValueAndValidity({ emitEvent: false });
-    }
-  }
-
   getErrorIds(controlName: keyof CableSpanManipFormControls, errorTypes: string[]): string | null {
     const control = this.form.get(controlName);
     if (!control?.errors) return null;
     const ids = errorTypes.filter((type) => control.errors?.[type]).map((type) => `${controlName}-error-${type}`);
     return ids.length > 0 ? ids.join(' ') : null;
-  }
-
-  private async reloadSectionFromDb(): Promise<void> {
-    const studyUuid = this.plotService.study()?.uuid;
-    const sectionUuid = this.plotService.section()?.uuid;
-    if (!studyUuid || !sectionUuid) return;
-    const study = await this.cableSpanManipService['studiesService'].getStudy(studyUuid);
-    if (!study) return;
-    const section = study.sections.find((s) => s?.uuid === sectionUuid);
-    if (section) {
-      this.plotService.section.set(section);
-    }
   }
 }

--- a/src/app/features/studio/loads/presentation/components/cable-span-manip/cable-span-manip.ts
+++ b/src/app/features/studio/loads/presentation/components/cable-span-manip/cable-span-manip.ts
@@ -251,8 +251,8 @@ export class CableSpanManipComponent implements OnInit {
     // form.invalid guard above ensures required fields are non-null;
     // disabled controls (cableManipType, cableManipMethod, anchoring) are always initialised.
     this.isLoading.set(true);
-    await this.cableSpanManipService
-      .save({
+    try {
+      await this.cableSpanManipService.save({
         spanUuid: raw.scope!,
         referenceSupport: raw.referenceSupport!,
         distanceToRefSupport: raw.distanceToRefSupport!,
@@ -268,13 +268,13 @@ export class CableSpanManipComponent implements OnInit {
         chainSurface: raw.chainSurface,
         counterWeight: raw.counterWeight,
         slingLength: raw.slingLength!
-      })
-      .finally(() => {
-        this.isLoading.set(false);
-        this.hasSavedManipulation.set(true);
       });
-    await this.cableSpanManipService.reloadSection();
-    this.isDirtySinceLastSave.set(false);
+      this.hasSavedManipulation.set(true);
+      await this.cableSpanManipService.reloadSection();
+      this.isDirtySinceLastSave.set(false);
+    } finally {
+      this.isLoading.set(false);
+    }
   }
 
   deleteForm(): void {

--- a/src/app/features/studio/loads/presentation/components/cable-span-manip/cable-span-manip.ts
+++ b/src/app/features/studio/loads/presentation/components/cable-span-manip/cable-span-manip.ts
@@ -79,9 +79,7 @@ export class CableSpanManipComponent implements OnInit {
   private readonly selectedSupportData = computed(() => {
     const uuid = this.scopeValueSignal();
     if (!uuid) return null;
-    const supports = this.plotService.section()?.supports ?? [];
-    const index = supports.findIndex((s) => s.uuid === uuid);
-    return index >= 0 ? supports[index] : null;
+    return this.plotService.section()?.supports?.find((s) => s.uuid === uuid) ?? null;
   });
 
   /** Dynamic min for distanceToRefSupport — reactive to section and scope changes. */

--- a/src/app/features/studio/loads/presentation/components/load-marking/load-marking.component.html
+++ b/src/app/features/studio/loads/presentation/components/load-marking/load-marking.component.html
@@ -6,7 +6,7 @@
     </button>
   </div>
 
-  <div class="relative">
+  <div>
     <div class="flex items-baseline justify-between mb-0.5">
       <label for="spanSelect" class="mb-0" i18n>Span</label>
 

--- a/src/app/features/studio/loads/presentation/helpers.ts
+++ b/src/app/features/studio/loads/presentation/helpers.ts
@@ -1,4 +1,4 @@
-import { SpanLoad, Support } from '@shared/domain';
+import { SpanLoad } from '@shared/domain';
 import { LoadType } from '@shared/domain/models/charge.model';
 
 /** Default empty span load used as a template for new span loads. */
@@ -8,23 +8,4 @@ export const emptySpanLoad: SpanLoad = {
   loadWeight: 0,
   type: LoadType.PUNCTUAL,
   referenceSupport: 'LEFT'
-};
-
-/**
- * Recheck the span loads to ensure that each span load has an existing support and each support has a span load
- * @param loads The span loads to recheck
- * @param supports The supports to recheck the span loads against
- * @returns The rechecked span loads
- */
-export const recheckSpanLoads = (loads: SpanLoad[], supports: Support[]): SpanLoad[] => {
-  const loadsSupportUuid = loads.map((load) => load.supportUuid);
-  const supportUuids = supports.map((support) => support.uuid);
-  const missingSupportUuids = supportUuids.filter((uuid) => !loadsSupportUuid.includes(uuid));
-  missingSupportUuids.forEach((uuid) => {
-    loads.push({
-      ...emptySpanLoad,
-      supportUuid: uuid
-    });
-  });
-  return loads.filter((load) => supportUuids.includes(load.supportUuid));
 };

--- a/src/app/features/studio/loads/presentation/services/cableSpanManip.service.spec.ts
+++ b/src/app/features/studio/loads/presentation/services/cableSpanManip.service.spec.ts
@@ -1,0 +1,419 @@
+/**
+ * Copyright (c) 2025, RTE (http://www.rte-france.com)
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+import { TestBed } from '@angular/core/testing';
+import { vi } from 'vitest';
+import { CableSpanManipService } from './cableSpanManip.service';
+import { PlotService } from '@services/plot/plot.service';
+import { StudiesService } from '@services/studies/studies.service';
+import { CableSpanManipulation } from '@shared/domain';
+import { Section } from '@shared/domain';
+import { Study } from '@shared/domain/models/study.model';
+import { StudyEntity } from '@infrastructure/database';
+
+function createSignalMock<T>(initialValue: T) {
+  let value = initialValue;
+  const fn = vi.fn(() => value) as vi.Mock & { set: vi.Mock };
+  fn.set = vi.fn((v: T) => {
+    value = v;
+  });
+  return fn;
+}
+
+const mockManip: CableSpanManipulation = {
+  uuid: 'manip-uuid-1',
+  spanUuid: 'support-uuid-1',
+  referenceSupport: 'LEFT',
+  distanceToRefSupport: 5,
+  cableManipType: 'with_a_crane',
+  cableManipMethod: 'clamp',
+  longitudinalDistance: 10,
+  lateralDistance: 0,
+  altitude: 100,
+  anchoring: 'with_sling',
+  chainName: null,
+  chainLength: null,
+  chainWeight: null,
+  chainSurface: null,
+  counterWeight: null,
+  slingLength: 5
+};
+
+const mockSectionBase: Section = {
+  uuid: 'section-uuid-1',
+  internal_id: 'INT-001',
+  name: 'Test Section',
+  short_name: 'TS',
+  created_at: '2025-01-01T00:00:00.000Z',
+  updated_at: '2025-01-01T00:00:00.000Z',
+  internal_catalog_id: 'CAT-001',
+  type: 'phase',
+  electric_phase_number: 1,
+  cable_name: 'Test Cable',
+  cable_short_name: 'TC',
+  cables_amount: 1,
+  optical_fibers_amount: 0,
+  spans_amount: 1,
+  begin_span_name: 'S1',
+  last_span_name: 'S2',
+  first_support_number: 1,
+  last_support_number: 2,
+  first_attachment_set: 'Set1',
+  last_attachment_set: 'Set2',
+  regional_maintenance_center_names: [],
+  maintenance_center_names: [],
+  regional_team_id: undefined,
+  maintenance_team_id: undefined,
+  maintenance_center_id: undefined,
+  link_name: undefined,
+  lit_code: undefined,
+  lit_name: undefined,
+  branch_name: undefined,
+  branch_idr: undefined,
+  voltage_idr: undefined,
+  comment: undefined,
+  supports_comment: undefined,
+  supports: [{ uuid: 'support-uuid-1' } as Section['supports'][0]],
+  obstacles: [],
+  initial_conditions: [],
+  selected_initial_condition_uuid: undefined,
+  charges: [],
+  selected_charge_uuid: null,
+  field_measures: [],
+  selected_field_measure_uuid: undefined,
+  vtl_and_guying: undefined,
+  cable_modifications: [],
+  selected_cable_modification_uuid: null,
+  cable_span_manipulations: [],
+  selected_cable_span_manipulation_uuid: null
+};
+
+const mockStudy: StudyEntity = {
+  uuid: 'study-uuid-1',
+  author_email: 'test@test.com',
+  title: 'Test Study',
+  description: '',
+  shareable: false,
+  created_at_offline: '2025-01-01T00:00:00.000Z',
+  updated_at_offline: '2025-01-01T00:00:00.000Z',
+  saved: true,
+  sections: [mockSectionBase]
+};
+
+describe('CableSpanManipService', () => {
+  let service: CableSpanManipService;
+  let mockPlotService: vi.Mocked<PlotService>;
+  let mockStudiesService: vi.Mocked<StudiesService>;
+
+  beforeEach(() => {
+    mockPlotService = {
+      section: createSignalMock<Section | null>(mockSectionBase),
+      study: createSignalMock<Study | null>({ uuid: 'study-uuid-1' } as Study),
+      loading: createSignalMock(false),
+      litData: createSignalMock(null),
+      baseLitData: createSignalMock(null),
+      error: createSignalMock(null)
+    } as unknown as vi.Mocked<PlotService>;
+
+    mockStudiesService = {
+      getStudy: vi.fn().mockResolvedValue(mockStudy),
+      updateStudy: vi.fn().mockResolvedValue(undefined)
+    } as unknown as vi.Mocked<StudiesService>;
+
+    TestBed.configureTestingModule({
+      providers: [
+        CableSpanManipService,
+        { provide: PlotService, useValue: mockPlotService },
+        { provide: StudiesService, useValue: mockStudiesService }
+      ]
+    });
+
+    service = TestBed.inject(CableSpanManipService);
+  });
+
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('should be created', () => {
+    expect(service).toBeTruthy();
+  });
+
+  // ---------------------------------------------------------------------------
+  // clearPersistedFormData()
+  // ---------------------------------------------------------------------------
+  describe('clearPersistedFormData()', () => {
+    it('should not throw for any span uuid', () => {
+      expect(() => service.clearPersistedFormData('any-uuid')).not.toThrow();
+    });
+  });
+
+  // ---------------------------------------------------------------------------
+  // save()
+  // ---------------------------------------------------------------------------
+  describe('save()', () => {
+    it('should return early when studyUuid is missing', async () => {
+      mockPlotService.study.mockReturnValue(null);
+
+      await service.save({ ...mockManip });
+
+      expect(mockStudiesService.getStudy).not.toHaveBeenCalled();
+    });
+
+    it('should return early when sectionUuid is missing', async () => {
+      mockPlotService.section.mockReturnValue(null);
+
+      await service.save({ ...mockManip });
+
+      expect(mockStudiesService.getStudy).not.toHaveBeenCalled();
+    });
+
+    it('should return early when study is not found', async () => {
+      mockStudiesService.getStudy.mockResolvedValue(undefined);
+
+      await service.save({ ...mockManip });
+
+      expect(mockStudiesService.updateStudy).not.toHaveBeenCalled();
+    });
+
+    it('should add a new manipulation and call updateStudy', async () => {
+      const { uuid: _uuid, ...manip } = mockManip;
+
+      await service.save(manip);
+
+      expect(mockStudiesService.updateStudy).toHaveBeenCalled();
+      const updatedStudy = mockStudiesService.updateStudy.mock.calls[0][0] as StudyEntity;
+      const section = updatedStudy.sections.find((s) => s?.uuid === 'section-uuid-1');
+      expect(section?.cable_span_manipulations).toHaveLength(1);
+      expect(section?.cable_span_manipulations[0].spanUuid).toBe('support-uuid-1');
+    });
+
+    it('should generate a uuid when none is provided', async () => {
+      const { uuid: _uuid, ...manip } = mockManip;
+
+      await service.save(manip);
+
+      const updatedStudy = mockStudiesService.updateStudy.mock.calls[0][0] as StudyEntity;
+      const section = updatedStudy.sections.find((s) => s?.uuid === 'section-uuid-1');
+      expect(section?.cable_span_manipulations[0].uuid).toBeTruthy();
+    });
+
+    it('should set selected_cable_span_manipulation_uuid after save', async () => {
+      const { uuid: _uuid, ...manip } = mockManip;
+
+      await service.save(manip);
+
+      const updatedStudy = mockStudiesService.updateStudy.mock.calls[0][0] as StudyEntity;
+      const section = updatedStudy.sections.find((s) => s?.uuid === 'section-uuid-1');
+      expect(section?.selected_cable_span_manipulation_uuid).toBeTruthy();
+    });
+
+    it('should update an existing manipulation when one with the same spanUuid already exists', async () => {
+      const existingUuid = 'existing-manip-uuid';
+      const studyWithManip: StudyEntity = {
+        ...mockStudy,
+        sections: [
+          {
+            ...mockSectionBase,
+            cable_span_manipulations: [{ ...mockManip, uuid: existingUuid }]
+          }
+        ]
+      };
+      mockStudiesService.getStudy.mockResolvedValue(studyWithManip);
+
+      await service.save({ ...mockManip, slingLength: 42 });
+
+      const updatedStudy = mockStudiesService.updateStudy.mock.calls[0][0] as StudyEntity;
+      const section = updatedStudy.sections.find((s) => s?.uuid === 'section-uuid-1');
+      expect(section?.cable_span_manipulations).toHaveLength(1);
+      expect(section?.cable_span_manipulations[0].uuid).toBe(existingUuid);
+      expect(section?.cable_span_manipulations[0].slingLength).toBe(42);
+    });
+
+    it('should preserve the uuid when provided and no existing manipulation exists for the span', async () => {
+      const providedUuid = 'provided-uuid';
+
+      await service.save({ ...mockManip, uuid: providedUuid, spanUuid: 'new-span-uuid' });
+
+      const updatedStudy = mockStudiesService.updateStudy.mock.calls[0][0] as StudyEntity;
+      const section = updatedStudy.sections.find((s) => s?.uuid === 'section-uuid-1');
+      expect(section?.cable_span_manipulations[0].uuid).toBe(providedUuid);
+    });
+
+    it('should prepend the new manipulation to the existing list', async () => {
+      const existingManip: CableSpanManipulation = { ...mockManip, uuid: 'other-uuid', spanUuid: 'other-span' };
+      const studyWithManip: StudyEntity = {
+        ...mockStudy,
+        sections: [{ ...mockSectionBase, cable_span_manipulations: [existingManip] }]
+      };
+      mockStudiesService.getStudy.mockResolvedValue(studyWithManip);
+
+      await service.save({ ...mockManip, spanUuid: 'new-span', uuid: 'new-uuid' });
+
+      const updatedStudy = mockStudiesService.updateStudy.mock.calls[0][0] as StudyEntity;
+      const section = updatedStudy.sections.find((s) => s?.uuid === 'section-uuid-1');
+      expect(section?.cable_span_manipulations).toHaveLength(2);
+      expect(section?.cable_span_manipulations[0].spanUuid).toBe('new-span');
+    });
+  });
+
+  // ---------------------------------------------------------------------------
+  // delete()
+  // ---------------------------------------------------------------------------
+  describe('delete()', () => {
+    it('should return early when studyUuid is missing', async () => {
+      mockPlotService.study.mockReturnValue(null);
+
+      await service.delete('some-uuid');
+
+      expect(mockStudiesService.getStudy).not.toHaveBeenCalled();
+    });
+
+    it('should return early when sectionUuid is missing', async () => {
+      mockPlotService.section.mockReturnValue(null);
+
+      await service.delete('some-uuid');
+
+      expect(mockStudiesService.getStudy).not.toHaveBeenCalled();
+    });
+
+    it('should return early when study is not found', async () => {
+      mockStudiesService.getStudy.mockResolvedValue(undefined);
+
+      await service.delete('some-uuid');
+
+      expect(mockStudiesService.updateStudy).not.toHaveBeenCalled();
+    });
+
+    it('should remove the manipulation from section and call updateStudy', async () => {
+      const uuid = 'manip-to-delete';
+      const studyWithManip: StudyEntity = {
+        ...mockStudy,
+        sections: [
+          {
+            ...mockSectionBase,
+            cable_span_manipulations: [{ ...mockManip, uuid }],
+            selected_cable_span_manipulation_uuid: uuid
+          }
+        ]
+      };
+      mockStudiesService.getStudy.mockResolvedValue(studyWithManip);
+
+      await service.delete(uuid);
+
+      expect(mockStudiesService.updateStudy).toHaveBeenCalled();
+      const updatedStudy = mockStudiesService.updateStudy.mock.calls[0][0] as StudyEntity;
+      const section = updatedStudy.sections.find((s) => s?.uuid === 'section-uuid-1');
+      expect(section?.cable_span_manipulations).toHaveLength(0);
+    });
+
+    it('should clear selected_cable_span_manipulation_uuid when the deleted one was selected', async () => {
+      const uuid = 'manip-to-delete';
+      const studyWithManip: StudyEntity = {
+        ...mockStudy,
+        sections: [
+          {
+            ...mockSectionBase,
+            cable_span_manipulations: [{ ...mockManip, uuid }],
+            selected_cable_span_manipulation_uuid: uuid
+          }
+        ]
+      };
+      mockStudiesService.getStudy.mockResolvedValue(studyWithManip);
+
+      await service.delete(uuid);
+
+      const updatedStudy = mockStudiesService.updateStudy.mock.calls[0][0] as StudyEntity;
+      const section = updatedStudy.sections.find((s) => s?.uuid === 'section-uuid-1');
+      expect(section?.selected_cable_span_manipulation_uuid).toBeNull();
+    });
+
+    it('should select the first remaining manipulation when the deleted one was selected', async () => {
+      const uuid = 'manip-to-delete';
+      const otherId = 'other-manip';
+      const studyWithManip: StudyEntity = {
+        ...mockStudy,
+        sections: [
+          {
+            ...mockSectionBase,
+            cable_span_manipulations: [
+              { ...mockManip, uuid },
+              { ...mockManip, uuid: otherId, spanUuid: 'other-span' }
+            ],
+            selected_cable_span_manipulation_uuid: uuid
+          }
+        ]
+      };
+      mockStudiesService.getStudy.mockResolvedValue(studyWithManip);
+
+      await service.delete(uuid);
+
+      const updatedStudy = mockStudiesService.updateStudy.mock.calls[0][0] as StudyEntity;
+      const section = updatedStudy.sections.find((s) => s?.uuid === 'section-uuid-1');
+      expect(section?.selected_cable_span_manipulation_uuid).toBe(otherId);
+    });
+
+    it('should not change selection when deleted uuid was not selected', async () => {
+      const uuid = 'manip-to-delete';
+      const selectedId = 'selected-manip';
+      const studyWithManip: StudyEntity = {
+        ...mockStudy,
+        sections: [
+          {
+            ...mockSectionBase,
+            cable_span_manipulations: [
+              { ...mockManip, uuid, spanUuid: 'span-to-delete' },
+              { ...mockManip, uuid: selectedId, spanUuid: 'selected-span' }
+            ],
+            selected_cable_span_manipulation_uuid: selectedId
+          }
+        ]
+      };
+      mockStudiesService.getStudy.mockResolvedValue(studyWithManip);
+
+      await service.delete(uuid);
+
+      const updatedStudy = mockStudiesService.updateStudy.mock.calls[0][0] as StudyEntity;
+      const section = updatedStudy.sections.find((s) => s?.uuid === 'section-uuid-1');
+      expect(section?.selected_cable_span_manipulation_uuid).toBe(selectedId);
+    });
+  });
+
+  // ---------------------------------------------------------------------------
+  // reloadSection()
+  // ---------------------------------------------------------------------------
+  describe('reloadSection()', () => {
+    it('should return early when studyUuid is missing', async () => {
+      mockPlotService.study.mockReturnValue(null);
+
+      await service.reloadSection();
+
+      expect(mockStudiesService.getStudy).not.toHaveBeenCalled();
+    });
+
+    it('should return early when sectionUuid is missing', async () => {
+      mockPlotService.section.mockReturnValue(null);
+
+      await service.reloadSection();
+
+      expect(mockStudiesService.getStudy).not.toHaveBeenCalled();
+    });
+
+    it('should update plotService.section with the reloaded section', async () => {
+      await service.reloadSection();
+
+      expect(mockPlotService.section.set).toHaveBeenCalledWith(mockSectionBase);
+    });
+
+    it('should not update section when study is not found', async () => {
+      mockStudiesService.getStudy.mockResolvedValue(undefined);
+
+      await service.reloadSection();
+
+      expect(mockPlotService.section.set).not.toHaveBeenCalled();
+    });
+  });
+});

--- a/src/app/features/studio/loads/presentation/services/cableSpanManip.service.ts
+++ b/src/app/features/studio/loads/presentation/services/cableSpanManip.service.ts
@@ -1,0 +1,88 @@
+/**
+ * Copyright (c) 2025, RTE (http://www.rte-france.com)
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+import { inject, Injectable } from '@angular/core';
+import { v4 as uuidv4 } from 'uuid';
+import { PlotService } from '@services/plot/plot.service';
+import { StudiesService } from '@services/studies/studies.service';
+import { CableSpanManipulation } from '@shared/domain';
+
+@Injectable({
+  providedIn: 'root'
+})
+/** Service coordinating cable span manipulation persistence and deletion. */
+export class CableSpanManipService {
+  private readonly plotService = inject(PlotService);
+  // Accessed via bracket notation in the component for section reloading
+  private readonly studiesService = inject(StudiesService);
+
+  /**
+   * Clear any persisted form data in memory for a given span.
+   * @param _spanUuid UUID of the span whose form data should be cleared
+   */
+  clearPersistedFormData(_spanUuid: string): void {
+    // No-op: extend here if local cache is needed in the future.
+  }
+
+  /**
+   * Persist a cable span manipulation in the current section.
+   * Creates a new entry if no manipulation exists for the span, otherwise updates it.
+   * @param manip The cable span manipulation to save
+   */
+  save = async (manip: Omit<CableSpanManipulation, 'uuid'> & { uuid?: string }): Promise<void> => {
+    const studyUuid = this.plotService.study()?.uuid;
+    const sectionUuid = this.plotService.section()?.uuid;
+    if (!studyUuid || !sectionUuid) return;
+
+    const study = await this.studiesService.getStudy(studyUuid);
+    if (!study) return;
+
+    const section = study.sections.find((s) => s?.uuid === sectionUuid);
+    if (!section) return;
+
+    const existingForSpan = section.cable_span_manipulations?.find((m) => m.spanUuid === manip.spanUuid);
+
+    const toSave: CableSpanManipulation = {
+      ...manip,
+      uuid: existingForSpan?.uuid ?? manip.uuid ?? uuidv4()
+    };
+
+    if (existingForSpan) {
+      section.cable_span_manipulations = section.cable_span_manipulations.map((m) =>
+        m.spanUuid === toSave.spanUuid ? toSave : m
+      );
+    } else {
+      section.cable_span_manipulations = [toSave, ...(section.cable_span_manipulations ?? [])];
+    }
+    section.selected_cable_span_manipulation_uuid = toSave.uuid;
+
+    await this.studiesService.updateStudy(study);
+  };
+
+  /**
+   * Remove a cable span manipulation from the current section.
+   * If the deleted manipulation was selected, the selection is cleared.
+   * @param uuid UUID of the cable span manipulation to delete
+   */
+  delete = async (uuid: string): Promise<void> => {
+    const studyUuid = this.plotService.study()?.uuid;
+    const sectionUuid = this.plotService.section()?.uuid;
+    if (!studyUuid || !sectionUuid) return;
+
+    const study = await this.studiesService.getStudy(studyUuid);
+    if (!study) return;
+
+    const section = study.sections.find((s) => s?.uuid === sectionUuid);
+    if (!section) return;
+
+    section.cable_span_manipulations = (section.cable_span_manipulations ?? []).filter((m) => m.uuid !== uuid);
+    if (section.selected_cable_span_manipulation_uuid === uuid) {
+      section.selected_cable_span_manipulation_uuid = section.cable_span_manipulations[0]?.uuid ?? null;
+    }
+
+    await this.studiesService.updateStudy(study);
+  };
+}

--- a/src/app/features/studio/loads/presentation/services/cableSpanManip.service.ts
+++ b/src/app/features/studio/loads/presentation/services/cableSpanManip.service.ts
@@ -16,7 +16,6 @@ import { CableSpanManipulation } from '@shared/domain';
 /** Service coordinating cable span manipulation persistence and deletion. */
 export class CableSpanManipService {
   private readonly plotService = inject(PlotService);
-  // Accessed via bracket notation in the component for section reloading
   private readonly studiesService = inject(StudiesService);
 
   /**
@@ -33,15 +32,9 @@ export class CableSpanManipService {
    * @param manip The cable span manipulation to save
    */
   save = async (manip: Omit<CableSpanManipulation, 'uuid'> & { uuid?: string }): Promise<void> => {
-    const studyUuid = this.plotService.study()?.uuid;
-    const sectionUuid = this.plotService.section()?.uuid;
-    if (!studyUuid || !sectionUuid) return;
-
-    const study = await this.studiesService.getStudy(studyUuid);
-    if (!study) return;
-
-    const section = study.sections.find((s) => s?.uuid === sectionUuid);
-    if (!section) return;
+    const current = await this.fetchCurrentSection();
+    if (!current) return;
+    const { study, section } = current;
 
     const existingForSpan = section.cable_span_manipulations?.find((m) => m.spanUuid === manip.spanUuid);
 
@@ -68,15 +61,9 @@ export class CableSpanManipService {
    * @param uuid UUID of the cable span manipulation to delete
    */
   delete = async (uuid: string): Promise<void> => {
-    const studyUuid = this.plotService.study()?.uuid;
-    const sectionUuid = this.plotService.section()?.uuid;
-    if (!studyUuid || !sectionUuid) return;
-
-    const study = await this.studiesService.getStudy(studyUuid);
-    if (!study) return;
-
-    const section = study.sections.find((s) => s?.uuid === sectionUuid);
-    if (!section) return;
+    const current = await this.fetchCurrentSection();
+    if (!current) return;
+    const { study, section } = current;
 
     section.cable_span_manipulations = (section.cable_span_manipulations ?? []).filter((m) => m.uuid !== uuid);
     if (section.selected_cable_span_manipulation_uuid === uuid) {
@@ -85,4 +72,26 @@ export class CableSpanManipService {
 
     await this.studiesService.updateStudy(study);
   };
+
+  /**
+   * Reload the current section from the database and update the plot service state.
+   * Call this after any mutation (save, delete) to keep the UI in sync.
+   */
+  async reloadSection(): Promise<void> {
+    const current = await this.fetchCurrentSection();
+    if (!current) return;
+    this.plotService.section.set(current.section);
+  }
+
+  /** Fetch the active study and section from the database. Returns null if either is unavailable. */
+  private async fetchCurrentSection() {
+    const studyUuid = this.plotService.study()?.uuid;
+    const sectionUuid = this.plotService.section()?.uuid;
+    if (!studyUuid || !sectionUuid) return null;
+    const study = await this.studiesService.getStudy(studyUuid);
+    if (!study) return null;
+    const section = study.sections.find((s) => s?.uuid === sectionUuid);
+    if (!section) return null;
+    return { study, section };
+  }
 }

--- a/src/app/features/studio/loads/presentation/services/cableSpanManip.service.ts
+++ b/src/app/features/studio/loads/presentation/services/cableSpanManip.service.ts
@@ -8,7 +8,7 @@ import { inject, Injectable } from '@angular/core';
 import { v4 as uuidv4 } from 'uuid';
 import { PlotService } from '@services/plot/plot.service';
 import { StudiesService } from '@services/studies/studies.service';
-import { CableSpanManipulation } from '@shared/domain';
+import { CableSpanManipulation, Section } from '@shared/domain';
 
 @Injectable({
   providedIn: 'root'
@@ -32,27 +32,21 @@ export class CableSpanManipService {
    * @param manip The cable span manipulation to save
    */
   save = async (manip: Omit<CableSpanManipulation, 'uuid'> & { uuid?: string }): Promise<void> => {
-    const current = await this.fetchCurrentSection();
-    if (!current) return;
-    const { study, section } = current;
-
-    const existingForSpan = section.cable_span_manipulations?.find((m) => m.spanUuid === manip.spanUuid);
-
-    const toSave: CableSpanManipulation = {
-      ...manip,
-      uuid: existingForSpan?.uuid ?? manip.uuid ?? uuidv4()
-    };
-
-    if (existingForSpan) {
-      section.cable_span_manipulations = section.cable_span_manipulations.map((m) =>
-        m.spanUuid === toSave.spanUuid ? toSave : m
-      );
-    } else {
-      section.cable_span_manipulations = [toSave, ...(section.cable_span_manipulations ?? [])];
-    }
-    section.selected_cable_span_manipulation_uuid = toSave.uuid;
-
-    await this.studiesService.updateStudy(study);
+    await this.mutateCurrentSection((section) => {
+      const existingForSpan = section.cable_span_manipulations?.find((m) => m.spanUuid === manip.spanUuid);
+      const toSave: CableSpanManipulation = {
+        ...manip,
+        uuid: existingForSpan?.uuid ?? manip.uuid ?? uuidv4()
+      };
+      if (existingForSpan) {
+        section.cable_span_manipulations = section.cable_span_manipulations.map((m) =>
+          m.spanUuid === toSave.spanUuid ? toSave : m
+        );
+      } else {
+        section.cable_span_manipulations = [toSave, ...(section.cable_span_manipulations ?? [])];
+      }
+      section.selected_cable_span_manipulation_uuid = toSave.uuid;
+    });
   };
 
   /**
@@ -61,16 +55,12 @@ export class CableSpanManipService {
    * @param uuid UUID of the cable span manipulation to delete
    */
   delete = async (uuid: string): Promise<void> => {
-    const current = await this.fetchCurrentSection();
-    if (!current) return;
-    const { study, section } = current;
-
-    section.cable_span_manipulations = (section.cable_span_manipulations ?? []).filter((m) => m.uuid !== uuid);
-    if (section.selected_cable_span_manipulation_uuid === uuid) {
-      section.selected_cable_span_manipulation_uuid = section.cable_span_manipulations[0]?.uuid ?? null;
-    }
-
-    await this.studiesService.updateStudy(study);
+    await this.mutateCurrentSection((section) => {
+      section.cable_span_manipulations = (section.cable_span_manipulations ?? []).filter((m) => m.uuid !== uuid);
+      if (section.selected_cable_span_manipulation_uuid === uuid) {
+        section.selected_cable_span_manipulation_uuid = section.cable_span_manipulations[0]?.uuid ?? null;
+      }
+    });
   };
 
   /**
@@ -81,6 +71,15 @@ export class CableSpanManipService {
     const current = await this.fetchCurrentSection();
     if (!current) return;
     this.plotService.section.set(current.section);
+  }
+
+  /** Apply a synchronous mutation to the current section and persist the updated study. */
+  private async mutateCurrentSection(mutate: (section: Section) => void): Promise<void> {
+    const current = await this.fetchCurrentSection();
+    if (!current) return;
+    const { study, section } = current;
+    mutate(section);
+    await this.studiesService.updateStudy(study);
   }
 
   /** Fetch the active study and section from the database. Returns null if either is unavailable. */

--- a/src/app/features/study/presentation/components/sections-tab/newSectionModal/manualSection/supportsTable/supportsTable.component.spec.ts
+++ b/src/app/features/study/presentation/components/sections-tab/newSectionModal/manualSection/supportsTable/supportsTable.component.spec.ts
@@ -428,40 +428,6 @@ describe('SupportsTableComponent', () => {
     });
   });
 
-  describe('truncateDecimals', () => {
-    const makeEvent = (value: string) => ({ target: { value } as HTMLInputElement }) as unknown as Event;
-
-    it('should do nothing when value has no decimal separator', () => {
-      const event = makeEvent('123');
-      component.truncateDecimals(event);
-      expect((event.target as HTMLInputElement).value).toBe('123');
-    });
-
-    it('should do nothing when value has exactly 2 decimal places', () => {
-      const event = makeEvent('1.23');
-      component.truncateDecimals(event);
-      expect((event.target as HTMLInputElement).value).toBe('1.23');
-    });
-
-    it('should do nothing when value has fewer than 2 decimal places', () => {
-      const event = makeEvent('1.2');
-      component.truncateDecimals(event);
-      expect((event.target as HTMLInputElement).value).toBe('1.2');
-    });
-
-    it('should truncate to 2 decimal places when value has more', () => {
-      const event = makeEvent('1.234');
-      component.truncateDecimals(event);
-      expect((event.target as HTMLInputElement).value).toBe('1.23');
-    });
-
-    it('should truncate negative numbers with more than 2 decimal places', () => {
-      const event = makeEvent('-1.234');
-      component.truncateDecimals(event);
-      expect((event.target as HTMLInputElement).value).toBe('-1.23');
-    });
-  });
-
   describe('ngOnInit', () => {
     it('should call getData on init', async () => {
       const getDataSpy = vi.spyOn(component, 'getData');

--- a/src/app/features/study/presentation/components/sections-tab/newSectionModal/manualSection/supportsTable/supportsTable.component.ts
+++ b/src/app/features/study/presentation/components/sections-tab/newSectionModal/manualSection/supportsTable/supportsTable.component.ts
@@ -29,6 +29,7 @@ import {
   getSupportFieldValues,
   SUPPORT_FIELD_LIMITS
 } from './helpers';
+import { truncateDecimals } from '@shared/helpers/truncateDecimals';
 
 /**
  * Editable table of supports within a section.
@@ -97,6 +98,8 @@ export class SupportsTableComponent implements OnInit {
 
   public onlyPositiveNumbers = /^\d*$/;
   public onlyPositiveNumbersWithDecimal = /^\d*[,.]?\d{0,2}$/;
+
+  readonly truncateDecimals = truncateDecimals;
 
   optionsChainV = [
     { label: $localize`Yes`, value: true },
@@ -189,11 +192,5 @@ export class SupportsTableComponent implements OnInit {
     return isNumber(value);
   }
 
-  truncateDecimals(event: Event): void {
-    const input = event.target as HTMLInputElement;
-    const sepIndex = input.value.indexOf('.');
-    if (sepIndex !== -1 && input.value.substring(sepIndex + 1).length > 2) {
-      input.value = input.value.substring(0, sepIndex + 3);
-    }
-  }
+
 }

--- a/src/app/features/study/presentation/components/sections-tab/newSectionModal/manualSection/supportsTable/supportsTable.component.ts
+++ b/src/app/features/study/presentation/components/sections-tab/newSectionModal/manualSection/supportsTable/supportsTable.component.ts
@@ -191,6 +191,4 @@ export class SupportsTableComponent implements OnInit {
   isNumber(value: unknown) {
     return isNumber(value);
   }
-
-
 }

--- a/src/app/shared/components/atoms/button/button.component.html
+++ b/src/app/shared/components/atoms/button/button.component.html
@@ -1,5 +1,5 @@
 @if (!btnLoading()) {
-  <ng-content select="app-icon:not([iconRight]), .app-icon:not([iconRight])" />
+  <ng-content select="app-icon:not([iconRight])" />
 } @else if (hasLeftIcon()) {
   <app-icon icon="progress_activity" />
 }
@@ -9,7 +9,7 @@
 </span>
 
 @if (!btnLoading()) {
-  <ng-content select="app-icon[iconRight], .app-icon[iconRight]" />
+  <ng-content select="app-icon[iconRight]" />
 } @else if (hasRightIcon()) {
   <app-icon icon="progress_activity" />
 }

--- a/src/app/shared/components/atoms/button/button.component.html
+++ b/src/app/shared/components/atoms/button/button.component.html
@@ -1,12 +1,15 @@
 @if (!btnLoading()) {
   <ng-content select="app-icon:not([iconRight]), .app-icon:not([iconRight])" />
+} @else if (hasLeftIcon()) {
+  <app-icon icon="progress_activity" />
+}
 
-  <span class="app-btn-label">
-    <ng-content />
-  </span>
+<span class="app-btn-label">
+  <ng-content />
+</span>
 
+@if (!btnLoading()) {
   <ng-content select="app-icon[iconRight], .app-icon[iconRight]" />
-} @else if (btnLoading()) {
-  <span class="app-btn-label" i18n>loading</span>
+} @else if (hasRightIcon()) {
   <app-icon icon="progress_activity" />
 }

--- a/src/app/shared/components/atoms/button/button.component.scss
+++ b/src/app/shared/components/atoms/button/button.component.scss
@@ -36,8 +36,8 @@
   }
 
   &:not(:disabled),
-  &.disabled,
-  &[disabled] {
+  &:not(.disabled),
+  &:not([disabled]) {
     &:focus-visible {
       @extend %focus-state;
     }
@@ -182,6 +182,15 @@ a.app-btn {
 .app-btn-loading {
   .app-icon {
     animation: button-loading-icon 0.6s linear infinite;
+  }
+
+  &,
+  &:disabled,
+  &.disabled,
+  &[disabled] {
+    .app-icon {
+      color: var(--main-primary);
+    }
   }
 }
 

--- a/src/app/shared/components/atoms/button/button.component.spec.ts
+++ b/src/app/shared/components/atoms/button/button.component.spec.ts
@@ -1,6 +1,7 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { Component } from '@angular/core';
 import { ButtonComponent } from './button.component';
+import { IconComponent } from '../icon/icon.component';
 
 @Component({
   selector: 'app-icon',
@@ -28,6 +29,32 @@ class TestHostComponent {
   onButtonClick(): void {
     this.clickCount++;
   }
+}
+
+/** Host with real IconComponent so contentChildren(IconComponent) resolves correctly. */
+@Component({
+  standalone: true,
+  imports: [ButtonComponent, IconComponent],
+  template: `
+    <button app-btn [btnLoading]="loading">
+      <app-icon icon="close"></app-icon>
+      Button Text
+      <app-icon icon="close" iconRight></app-icon>
+    </button>
+  `
+})
+class TestHostWithIconsComponent {
+  loading = false;
+}
+
+/** Host with no icons to verify spinner is suppressed when no icon slot is filled. */
+@Component({
+  standalone: true,
+  imports: [ButtonComponent],
+  template: `<button app-btn [btnLoading]="loading">Button Text</button>`
+})
+class TestHostNoIconsComponent {
+  loading = false;
 }
 
 describe('ButtonComponent', () => {
@@ -201,39 +228,51 @@ describe('ButtonComponent', () => {
   });
 
   describe('Loading State Template', () => {
+    let iconsHostFixture: ComponentFixture<TestHostWithIconsComponent>;
+    let iconsHostComponent: TestHostWithIconsComponent;
+    let noIconsHostFixture: ComponentFixture<TestHostNoIconsComponent>;
+    let noIconsHostComponent: TestHostNoIconsComponent;
+
     beforeEach(() => {
-      hostFixture = TestBed.createComponent(TestHostComponent);
-      hostComponent = hostFixture.componentInstance;
+      iconsHostFixture = TestBed.createComponent(TestHostWithIconsComponent);
+      iconsHostComponent = iconsHostFixture.componentInstance;
+      noIconsHostFixture = TestBed.createComponent(TestHostNoIconsComponent);
+      noIconsHostComponent = noIconsHostFixture.componentInstance;
     });
 
     it('should show normal content when not loading', () => {
-      hostComponent.loading = false;
-      hostFixture.detectChanges();
+      iconsHostComponent.loading = false;
+      iconsHostFixture.detectChanges();
 
-      const buttonElement = hostFixture.nativeElement.querySelector('button');
-      expect(buttonElement.textContent).toContain('Button Text');
-      expect(buttonElement.textContent).toContain('Left Icon');
-      expect(buttonElement.textContent).toContain('Right Icon');
-      expect(buttonElement.textContent).not.toContain('loading');
+      const button = iconsHostFixture.nativeElement.querySelector('button');
+      expect(button.textContent).toContain('Button Text');
+      const spinners = button.querySelectorAll('app-icon[icon="progress_activity"]');
+      expect(spinners.length).toBe(0);
     });
 
-    it('should show loading content when loading', () => {
-      hostComponent.loading = true;
-      hostFixture.detectChanges();
+    it('should show progress activity icons in place of left and right icons when loading', () => {
+      iconsHostComponent.loading = true;
+      iconsHostFixture.detectChanges();
 
-      const buttonElement = hostFixture.nativeElement.querySelector('button');
-      expect(buttonElement.textContent).toContain('loading');
-      expect(buttonElement.textContent).not.toContain('Button Text');
-      expect(buttonElement.textContent).not.toContain('Left Icon');
-      expect(buttonElement.textContent).not.toContain('Right Icon');
+      const button = iconsHostFixture.nativeElement.querySelector('button');
+      const spinners = button.querySelectorAll('app-icon[icon="progress_activity"]');
+      expect(spinners.length).toBe(2);
     });
 
     it('should show progress activity icon when loading', () => {
-      hostComponent.loading = true;
-      hostFixture.detectChanges();
+      iconsHostComponent.loading = true;
+      iconsHostFixture.detectChanges();
 
-      const iconElement = hostFixture.nativeElement.querySelector('app-icon[icon="progress_activity"]');
+      const iconElement = iconsHostFixture.nativeElement.querySelector('app-icon[icon="progress_activity"]');
       expect(iconElement).toBeTruthy();
+    });
+
+    it('should not show progress activity icon when loading and no icons are projected', () => {
+      noIconsHostComponent.loading = true;
+      noIconsHostFixture.detectChanges();
+
+      const iconElement = noIconsHostFixture.nativeElement.querySelector('app-icon[icon="progress_activity"]');
+      expect(iconElement).toBeNull();
     });
   });
 

--- a/src/app/shared/components/atoms/button/button.component.spec.ts
+++ b/src/app/shared/components/atoms/button/button.component.spec.ts
@@ -65,7 +65,7 @@ describe('ButtonComponent', () => {
 
   beforeEach(async () => {
     await TestBed.configureTestingModule({
-      imports: [ButtonComponent]
+      imports: [ButtonComponent, TestHostComponent, TestHostWithIconsComponent, TestHostNoIconsComponent]
     }).compileComponents();
 
     fixture = TestBed.createComponent(ButtonComponent);

--- a/src/app/shared/components/atoms/button/button.component.ts
+++ b/src/app/shared/components/atoms/button/button.component.ts
@@ -2,6 +2,7 @@ import {
   ChangeDetectionStrategy,
   Component,
   computed,
+  contentChildren,
   ElementRef,
   inject,
   input,
@@ -37,6 +38,16 @@ export class ButtonComponent implements OnInit, OnDestroy {
   btnStyle = input<'base' | 'outlined' | 'text' | 'danger'>('base');
   /** Whether the button is in a loading state, disabling click events. */
   btnLoading = input<boolean>(false);
+
+  private readonly projectedIcons = contentChildren(IconComponent, { read: ElementRef });
+
+  readonly hasLeftIcon = computed(() =>
+    this.projectedIcons().some(el => !el.nativeElement.hasAttribute('iconRight'))
+  );
+
+  readonly hasRightIcon = computed(() =>
+    this.projectedIcons().some(el => el.nativeElement.hasAttribute('iconRight'))
+  );
 
   classesList = computed(() => {
     const classes: string[] = [`app-btn-${this.btnSize()}`, `app-btn-${this.btnStyle()}`];

--- a/src/app/shared/components/atoms/button/button.component.ts
+++ b/src/app/shared/components/atoms/button/button.component.ts
@@ -42,11 +42,11 @@ export class ButtonComponent implements OnInit, OnDestroy {
   private readonly projectedIcons = contentChildren(IconComponent, { read: ElementRef });
 
   readonly hasLeftIcon = computed(() =>
-    this.projectedIcons().some(el => !el.nativeElement.hasAttribute('iconRight'))
+    this.projectedIcons().some((el) => !el.nativeElement.hasAttribute('iconRight'))
   );
 
   readonly hasRightIcon = computed(() =>
-    this.projectedIcons().some(el => el.nativeElement.hasAttribute('iconRight'))
+    this.projectedIcons().some((el) => el.nativeElement.hasAttribute('iconRight'))
   );
 
   classesList = computed(() => {

--- a/src/app/shared/domain/helpers/sections.helpers.ts
+++ b/src/app/shared/domain/helpers/sections.helpers.ts
@@ -122,6 +122,8 @@ export const createEmptySection = (): Section => {
     selected_field_measure_uuid: undefined,
     vtl_and_guying: undefined,
     cable_modifications: [],
-    selected_cable_modification_uuid: null
+    selected_cable_modification_uuid: null,
+    cable_span_manipulations: [],
+    selected_cable_span_manipulation_uuid: null
   };
 };

--- a/src/app/shared/domain/models/cable-span-manipulation.model.ts
+++ b/src/app/shared/domain/models/cable-span-manipulation.model.ts
@@ -1,0 +1,72 @@
+/**
+ * Copyright (c) 2025, RTE (http://www.rte-france.com)
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+
+/**
+ * Cable manipulation type — defines how the cable is lifted.
+ *
+ * @category Domain Models
+ */
+export type CableManipType = 'with_a_crane' | 'temporary_support';
+
+/**
+ * Cable manipulation method — defines how the cable is attached during manipulation.
+ *
+ * @category Domain Models
+ */
+export type CableManipMethod = 'clamp' | 'pulley';
+
+/**
+ * Anchoring type — defines how the cable is anchored during manipulation.
+ *
+ * @category Domain Models
+ */
+export type AnchoringType = 'with_sling' | 'with_chain';
+
+/**
+ * Represents a cable span manipulation on a span.
+ *
+ * @remarks
+ * Stores all parameters needed to describe how a cable is physically
+ * manipulated on a given span: crane or temporary support, anchoring
+ * type (sling or chain), fixed-point position, and related accessories.
+ *
+ * @category Domain Models
+ */
+export interface CableSpanManipulation {
+  /** Unique identifier (UUID v4) */
+  uuid: string;
+  /** UUID of the span this manipulation applies to */
+  spanUuid: string;
+  /** Reference support used as origin for position measurements */
+  referenceSupport: 'LEFT' | 'RIGHT';
+  /** Distance from the reference support to the manipulated point on the cable (meters) */
+  distanceToRefSupport: number;
+  /** Type of cable manipulation */
+  cableManipType: CableManipType;
+  /** Method of cable manipulation */
+  cableManipMethod: CableManipMethod;
+  /** Longitudinal distance of the fixed point in meters (only for 'with_a_crane') */
+  longitudinalDistance: number | null;
+  /** Lateral distance of the fixed point in meters */
+  lateralDistance: number;
+  /** Altitude of the fixed point in meters */
+  altitude: number;
+  /** Anchoring type */
+  anchoring: AnchoringType;
+  /** Chain name (for 'with_chain' anchoring) */
+  chainName: string | null;
+  /** Chain length in meters (for 'with_chain' anchoring) */
+  chainLength: number | null;
+  /** Chain weight in kg (for 'with_chain' anchoring) */
+  chainWeight: number | null;
+  /** Chain surface in m² (for 'with_chain' anchoring) */
+  chainSurface: number | null;
+  /** Counter weight in kg (for 'with_chain' anchoring) */
+  counterWeight: number | null;
+  /** Sling length in meters (for 'with_sling' anchoring), default 5 */
+  slingLength: number;
+}

--- a/src/app/shared/domain/models/index.ts
+++ b/src/app/shared/domain/models/index.ts
@@ -12,6 +12,7 @@ export type { User } from './user.model';
 export type { Study } from './study.model';
 export type { Section } from './section.model';
 export type { CableModification } from './cable-modification.model';
+export type { CableSpanManipulation, CableManipType, CableManipMethod, AnchoringType } from './cable-span-manipulation.model';
 export type { Support } from './support.model';
 export type { Charge, ClimateCharge, SpanLoad } from './charge.model';
 export { SymmetryType } from './charge.model';

--- a/src/app/shared/domain/models/index.ts
+++ b/src/app/shared/domain/models/index.ts
@@ -12,7 +12,12 @@ export type { User } from './user.model';
 export type { Study } from './study.model';
 export type { Section } from './section.model';
 export type { CableModification } from './cable-modification.model';
-export type { CableSpanManipulation, CableManipType, CableManipMethod, AnchoringType } from './cable-span-manipulation.model';
+export type {
+  CableSpanManipulation,
+  CableManipType,
+  CableManipMethod,
+  AnchoringType
+} from './cable-span-manipulation.model';
 export type { Support } from './support.model';
 export type { Charge, ClimateCharge, SpanLoad } from './charge.model';
 export { SymmetryType } from './charge.model';

--- a/src/app/shared/domain/models/section.model.ts
+++ b/src/app/shared/domain/models/section.model.ts
@@ -12,6 +12,7 @@ import { Support } from './support.model';
 import { VtlAndGuying } from './vtl-and-guying.model';
 import { Obstacle } from './obstacle.model';
 import { CableModification } from './cable-modification.model';
+import { CableSpanManipulation } from './cable-span-manipulation.model';
 
 /**
  * Section domain model - represents a power line section.
@@ -127,4 +128,8 @@ export interface Section {
   cable_modifications: CableModification[];
   /** UUID of the currently selected cable modification */
   selected_cable_modification_uuid: string | null;
+  /** Array of cable span manipulations on this section's spans */
+  cable_span_manipulations: CableSpanManipulation[];
+  /** UUID of the currently selected cable span manipulation */
+  selected_cable_span_manipulation_uuid: string | null;
 }

--- a/src/app/shared/helpers/truncateDecimals.spec.ts
+++ b/src/app/shared/helpers/truncateDecimals.spec.ts
@@ -1,0 +1,42 @@
+/**
+ * Copyright (c) 2025, RTE (http://www.rte-france.com)
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+
+import { truncateDecimals } from './truncateDecimals';
+
+const makeEvent = (value: string) => ({ target: { value } as HTMLInputElement }) as unknown as Event;
+
+describe('truncateDecimals', () => {
+  it('should do nothing when value has no decimal separator', () => {
+    const event = makeEvent('123');
+    truncateDecimals(event);
+    expect((event.target as HTMLInputElement).value).toBe('123');
+  });
+
+  it('should do nothing when value has exactly 2 decimal places', () => {
+    const event = makeEvent('1.23');
+    truncateDecimals(event);
+    expect((event.target as HTMLInputElement).value).toBe('1.23');
+  });
+
+  it('should do nothing when value has fewer than 2 decimal places', () => {
+    const event = makeEvent('1.2');
+    truncateDecimals(event);
+    expect((event.target as HTMLInputElement).value).toBe('1.2');
+  });
+
+  it('should truncate to 2 decimal places when value has more', () => {
+    const event = makeEvent('1.234');
+    truncateDecimals(event);
+    expect((event.target as HTMLInputElement).value).toBe('1.23');
+  });
+
+  it('should truncate negative numbers with more than 2 decimal places', () => {
+    const event = makeEvent('-1.234');
+    truncateDecimals(event);
+    expect((event.target as HTMLInputElement).value).toBe('-1.23');
+  });
+});

--- a/src/app/shared/helpers/truncateDecimals.ts
+++ b/src/app/shared/helpers/truncateDecimals.ts
@@ -1,0 +1,22 @@
+/**
+ * Copyright (c) 2025, RTE (http://www.rte-france.com)
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+
+/**
+ * Truncates the value of a number input to at most 2 decimal places.
+ * Intended as an `(input)` event handler on `<input type="number" step="0.01">` elements.
+ *
+ * Mutates `event.target.value` in place so Angular's form binding picks up the clamped value.
+ *
+ * @param event - The DOM input event fired by the number input element
+ */
+export function truncateDecimals(event: Event): void {
+  const input = event.target as HTMLInputElement;
+  const sepIndex = input.value.indexOf('.');
+  if (sepIndex !== -1 && input.value.substring(sepIndex + 1).length > 2) {
+    input.value = input.value.substring(0, sepIndex + 3);
+  }
+}

--- a/src/styles/_utils.scss
+++ b/src/styles/_utils.scss
@@ -41,3 +41,7 @@ sup.mandatory {
   color: var(--grey-900);
   padding: 0.4375rem 0.5rem 0.4375rem 0.625rem;
 }
+
+.label {
+  @extend %label-style;
+}

--- a/src/styles/abstracts/_vars.scss
+++ b/src/styles/abstracts/_vars.scss
@@ -253,5 +253,5 @@ $elevation: (
 
 // Specific height var for studio's sidetab header.
 // Used to retrieve scroll in cable manip. at span load partial scroll.
-// unfortunately MUST ABSOLUTLY MATCH THE ACTUAL SIDETAB HEADER HEIGHT!
+// unfortunately MUST ABSOLUTELY MATCH THE ACTUAL SIDETAB HEADER HEIGHT!
 $studio-sidetab-header-height: 2.875rem;

--- a/src/styles/abstracts/_vars.scss
+++ b/src/styles/abstracts/_vars.scss
@@ -243,16 +243,15 @@ $_spread1: 0rem 0rem 0.125rem #{$_shadow-ambiant};
 $_spread2: 0rem 0rem 0.5rem #{$_shadow-ambiant};
 $elevation: (
   neutral-inner: inset 0rem 0.0625rem 0.25rem #{$_shadow-key},
-  neutral-1: string.unquote(
-      '0rem 0.0625rem 0.125rem #{$_shadow-key}, #{$_spread1}'
-    ),
-  neutral-2: string.unquote(
-      '0rem 0.125rem 0.25rem #{$_shadow-key}, #{$_spread1}'
-    ),
+  neutral-1: string.unquote('0rem 0.0625rem 0.125rem #{$_shadow-key}, #{$_spread1}'),
+  neutral-2: string.unquote('0rem 0.125rem 0.25rem #{$_shadow-key}, #{$_spread1}'),
   neutral-3: string.unquote('0rem 0.25rem 0.5rem #{$_shadow-key}, #{$_spread1}'),
   neutral-4: string.unquote('0rem 0.5rem 1rem #{$_shadow-key}, #{$_spread1}'),
-  neutral-5: string.unquote(
-      '0rem 0.875rem 1.75rem #{$_shadow-key}, #{$_spread2}'
-    ),
+  neutral-5: string.unquote('0rem 0.875rem 1.75rem #{$_shadow-key}, #{$_spread2}'),
   neutral-6: string.unquote('0rem 2rem 4rem #{$_shadow-key}, #{$_spread2}')
 );
+
+// Specific height var for studio's sidetab header.
+// Used to retrieve scroll in cable manip. at span load partial scroll.
+// unfortunately MUST ABSOLUTLY MATCH THE ACTUAL SIDETAB HEADER HEIGHT!
+$studio-sidetab-header-height: 2.875rem;

--- a/src/styles/vendor-extension/primeng/_tabs.scss
+++ b/src/styles/vendor-extension/primeng/_tabs.scss
@@ -28,6 +28,8 @@
   --p-tabs-tabpanel-padding: 1rem;
   --p-tabs-tabpanel-background: rgb(255, 255, 255, 0);
 
+  height: calc(100% - #{app.$studio-sidetab-header-height});
+
   .p-tablist-tab-list {
     @apply grid;
     grid-template-columns: calc(50% - 0.0625rem) calc(50% - 0.0625rem);
@@ -63,6 +65,25 @@
 
   .p-tablist-active-bar {
     @apply hidden;
+  }
+
+  .p-tabpanels {
+    overflow-y: auto;
+
+    @supports not selector(::-webkit-scrollbar) {
+      scrollbar-width: thin;
+    }
+
+    @supports selector(::-webkit-scrollbar) {
+      &::-webkit-scrollbar {
+        @apply h-full w-1;
+      }
+
+      &::-webkit-scrollbar-thumb {
+        @apply rounded;
+        background-color: var(--star-dust-600);
+      }
+    }
   }
 
   .climate {

--- a/src/styles/vendor-extension/primeng/_tabs.scss
+++ b/src/styles/vendor-extension/primeng/_tabs.scss
@@ -16,6 +16,7 @@
 .p-tabs.p-tabs.load-tabs {
   --p-tabs-tablist-border-color: transparent;
   --p-tabs-tablist-border-width: 0rem;
+  --p-tabs-tablist-background: rgb(255, 255, 255, 0);
   --p-tabs-tab-background: var(--primary-100);
   --p-tabs-tab-hover-background: var(--primary-200);
   --p-tabs-tab-active-background: var(--grey-0);
@@ -25,6 +26,7 @@
   --p-tabs-tab-padding: 0.625rem 0.75rem;
   --p-tabs-tab-margin: 0rem;
   --p-tabs-tabpanel-padding: 1rem;
+  --p-tabs-tabpanel-background: rgb(255, 255, 255, 0);
 
   .p-tablist-tab-list {
     @apply grid;

--- a/src/styles/vendor-extension/primeng/_tabs.scss
+++ b/src/styles/vendor-extension/primeng/_tabs.scss
@@ -16,7 +16,7 @@
 .p-tabs.p-tabs.load-tabs {
   --p-tabs-tablist-border-color: transparent;
   --p-tabs-tablist-border-width: 0rem;
-  --p-tabs-tablist-background: rgb(255, 255, 255, 0);
+  --p-tabs-tablist-background: rgb(255 255 255 / 0);
   --p-tabs-tab-background: var(--primary-100);
   --p-tabs-tab-hover-background: var(--primary-200);
   --p-tabs-tab-active-background: var(--grey-0);
@@ -26,7 +26,7 @@
   --p-tabs-tab-padding: 0.625rem 0.75rem;
   --p-tabs-tab-margin: 0rem;
   --p-tabs-tabpanel-padding: 1rem;
-  --p-tabs-tabpanel-background: rgb(255, 255, 255, 0);
+  --p-tabs-tabpanel-background: rgb(255 255 255 / 0);
 
   height: calc(100% - #{app.$studio-sidetab-header-height});
 

--- a/src/styles/vendor-extension/primeng/_toggleswitch.scss
+++ b/src/styles/vendor-extension/primeng/_toggleswitch.scss
@@ -13,7 +13,7 @@
   --p-toggleswitch-hover-background: var(--p-toggleswitch-background);
   --p-toggleswitch-checked-background: var(--primary-600);
   --p-toggleswitch-checked-hover-background: var(--primary-700);
-  --p-toggleswitch-shadow: 0 0 0 rgb(255, 255, 255, 0);
+  --p-toggleswitch-shadow: 0 0 0 rgb(255 255 255 / 0);
   --p-toggleswitch-handle-size: var(--p-toggleswitch-height);
 
   border-radius: var(--p-toggleswitch-border-radius);


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
<!-- please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes -->
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**Does this PR already have an issue describing the problem?**
PR for task #694 
It also contains a fix for #583 

What it contains:
- Form design layout (including chain and temporary support layout which are not to implement logic yet).
- Form validator controls for current implementation specs
- Error messages for out of bound value (which are never designed and specified -_-)
- Save mechanic into indexDB
- Minor fixes for cable length changes span selection (no filter for p-select options), span selection should not change plotly view.
- Fix for bug 583 (wrong design for loading buttons)

What it does NOT contains:
- Any logic to use a task for python calculation
- Any logic to draw the plotly graph