### PR TITLE
add wind rounded incidence calcul result.

### DIFF
--- a/assets/i18n/messages.fr.xlf
+++ b/assets/i18n/messages.fr.xlf
@@ -3894,13 +3894,25 @@
     <unit id="3643941097771362577">
       <segment state="initial">
         <source>strand is not cut</source>
-        <target>le brin n'est pas coupé</target>
+        <target>le brin n&apos;est pas coupé</target>
       </segment>
     </unit>
     <unit id="1964966931243862246">
       <segment state="initial">
         <source>Max section</source>
         <target>Max canton</target>
+      </segment>
+    </unit>
+    <unit id="2658311569006173825">
+      <segment state="initial">
+        <source>Computing wind incidence</source>
+        <target>Calcul de l&apos;incidence du vent</target>
+      </segment>
+    </unit>
+    <unit id="7452118962262453473">
+      <segment state="initial">
+        <source> Wind direction and azimuth are required. </source>
+        <target> La direction du vent et l&apos;azimut sont requis. </target>
       </segment>
     </unit>
   </file>

--- a/assets/i18n/messages.xlf
+++ b/assets/i18n/messages.xlf
@@ -3230,5 +3230,15 @@
         <source>Working load</source>
       </segment>
     </unit>
+    <unit id="2658311569006173825">
+      <segment>
+        <source>Computing wind incidence</source>
+      </segment>
+    </unit>
+    <unit id="7452118962262453473">
+      <segment>
+        <source> Wind direction and azimuth are required. </source>
+      </segment>
+    </unit>
   </file>
 </xliff>

--- a/src/app/features/studio/field-measuring/presentation/components/temperature-calculation/temperature-calculation.component.html
+++ b/src/app/features/studio/field-measuring/presentation/components/temperature-calculation/temperature-calculation.component.html
@@ -70,8 +70,26 @@
       />
     </dt>
     <dd class="windIncidence__value">
