### PR TITLE
support selection in dis-symmetric ice thickness now display support …

### DIFF
--- a/src/app/features/studio/loads/presentation/components/climate/climate.component.ts
+++ b/src/app/features/studio/loads/presentation/components/climate/climate.component.ts
@@ -17,7 +17,7 @@ import { InputGroupAddonModule } from 'primeng/inputgroupaddon';
 import { PlotService } from '@services/plot/plot.service';
 import { ChargesService } from '@services/charges/charges.service';
 import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
-import { LoadFormsService } from '../../services/loadForms.service';
+import { LoadFormsService } from '@features/studio/loads/presentation/services/loadForms.service';
 import { ChargeData, ClimateCharge, SymmetryType } from '@shared/domain/models/charge.model';
 import { formatSupportNumber } from '@shared/helpers/formatSupportNumber';
 import { MessageModule } from 'primeng/message';
@@ -160,10 +160,13 @@ export class ClimateComponent {
   async initForm() {
     const supports = this.plotService.section()?.supports;
     const frontierSupportOptions =
-      supports?.map((support, index) => ({
-        label: formatSupportNumber(support.number),
-        value: index + 1
-      })) ?? [];
+      supports?.map((support, index) => {
+        const num = support.number;
+        return {
+          label: num ? formatSupportNumber(num) : String(index + 1),
+          value: index + 1
+        };
+      }) ?? [];
     frontierSupportOptions.shift();
     frontierSupportOptions.pop();
     this.frontierSupportOptions.set(frontierSupportOptions);

--- a/src/app/features/studio/loads/presentation/components/climate/climate.component.ts
+++ b/src/app/features/studio/loads/presentation/components/climate/climate.component.ts
@@ -19,6 +19,7 @@ import { ChargesService } from '@services/charges/charges.service';
 import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
 import { LoadFormsService } from '../../services/loadForms.service';
 import { ChargeData, ClimateCharge, SymmetryType } from '@shared/domain/models/charge.model';
+import { formatSupportNumber } from '@shared/helpers/formatSupportNumber';
 import { MessageModule } from 'primeng/message';
 
 /** Validator that rejects non-integer numeric values. */
@@ -159,8 +160,8 @@ export class ClimateComponent {
   async initForm() {
     const supports = this.plotService.section()?.supports;
     const frontierSupportOptions =
-      supports?.map((_, index) => ({
-        label: (index + 1).toString(),
+      supports?.map((support, index) => ({
+        label: formatSupportNumber(support.number),
         value: index + 1
       })) ?? [];
     frontierSupportOptions.shift();

--- a/src/app/shared/components/studio/section/helpers/createPlotDataObject.spec.ts
+++ b/src/app/shared/components/studio/section/helpers/createPlotDataObject.spec.ts
@@ -127,17 +127,24 @@ describe('createPlotDataObject', () => {
       expect((result[0] as Partial<PlotData>).text).toEqual(['', '42']);
     });
 
-    it('should return empty strings when no support is provided', () => {
+    it('should return "-" strings when no support is provided', () => {
       const result = createDataObject(testData, 0, 1, 'supports', '2d', 'profile');
 
-      expect((result[0] as Partial<PlotData>).text).toEqual(['', '']);
+      expect((result[0] as Partial<PlotData>).text).toEqual(['', '-']);
     });
 
-    it('should return empty strings when support number is null', () => {
+    it('should return "-" at the highest point when support number is null', () => {
       const supports = [createMockSupport({ uuid: 'uuid-1', number: null })];
       const result = createDataObject(testData, 0, 0, 'supports', '2d', 'profile', supports);
 
-      expect((result[0] as Partial<PlotData>).text).toEqual(['', '']);
+      expect((result[0] as Partial<PlotData>).text).toEqual(['', '-']);
+    });
+
+    it('should truncate support number longer than 5 characters', () => {
+      const supports = [createMockSupport({ uuid: 'uuid-1', number: 'ABCDEFGH' })];
+      const result = createDataObject(testData, 0, 0, 'supports', '2d', 'profile', supports);
+
+      expect((result[0] as Partial<PlotData>).text).toEqual(['', 'ABCDE']);
     });
 
     it('should return empty array for non-supports type', () => {

--- a/src/app/shared/components/studio/section/helpers/createPlotDataObject.spec.ts
+++ b/src/app/shared/components/studio/section/helpers/createPlotDataObject.spec.ts
@@ -127,17 +127,27 @@ describe('createPlotDataObject', () => {
       expect((result[0] as Partial<PlotData>).text).toEqual(['', '42']);
     });
 
-    it('should return "-" strings when no support is provided', () => {
+    it('should use index-based fallback label when no support is provided', () => {
       const result = createDataObject(testData, 0, 1, 'supports', '2d', 'profile');
 
-      expect((result[0] as Partial<PlotData>).text).toEqual(['', '-']);
+      // startSupport=0, index=0 → fallback = '1'
+      expect((result[0] as Partial<PlotData>).text).toEqual(['', '1']);
     });
 
-    it('should return "-" at the highest point when support number is null', () => {
+    it('should use index-based fallback label when support number is null', () => {
       const supports = [createMockSupport({ uuid: 'uuid-1', number: null })];
       const result = createDataObject(testData, 0, 0, 'supports', '2d', 'profile', supports);
 
-      expect((result[0] as Partial<PlotData>).text).toEqual(['', '-']);
+      // startSupport=0, index=0 → fallback = '1'
+      expect((result[0] as Partial<PlotData>).text).toEqual(['', '1']);
+    });
+
+    it('should use index-based fallback label when support number is an empty string', () => {
+      const supports = [createMockSupport({ uuid: 'uuid-1', number: '' })];
+      const result = createDataObject(testData, 0, 0, 'supports', '2d', 'profile', supports);
+
+      // startSupport=0, index=0 → fallback = '1'
+      expect((result[0] as Partial<PlotData>).text).toEqual(['', '1']);
     });
 
     it('should truncate support number longer than 5 characters', () => {

--- a/src/app/shared/components/studio/section/helpers/createPlotDataObject.ts
+++ b/src/app/shared/components/studio/section/helpers/createPlotDataObject.ts
@@ -2,6 +2,7 @@ import { Dash, Data, PlotData } from 'plotly.js-dist-min';
 import { SPAN_COLOR } from './plot.constants';
 import { PlotObjectsType, Side, View } from '@shared/types/plot.types';
 import { Support } from '@shared/domain/models/support.model';
+import { formatSupportNumber } from '@shared/helpers/formatSupportNumber';
 
 /**
  * Returns line styling for a given plot object type and view mode.
@@ -41,7 +42,7 @@ const getMode = (type: PlotObjectsType): PlotData['mode'] => {
 const getText = (type: PlotObjectsType, points: number[][], support: Support | undefined): string[] => {
   if (type !== 'supports') return [];
   const highestPointIndex = points.findIndex((point) => point[2] === Math.max(...points.map((p) => p[2])));
-  const label = support?.number ?? '';
+  const label = formatSupportNumber(support?.number ?? null);
   return points.map((_, index) => (index === highestPointIndex ? label : ''));
 };
 

--- a/src/app/shared/components/studio/section/helpers/createPlotDataObject.ts
+++ b/src/app/shared/components/studio/section/helpers/createPlotDataObject.ts
@@ -39,10 +39,15 @@ const getMode = (type: PlotObjectsType): PlotData['mode'] => {
   return 'lines+markers';
 };
 
-const getText = (type: PlotObjectsType, points: number[][], support: Support | undefined): string[] => {
+const getText = (
+  type: PlotObjectsType,
+  points: number[][],
+  support: Support | undefined,
+  fallbackIndex: number
+): string[] => {
   if (type !== 'supports') return [];
   const highestPointIndex = points.findIndex((point) => point[2] === Math.max(...points.map((p) => p[2])));
-  const label = formatSupportNumber(support?.number ?? null);
+  const label = formatSupportNumber(support?.number || String(fallbackIndex));
   return points.map((_, index) => (index === highestPointIndex ? label : ''));
 };
 
@@ -101,7 +106,7 @@ export const createDataObject = (
       line: getLine(type, view),
       textposition: 'top center',
       marker: getMarker(type, view),
-      text: getText(type, points, supports[startSupport + index]),
+      text: getText(type, points, supports[startSupport + index], startSupport + index + 1),
       name: type,
       supportUuid: supports[startSupport + index]?.uuid
     };


### PR DESCRIPTION
…number instead of index. Support number are trimmed to 5 first characters in plotly graph

**Please check if the PR fulfills these requirements**
<!-- please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes -->
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**Does this PR already have an issue describing the problem?**
PR for bugfix from ticket #679 