-      @if (measureData().windIncidenceMode === 'auto') {
-        {{ measureData().windIncidence }}
+      @if (
+        measureData().windIncidenceMode === 'auto' &&
+        measureData().windDirection !== null &&
+        measureData().azimuth !== null
+      ) {
+        @if (isWindIncidenceLoading()) {
+          <p-progressspinner
+            styleClass="wind-incidence-loader"
+            strokeWidth="2"
+            aria-label="Computing wind incidence"
+            i18n-aria-label
+            data-testid="wind-incidence-spinner"
+          />
+        } @else {
+          <span data-testid="wind-incidence-value">{{ measureData().windIncidence }}°</span>
+        }
+      } @else if (measureData().windIncidenceMode === 'auto') {
+        <p-message severity="warn" size="small" variant="simple" i18n>
+          Wind direction and azimuth are required.
+        </p-message>
       } @else {
         90°
       }

--- a/src/app/features/studio/field-measuring/presentation/components/temperature-calculation/temperature-calculation.component.html
+++ b/src/app/features/studio/field-measuring/presentation/components/temperature-calculation/temperature-calculation.component.html
@@ -63,35 +63,39 @@
         (onChange)="updateField('windIncidenceMode', $event.value)"
         optionLabel="label"
         optionValue="value"
-        optionDisabled="disabled"
         allowEmpty="false"
         ariaLabelledBy="windIncidenceLabel"
         data-testid="wind-incidence-mode-selector"
       />
     </dt>
     <dd class="windIncidence__value">
-      @if (
-        measureData().windIncidenceMode === 'auto' &&
-        measureData().windDirection !== null &&
-        measureData().azimuth !== null
-      ) {
-        @if (isWindIncidenceLoading()) {
+      @switch (windIncidenceDisplayState()) {
+        @case ('loading') {
           <p-progressspinner
             styleClass="wind-incidence-loader"
             strokeWidth="2"
-            aria-label="Computing wind incidence"
-            i18n-aria-label
+            ariaLabel="Computing wind incidence"
+            i18n-ariaLabel
             data-testid="wind-incidence-spinner"
           />
-        } @else {
+        }
+        @case ('missing-inputs') {
+          <p-message
+            severity="warn"
+            size="small"
+            variant="simple"
+            i18n
+            data-testid="wind-incidence-missing-inputs-warning"
+          >
+            Wind direction and azimuth are required.
+          </p-message>
+        }
+        @case ('value') {
           <span data-testid="wind-incidence-value">{{ measureData().windIncidence }}°</span>
         }
-      } @else if (measureData().windIncidenceMode === 'auto') {
-        <p-message severity="warn" size="small" variant="simple" i18n>
-          Wind direction and azimuth are required.
-        </p-message>
-      } @else {
-        90°
+        @case ('perpendicular') {
+          <span data-testid="wind-incidence-perpendicular">90°</span>
+        }
       }
     </dd>
   </dl>

--- a/src/app/features/studio/field-measuring/presentation/components/temperature-calculation/temperature-calculation.component.spec.ts
+++ b/src/app/features/studio/field-measuring/presentation/components/temperature-calculation/temperature-calculation.component.spec.ts
@@ -1,10 +1,12 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { ComponentRef } from '@angular/core';
+import { BehaviorSubject } from 'rxjs';
+import { provideNoopAnimations } from '@angular/platform-browser/animations';
 
 import { TemperatureCalculationComponent } from './temperature-calculation.component';
 import { createTestMeasureData } from '@features/studio/field-measuring/presentation/helpers';
 import { WorkerPythonService } from '@services/worker_python/worker-python.service';
-import { Task, TaskError, TaskOutputs } from '@services/worker_python/tasks/types';
+import { Task, TaskError, TaskOutputs, PythonErrorCode } from '@services/worker_python/tasks/types';
 import {
   WIND_DIRECTION_OPTIONS,
   SKY_COVER_OPTIONS,
@@ -16,15 +18,19 @@ describe('TemperatureCalculationComponent', () => {
   let fixture: ComponentFixture<TemperatureCalculationComponent>;
   let componentRef: ComponentRef<TemperatureCalculationComponent>;
   let workerPythonServiceMock: vi.Mocked<WorkerPythonService>;
+  let workerReadySubject: BehaviorSubject<boolean>;
 
   beforeEach(async () => {
+    workerReadySubject = new BehaviorSubject<boolean>(false);
+
     workerPythonServiceMock = {
-      runTask: vi.fn()
+      runTask: vi.fn(),
+      ready$: workerReadySubject.asObservable()
     } as unknown as vi.Mocked<WorkerPythonService>;
 
     await TestBed.configureTestingModule({
       imports: [TemperatureCalculationComponent],
-      providers: [{ provide: WorkerPythonService, useValue: workerPythonServiceMock }]
+      providers: [provideNoopAnimations(), { provide: WorkerPythonService, useValue: workerPythonServiceMock }]
     }).compileComponents();
 
     fixture = TestBed.createComponent(TemperatureCalculationComponent);
@@ -133,7 +139,11 @@ describe('TemperatureCalculationComponent', () => {
     });
 
     it('should be true during calculation and false after', async () => {
-      let resolveTask!: (value: { result: TaskOutputs[Task.temperatureCalculation]; error: TaskError | null }) => void;
+      let resolveTask!: (value: {
+        result: TaskOutputs[Task.temperatureCalculation];
+        error: TaskError | null;
+        pythonErrorCode: PythonErrorCode | null;
+      }) => void;
       workerPythonServiceMock.runTask.mockReturnValueOnce(
         new Promise((res) => {
           resolveTask = res;
@@ -147,7 +157,11 @@ describe('TemperatureCalculationComponent', () => {
       const calcPromise = component.calculateTemperature();
       expect(component.isCalculating()).toBe(true);
 
-      resolveTask({ result: { cableSolarFlux: 0, cableTemperature: 0, cableTemperatureUncertainty: 0 }, error: null });
+      resolveTask({
+        result: { cableSolarFlux: 0, cableTemperature: 0, cableTemperatureUncertainty: 0 },
+        error: null,
+        pythonErrorCode: null
+      });
       await calcPromise;
 
       expect(component.isCalculating()).toBe(false);
@@ -174,7 +188,8 @@ describe('TemperatureCalculationComponent', () => {
 
     workerPythonServiceMock.runTask.mockResolvedValue({
       result: mockResult,
-      error: null
+      error: null,
+      pythonErrorCode: null
     });
 
     // Set all required fields
@@ -224,6 +239,151 @@ describe('TemperatureCalculationComponent', () => {
       const el = getByTestId('calculate-temperature-btn');
       expect(el).toBeTruthy();
       expect(el?.tagName).toBe('BUTTON');
+    });
+
+    describe('wind incidence area', () => {
+      beforeEach(() => {
+        componentRef.setInput(
+          'measureData',
+          createTestMeasureData({ azimuth: 45, windDirection: 'North', windIncidenceMode: 'auto' })
+        );
+        fixture.detectChanges();
+      });
+
+      it('should show spinner when worker is not ready', () => {
+        expect(getByTestId('wind-incidence-spinner')).toBeTruthy();
+        expect(getByTestId('wind-incidence-value')).toBeNull();
+      });
+
+      it('should show value and hide spinner when worker is ready', async () => {
+        workerPythonServiceMock.runTask.mockResolvedValue({
+          result: { windIncidence: 58.00000000000001 },
+          error: null,
+          pythonErrorCode: null
+        });
+        workerReadySubject.next(true);
+        fixture.detectChanges();
+        await fixture.whenStable();
+        fixture.detectChanges();
+
+        expect(getByTestId('wind-incidence-spinner')).toBeNull();
+        const valueEl = getByTestId('wind-incidence-value');
+        expect(valueEl).toBeTruthy();
+        expect(valueEl?.textContent).toContain('58°');
+      });
+    });
+  });
+
+  describe('isWindIncidenceLoading', () => {
+    it('should be true when worker is not ready', () => {
+      expect(component.isWindIncidenceLoading()).toBe(true);
+    });
+
+    it('should be false when worker becomes ready', () => {
+      workerReadySubject.next(true);
+      expect(component.isWindIncidenceLoading()).toBe(false);
+    });
+  });
+
+  describe('computeWindIncidence rounding', () => {
+    beforeEach(() => {
+      componentRef.setInput(
+        'measureData',
+        createTestMeasureData({ azimuth: 45, windDirection: 'North', windIncidenceMode: 'auto' })
+      );
+      fixture.detectChanges();
+    });
+
+    it('should round 58.00000000000001 to 58', async () => {
+      workerPythonServiceMock.runTask.mockResolvedValue({
+        result: { windIncidence: 58.00000000000001 },
+        error: null,
+        pythonErrorCode: null
+      });
+      workerReadySubject.next(true);
+      fixture.detectChanges();
+      await fixture.whenStable();
+
+      expect(component.measureData().windIncidence).toBe(58);
+    });
+
+    it('should round 63.999999999999986 to 64', async () => {
+      workerPythonServiceMock.runTask.mockResolvedValue({
+        result: { windIncidence: 63.999999999999986 },
+        error: null,
+        pythonErrorCode: null
+      });
+      workerReadySubject.next(true);
+      fixture.detectChanges();
+      await fixture.whenStable();
+
+      expect(component.measureData().windIncidence).toBe(64);
+    });
+
+    it('should not update windIncidence when task returns an error', async () => {
+      workerPythonServiceMock.runTask.mockResolvedValue({
+        result: undefined,
+        error: TaskError.CALCULATION_ERROR,
+        pythonErrorCode: null
+      });
+      workerReadySubject.next(true);
+      fixture.detectChanges();
+      await fixture.whenStable();
+
+      expect(component.measureData().windIncidence).toBeNull();
+    });
+  });
+
+  describe('wind incidence deduplication effect', () => {
+    beforeEach(() => {
+      workerPythonServiceMock.runTask.mockResolvedValue({
+        result: { windIncidence: 45 },
+        error: null,
+        pythonErrorCode: null
+      });
+      componentRef.setInput(
+        'measureData',
+        createTestMeasureData({ azimuth: 45, windDirection: 'North', windIncidenceMode: 'auto' })
+      );
+      workerReadySubject.next(true);
+      fixture.detectChanges();
+    });
+
+    it('should call runTask once for initial valid inputs', async () => {
+      await fixture.whenStable();
+      const windCalls = workerPythonServiceMock.runTask.mock.calls.filter(([task]) => task === Task.getWindIncidence);
+      expect(windCalls.length).toBe(1);
+    });
+
+    it('should not call runTask again when same azimuth and windDirection are set', async () => {
+      await fixture.whenStable();
+      component.updateField('azimuth', 45);
+      component.updateField('windDirection', 'North');
+      fixture.detectChanges();
+      await fixture.whenStable();
+
+      const windCalls = workerPythonServiceMock.runTask.mock.calls.filter(([task]) => task === Task.getWindIncidence);
+      expect(windCalls.length).toBe(1);
+    });
+
+    it('should call runTask again when azimuth changes', async () => {
+      await fixture.whenStable();
+      component.updateField('azimuth', 90);
+      fixture.detectChanges();
+      await fixture.whenStable();
+
+      const windCalls = workerPythonServiceMock.runTask.mock.calls.filter(([task]) => task === Task.getWindIncidence);
+      expect(windCalls.length).toBe(2);
+    });
+
+    it('should call runTask again when windDirection changes', async () => {
+      await fixture.whenStable();
+      component.updateField('windDirection', 'South');
+      fixture.detectChanges();
+      await fixture.whenStable();
+
+      const windCalls = workerPythonServiceMock.runTask.mock.calls.filter(([task]) => task === Task.getWindIncidence);
+      expect(windCalls.length).toBe(2);
     });
   });
 });

--- a/src/app/features/studio/field-measuring/presentation/components/temperature-calculation/temperature-calculation.component.spec.ts
+++ b/src/app/features/studio/field-measuring/presentation/components/temperature-calculation/temperature-calculation.component.spec.ts
@@ -255,7 +255,30 @@ describe('TemperatureCalculationComponent', () => {
         expect(getByTestId('wind-incidence-value')).toBeNull();
       });
 
-      it('should show value and hide spinner when worker is ready', async () => {
+      it('should still show spinner when worker is ready but windIncidence is still null', async () => {
+        let resolveTask!: (value: { result: { windIncidence: number }; error: null; pythonErrorCode: null }) => void;
+        workerPythonServiceMock.runTask.mockReturnValueOnce(
+          new Promise((res) => {
+            resolveTask = res;
+          })
+        );
+
+        workerReadySubject.next(true);
+        fixture.detectChanges();
+
+        // task not yet resolved — windIncidence still null
+        expect(getByTestId('wind-incidence-spinner')).toBeTruthy();
+        expect(getByTestId('wind-incidence-value')).toBeNull();
+
+        resolveTask({ result: { windIncidence: 58 }, error: null, pythonErrorCode: null });
+        await fixture.whenStable();
+        fixture.detectChanges();
+
+        expect(getByTestId('wind-incidence-spinner')).toBeNull();
+        expect(getByTestId('wind-incidence-value')).toBeTruthy();
+      });
+
+      it('should show value and hide spinner when worker is ready and value is returned', async () => {
         workerPythonServiceMock.runTask.mockResolvedValue({
           result: { windIncidence: 58.00000000000001 },
           error: null,
@@ -271,6 +294,44 @@ describe('TemperatureCalculationComponent', () => {
         expect(valueEl).toBeTruthy();
         expect(valueEl?.textContent).toContain('58°');
       });
+
+      describe('missing inputs warning', () => {
+        it('should show warning when windDirection is null and hide spinner and value', () => {
+          componentRef.setInput(
+            'measureData',
+            createTestMeasureData({ azimuth: 45, windDirection: null, windIncidenceMode: 'auto' })
+          );
+          fixture.detectChanges();
+
+          expect(getByTestId('wind-incidence-missing-inputs-warning')).toBeTruthy();
+          expect(getByTestId('wind-incidence-spinner')).toBeNull();
+          expect(getByTestId('wind-incidence-value')).toBeNull();
+        });
+
+        it('should show warning when azimuth is null and hide spinner and value', () => {
+          componentRef.setInput(
+            'measureData',
+            createTestMeasureData({ azimuth: null, windDirection: 'North', windIncidenceMode: 'auto' })
+          );
+          fixture.detectChanges();
+
+          expect(getByTestId('wind-incidence-missing-inputs-warning')).toBeTruthy();
+          expect(getByTestId('wind-incidence-spinner')).toBeNull();
+          expect(getByTestId('wind-incidence-value')).toBeNull();
+        });
+
+        it('should not show warning when mode is perpendicular', () => {
+          componentRef.setInput(
+            'measureData',
+            createTestMeasureData({ azimuth: null, windDirection: null, windIncidenceMode: 'perpendicular' })
+          );
+          fixture.detectChanges();
+
+          expect(getByTestId('wind-incidence-missing-inputs-warning')).toBeNull();
+          expect(getByTestId('wind-incidence-perpendicular')).toBeTruthy();
+          expect(getByTestId('wind-incidence-perpendicular')?.textContent).toContain('90°');
+        });
+      });
     });
   });
 
@@ -282,6 +343,56 @@ describe('TemperatureCalculationComponent', () => {
     it('should be false when worker becomes ready', () => {
       workerReadySubject.next(true);
       expect(component.isWindIncidenceLoading()).toBe(false);
+    });
+  });
+
+  describe('windIncidenceDisplayState', () => {
+    it('should return perpendicular when mode is perpendicular', () => {
+      componentRef.setInput('measureData', createTestMeasureData({ windIncidenceMode: 'perpendicular' }));
+      expect(component.windIncidenceDisplayState()).toBe('perpendicular');
+    });
+
+    it('should return missing-inputs when mode is auto and windDirection is null', () => {
+      componentRef.setInput(
+        'measureData',
+        createTestMeasureData({ windIncidenceMode: 'auto', azimuth: 45, windDirection: null })
+      );
+      expect(component.windIncidenceDisplayState()).toBe('missing-inputs');
+    });
+
+    it('should return missing-inputs when mode is auto and azimuth is null', () => {
+      componentRef.setInput(
+        'measureData',
+        createTestMeasureData({ windIncidenceMode: 'auto', azimuth: null, windDirection: 'North' })
+      );
+      expect(component.windIncidenceDisplayState()).toBe('missing-inputs');
+    });
+
+    it('should return loading when worker is not ready', () => {
+      componentRef.setInput(
+        'measureData',
+        createTestMeasureData({ windIncidenceMode: 'auto', azimuth: 45, windDirection: 'North' })
+      );
+      // workerReady is false by default
+      expect(component.windIncidenceDisplayState()).toBe('loading');
+    });
+
+    it('should return loading when worker is ready but windIncidence is still null', () => {
+      componentRef.setInput(
+        'measureData',
+        createTestMeasureData({ windIncidenceMode: 'auto', azimuth: 45, windDirection: 'North', windIncidence: null })
+      );
+      workerReadySubject.next(true);
+      expect(component.windIncidenceDisplayState()).toBe('loading');
+    });
+
+    it('should return value when worker is ready and windIncidence is set', () => {
+      componentRef.setInput(
+        'measureData',
+        createTestMeasureData({ windIncidenceMode: 'auto', azimuth: 45, windDirection: 'North', windIncidence: 58 })
+      );
+      workerReadySubject.next(true);
+      expect(component.windIncidenceDisplayState()).toBe('value');
     });
   });
 

--- a/src/app/features/studio/field-measuring/presentation/components/temperature-calculation/temperature-calculation.component.ts
+++ b/src/app/features/studio/field-measuring/presentation/components/temperature-calculation/temperature-calculation.component.ts
@@ -1,5 +1,7 @@
-import { ChangeDetectionStrategy, Component, inject, input, model, signal, computed } from '@angular/core';
-import { NgClass } from '@angular/common';
+import { ChangeDetectionStrategy, Component, inject, input, model, signal, computed, effect } from '@angular/core';
+import { ProgressSpinnerModule } from 'primeng/progressspinner';
+import { toSignal } from '@angular/core/rxjs-interop';
+import { NgClass, DecimalPipe } from '@angular/common';
 import { FormsModule } from '@angular/forms';
 import { trigger, transition, style, animate } from '@angular/animations';
 import { SelectModule } from 'primeng/select';
@@ -15,7 +17,6 @@ import { FieldMeasure } from '@features/studio/field-measuring/domain/types';
 import { WorkerPythonService } from '@services/worker_python/worker-python.service';
 import { WIND_SPEED_UNIT_OPTIONS, TRANSIT_BOUNDS } from '../../constants';
 import { Task } from '@services/worker_python/tasks/types';
-import { DecimalPipe } from '@angular/common';
 @Component({
   selector: 'app-temperature-calculation',
   imports: [
@@ -28,6 +29,7 @@ import { DecimalPipe } from '@angular/common';
     SelectButtonModule,
     RadioButtonModule,
     MessageModule,
+    ProgressSpinnerModule,
     IconComponent,
     ButtonComponent,
     DecimalPipe
@@ -61,11 +63,36 @@ export class TemperatureCalculationComponent {
   readonly windSpeedUnitOptions = WIND_SPEED_UNIT_OPTIONS;
 
   readonly windIncidenceModeOptions = [
-    { label: $localize`Auto`, value: 'auto', disabled: true },
+    { label: $localize`Auto`, value: 'auto' },
     { label: $localize`Perpendicular`, value: 'perpendicular' }
   ];
 
   private readonly workerPythonService = inject(WorkerPythonService);
+  private readonly workerReady = toSignal(this.workerPythonService.ready$, { initialValue: false });
+
+  readonly isWindIncidenceLoading = computed(() => !this.workerReady());
+  private readonly lastWindIncidenceInput = signal<{ azimuth: number; windDirection: string } | null>(null);
+
+  private readonly windIncidenceEffect = effect(() => {
+    const isWorkerReady = this.workerReady();
+    const { azimuth, windDirection } = this.measureData();
+
+    if (!isWorkerReady || azimuth === null || windDirection === null) {
+      this.lastWindIncidenceInput.set(null);
+      return;
+    }
+
+    const lastInput = this.lastWindIncidenceInput();
+    const hasSameInput =
+      lastInput !== null && lastInput.azimuth === azimuth && lastInput.windDirection === windDirection;
+
+    if (hasSameInput) {
+      return;
+    }
+
+    this.lastWindIncidenceInput.set({ azimuth, windDirection });
+    void this.computeWindIncidence(azimuth, windDirection);
+  });
 
   isTransitOutOfBounds = computed(() => {
     const transit = this.measureData().transit;
@@ -82,6 +109,16 @@ export class TemperatureCalculationComponent {
     const option = this.windDirectionOptions().find((opt) => opt.value === windDirection);
     return option?.label ?? windDirection;
   });
+
+  private async computeWindIncidence(azimuth: number, windDirection: string): Promise<void> {
+    const { result, error } = await this.workerPythonService.runTask(Task.getWindIncidence, {
+      azimuth,
+      windDirection
+    });
+    if (!error && result !== undefined) {
+      this.measureData.update((d) => ({ ...d, windIncidence: Math.round(result.windIncidence) }));
+    }
+  }
 
   updateField<K extends keyof FieldMeasure>(field: K, value: FieldMeasure[K]) {
     this.measureData.update((d) => ({ ...d, [field]: value }));

--- a/src/app/features/studio/field-measuring/presentation/components/temperature-calculation/temperature-calculation.component.ts
+++ b/src/app/features/studio/field-measuring/presentation/components/temperature-calculation/temperature-calculation.component.ts
@@ -71,6 +71,15 @@ export class TemperatureCalculationComponent {
   private readonly workerReady = toSignal(this.workerPythonService.ready$, { initialValue: false });
 
   readonly isWindIncidenceLoading = computed(() => !this.workerReady());
+
+  readonly windIncidenceDisplayState = computed((): 'perpendicular' | 'missing-inputs' | 'loading' | 'value' => {
+    const { windIncidenceMode, windDirection, azimuth, windIncidence } = this.measureData();
+    if (windIncidenceMode !== 'auto') return 'perpendicular';
+    if (windDirection === null || azimuth === null) return 'missing-inputs';
+    if (this.isWindIncidenceLoading() || windIncidence === null) return 'loading';
+    return 'value';
+  });
+
   private readonly lastWindIncidenceInput = signal<{ azimuth: number; windDirection: string } | null>(null);
 
   private readonly windIncidenceEffect = effect(() => {

--- a/src/styles/vendor-extension/primeng/_message.scss
+++ b/src/styles/vendor-extension/primeng/_message.scss
@@ -1,4 +1,5 @@
 .p-message.p-message {
   --p-message-error-simple-color: var(--main-error);
+  --p-message-warn-simple-color: var(--main-warning);
   --p-message-text-sm-font-size: 0.75rem;
 }

--- a/src/styles/vendor-extension/primeng/_prime-extension.extract.scss
+++ b/src/styles/vendor-extension/primeng/_prime-extension.extract.scss
@@ -22,3 +22,4 @@
 @forward './speeddial';
 @forward './message';
 @forward './toast';
+@forward './progress-spinner';

--- a/src/styles/vendor-extension/primeng/_progress-spinner.scss
+++ b/src/styles/vendor-extension/primeng/_progress-spinner.scss
@@ -1,0 +1,7 @@
+.p-progressspinner.p-progressspinner {
+  // specific for studio page tool temperature calculation wind incidence
+  &.wind-incidence-loader {
+    height: 2rem;
+    aspect-ratio: 1;
+  }
+}


### PR DESCRIPTION
add fallback warning message when trying to get calculated wind incidence without wind direction and azimuth. add loader for calculated wind incidence when workers aren't fully available (and accessibility test). add unit tests.
change default warning text color from p-message component.

**Please check if the PR fulfills these requirements**
<!-- please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes -->
- [X] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**Does this PR already have an issue describing the problem?**
PR for ticket #575 UI