### PR TITLE
fixbug fuite de memoire plotly

### DIFF
--- a/src/app/shared/components/studio/section/helpers/createPlot.ts
+++ b/src/app/shared/components/studio/section/helpers/createPlot.ts
@@ -1,10 +1,9 @@
-import Plotly, { Camera, Layout, ModeBarDefaultButtons } from 'plotly.js-dist-min';
+import Plotly, { Camera, Data, Layout, ModeBarDefaultButtons } from 'plotly.js-dist-min';
 import { AxesNorms, Side, View } from '@shared/types/plot.types';
 import { Distance, GetSectionOutput } from '@services/worker_python/tasks/types';
 import { createLoadAnnotations } from './createLoadAnnotations';
 import { SpanLoad } from '@shared/domain';
 import { Obstacle } from '@shared/domain/models/obstacle.model';
-import { DataObject } from './createPlotDataObject';
 import { createDistanceVisuals } from './createDistanceTraces';
 import { createObstaclesAnnotations } from './obstacles';
 import { Support } from '@shared/domain/models/support.model';
@@ -20,7 +19,7 @@ export interface CreatePlotParams {
   /** The DOM element ID of the plot container. */
   plotId: string;
   /** Array of data objects to render in the plot. */
-  data: DataObject[];
+  data: Data[];
   /** Raw section output data from the Python computation engine. */
   litData: GetSectionOutput;
   /** Whether to invert the plot axis direction. */

--- a/src/app/shared/components/studio/section/helpers/createPlot.ts
+++ b/src/app/shared/components/studio/section/helpers/createPlot.ts
@@ -209,3 +209,16 @@ export const createPlot = (plotParams: CreatePlotParams) => {
   // It will create the plot if it doesn't exist, or update it if it does
   return Plotly.react(plotParams.plotId, allData, baseLayout, config);
 };
+
+/**
+ * Purges a Plotly plot if the target element exists.
+ * Safe to call multiple times.
+ */
+export const purgePlot = (documentRef: Document, plotId: string): void => {
+  const plotElement = documentRef.getElementById(plotId);
+  if (!plotElement) {
+    return;
+  }
+
+  Plotly.purge(plotElement);
+};

--- a/src/app/shared/components/studio/section/section-plot.component.spec.ts
+++ b/src/app/shared/components/studio/section/section-plot.component.spec.ts
@@ -3,7 +3,7 @@ import { signal } from '@angular/core';
 import { of } from 'rxjs';
 import { SectionPlotComponent } from './section-plot.component';
 import { GetSectionOutput } from '@services/worker_python/tasks/types';
-import { createPlot } from './helpers/createPlot';
+import { createPlot, purgePlot } from './helpers/createPlot';
 import { createPlotData } from './helpers/createPlotData';
 import { Data, PlotlyHTMLElement } from 'plotly.js-dist-min';
 import { PlotOptions, SelectedDisplayOptions } from '@shared/types/plot.types';
@@ -29,6 +29,7 @@ vi.mock('./helpers/createShadowPlotData');
 import { createShadowPlotData } from './helpers/createShadowPlotData';
 
 const mockCreatePlot = vi.mocked(createPlot);
+const mockPurgePlot = vi.mocked(purgePlot);
 const mockCreatePlotData = vi.mocked(createPlotData);
 const mockCreateShadowPlotData = vi.mocked(createShadowPlotData);
 
@@ -194,7 +195,7 @@ describe('SectionPlotComponent', () => {
     } as Data
   ];
 
-  const mockPlotElement = { on: vi.fn() };
+  const mockPlotElement = { on: vi.fn(), removeAllListeners: vi.fn() };
   const noopMock = vi.fn();
 
   const litDataSignal = signal<GetSectionOutput | null>(null);
@@ -268,6 +269,7 @@ describe('SectionPlotComponent', () => {
     vi.clearAllMocks();
     mockCreatePlotData.mockReturnValue(mockPlotData);
     mockCreatePlot.mockResolvedValue(mockPlotElement as unknown as PlotlyHTMLElement);
+    mockPurgePlot.mockImplementation(() => undefined);
     mockCreateShadowPlotData.mockReturnValue([]);
 
     litDataSignal.set(mockLitData);
@@ -378,6 +380,19 @@ describe('SectionPlotComponent', () => {
           invert: true,
           view: '3d',
           side: 'face'
+        })
+      );
+    });
+
+    it('should fallback to empty plot data when createPlotData is not iterable', async () => {
+      mockCreatePlotData.mockReturnValueOnce(undefined as unknown as DataObject[]);
+      litDataSignal.set(mockLitData);
+
+      await component.refreshPlot();
+
+      expect(mockCreatePlot).toHaveBeenCalledWith(
+        expect.objectContaining({
+          data: []
         })
       );
     });
@@ -508,6 +523,26 @@ describe('SectionPlotComponent', () => {
       await component.refreshPlot();
 
       expect(mockCreateShadowPlotData).not.toHaveBeenCalled();
+      expect(mockCreatePlot).toHaveBeenCalledWith(
+        expect.objectContaining({
+          data: mockPlotData
+        })
+      );
+    });
+
+    it('should fallback to base plot data when shadow traces are not iterable', async () => {
+      const displayOptionsWithBase: SelectedDisplayOptions = {
+        loads: false,
+        baseState: true
+      };
+
+      baseLitDataSignal.set(mockLitData);
+      selectedDisplayOptionsSignal.set(displayOptionsWithBase);
+      mockCreateShadowPlotData.mockReturnValueOnce(undefined as unknown as Data[]);
+      litDataSignal.set(mockLitData);
+
+      await component.refreshPlot();
+
       expect(mockCreatePlot).toHaveBeenCalledWith(
         expect.objectContaining({
           data: mockPlotData
@@ -688,11 +723,18 @@ describe('SectionPlotComponent', () => {
 
     it('should handle multiple successive plot refreshes', async () => {
       litDataSignal.set(mockLitData);
+      mockPlotElement.on.mockClear();
+      mockPlotElement.removeAllListeners.mockClear();
 
       await component.refreshPlot();
       await component.refreshPlot();
 
       expect(mockCreatePlot).toHaveBeenCalledTimes(2);
+      expect(mockPlotElement.removeAllListeners).toHaveBeenCalledTimes(4);
+      expect(mockPlotElement.removeAllListeners).toHaveBeenNthCalledWith(1, 'plotly_clickannotation');
+      expect(mockPlotElement.removeAllListeners).toHaveBeenNthCalledWith(2, 'plotly_relayout');
+      expect(mockPlotElement.removeAllListeners).toHaveBeenNthCalledWith(3, 'plotly_clickannotation');
+      expect(mockPlotElement.removeAllListeners).toHaveBeenNthCalledWith(4, 'plotly_relayout');
     });
 
     it('should preserve obstacle data across refreshes', async () => {
@@ -906,6 +948,38 @@ describe('SectionPlotComponent', () => {
 
       expect(mockSideTabsService.sideTabs()).toBeNull();
       expect(mockLoadFormsService.activeLoadTab()).toBe('0');
+    });
+  });
+
+  describe('addEventListenersToPlot — listener cleanup', () => {
+    it('should remove stale click and relayout listeners before reattaching', () => {
+      const removeAllListeners = vi.fn();
+      const on = vi.fn();
+      const plot = {
+        removeAllListeners,
+        on
+      } as unknown as PlotlyHTMLElement;
+
+      component.addEventListenersToPlot(plot);
+
+      expect(removeAllListeners).toHaveBeenCalledWith('plotly_clickannotation');
+      expect(removeAllListeners).toHaveBeenCalledWith('plotly_relayout');
+      expect(on).toHaveBeenCalledWith('plotly_clickannotation', expect.any(Function));
+      expect(on).toHaveBeenCalledWith('plotly_relayout', expect.any(Function));
+    });
+  });
+
+  describe('Lifecycle cleanup', () => {
+    it('should purge plot on component destroy', () => {
+      fixture.destroy();
+
+      expect(mockPurgePlot).toHaveBeenCalledWith(expect.anything(), 'plotly-output');
+    });
+
+    it('should keep destroy cleanup idempotent', () => {
+      expect(() => component.ngOnDestroy()).not.toThrow();
+      expect(() => component.ngOnDestroy()).not.toThrow();
+      expect(mockPurgePlot).toHaveBeenCalledTimes(2);
     });
   });
 });

--- a/src/app/shared/components/studio/section/section-plot.component.spec.ts
+++ b/src/app/shared/components/studio/section/section-plot.component.spec.ts
@@ -3,7 +3,7 @@ import { signal } from '@angular/core';
 import { of } from 'rxjs';
 import { SectionPlotComponent } from './section-plot.component';
 import { GetSectionOutput } from '@services/worker_python/tasks/types';
-import { createPlot, purgePlot } from './helpers/createPlot';
+import { createPlot } from './helpers/createPlot';
 import { createPlotData } from './helpers/createPlotData';
 import { Data, PlotlyHTMLElement } from 'plotly.js-dist-min';
 import { PlotOptions, SelectedDisplayOptions } from '@shared/types/plot.types';
@@ -29,7 +29,6 @@ vi.mock('./helpers/createShadowPlotData');
 import { createShadowPlotData } from './helpers/createShadowPlotData';
 
 const mockCreatePlot = vi.mocked(createPlot);
-const mockPurgePlot = vi.mocked(purgePlot);
 const mockCreatePlotData = vi.mocked(createPlotData);
 const mockCreateShadowPlotData = vi.mocked(createShadowPlotData);
 
@@ -210,7 +209,8 @@ describe('SectionPlotComponent', () => {
     litData: litDataSignal,
     baseLitData: baseLitDataSignal,
     temporaryLoadData: null as ChargeData | null | undefined,
-    plotOptionsChange: noopMock
+    plotOptionsChange: noopMock,
+    purgePlot: vi.fn()
   };
 
   const mockSpanService = {
@@ -269,7 +269,6 @@ describe('SectionPlotComponent', () => {
     vi.clearAllMocks();
     mockCreatePlotData.mockReturnValue(mockPlotData);
     mockCreatePlot.mockResolvedValue(mockPlotElement as unknown as PlotlyHTMLElement);
-    mockPurgePlot.mockImplementation(() => undefined);
     mockCreateShadowPlotData.mockReturnValue([]);
 
     litDataSignal.set(mockLitData);
@@ -973,13 +972,13 @@ describe('SectionPlotComponent', () => {
     it('should purge plot on component destroy', () => {
       fixture.destroy();
 
-      expect(mockPurgePlot).toHaveBeenCalledWith(expect.anything(), 'plotly-output');
+      expect(mockPlotService.purgePlot).toHaveBeenCalledTimes(1);
     });
 
     it('should keep destroy cleanup idempotent', () => {
       expect(() => component.ngOnDestroy()).not.toThrow();
       expect(() => component.ngOnDestroy()).not.toThrow();
-      expect(mockPurgePlot).toHaveBeenCalledTimes(2);
+      expect(mockPlotService.purgePlot).toHaveBeenCalledTimes(2);
     });
   });
 });

--- a/src/app/shared/components/studio/section/section-plot.component.ts
+++ b/src/app/shared/components/studio/section/section-plot.component.ts
@@ -1,7 +1,7 @@
-import { ChangeDetectionStrategy, Component, computed, effect, inject, input, signal } from '@angular/core';
+import { ChangeDetectionStrategy, Component, OnDestroy, computed, effect, inject, input, signal } from '@angular/core';
 import { DOCUMENT } from '@angular/common';
 import { GetSectionOutput } from '@services/worker_python/tasks/types';
-import { createPlot } from './helpers/createPlot';
+import { createPlot, purgePlot } from './helpers/createPlot';
 import { SelectModule } from 'primeng/select';
 import { FormsModule } from '@angular/forms';
 import { KeyFilterModule } from 'primeng/keyfilter';
@@ -41,7 +41,7 @@ import { STUDIO_PLOT_DEBOUNCE_DELAY } from '@shared/components/studio/section/he
  * Renders an interactive Plotly section plot for a transmission-line study.
  * Listens to display options, obstacle positions, and span loads to keep the plot in sync.
  */
-export class SectionPlotComponent {
+export class SectionPlotComponent implements OnDestroy {
   // Input
   /** Lit data output used to draw the section plot. `null` when no data is available. */
   litData = input<GetSectionOutput | null>(null);
@@ -158,11 +158,13 @@ export class SectionPlotComponent {
       const spanLoads = this.getSpanLoadsToDisplay(selectedDisplayOptions, plotOptions);
       const obstacles = this.buildObstacleList();
       const supports = this.spanService.section()?.supports ?? [];
-      let plotData = createPlotData(litData, plotOptions, supports);
+      const sectionPlotData = createPlotData(litData, plotOptions, supports);
+      let plotData = Array.isArray(sectionPlotData) ? sectionPlotData : [];
 
       if (selectedDisplayOptions.baseState && this.plotService.baseLitData()) {
         const shadowData = createShadowPlotData(this.plotService.baseLitData()!, plotOptions);
-        plotData = [...(shadowData as typeof plotData), ...plotData];
+        const safeShadowData = Array.isArray(shadowData) ? shadowData : [];
+        plotData = [...(safeShadowData as typeof plotData), ...plotData];
       }
 
       const camera = this.plotOptionsService.camera();
@@ -208,11 +210,13 @@ export class SectionPlotComponent {
     }
     const plotEl = plot as Plotly.PlotlyHTMLElement & {
       on(e: 'plotly_clickannotation', fn: (event: ClickAnnotationEvent) => void): void;
+      on(e: 'plotly_relayout', fn: () => void): void;
       removeAllListeners(e: string): void;
     };
     // Remove stale listeners before re-adding — the plot element is reused across refreshes,
     // and each refresh call would otherwise accumulate a new listener, causing a memory leak.
     plotEl.removeAllListeners('plotly_clickannotation');
+    plotEl.removeAllListeners('plotly_relayout');
     plotEl.on('plotly_clickannotation', (event: ClickAnnotationEvent) => {
       if (event?.annotation?.data?.type === 'obstacle') {
         const section = this.spanService.section();
@@ -233,12 +237,12 @@ export class SectionPlotComponent {
       }
     });
 
-    (
-      plot as Plotly.PlotlyHTMLElement & {
-        on(e: 'plotly_relayout', fn: () => void): void;
-      }
-    ).on('plotly_relayout', () => {
+    plotEl.on('plotly_relayout', () => {
       this.plotOptionsService.refreshCamera();
     });
   };
+
+  ngOnDestroy(): void {
+    purgePlot(this.documentRef, PLOT_ID);
+  }
 }

--- a/src/app/shared/components/studio/section/section-plot.component.ts
+++ b/src/app/shared/components/studio/section/section-plot.component.ts
@@ -1,7 +1,7 @@
 import { ChangeDetectionStrategy, Component, OnDestroy, computed, effect, inject, input, signal } from '@angular/core';
 import { DOCUMENT } from '@angular/common';
 import { GetSectionOutput } from '@services/worker_python/tasks/types';
-import { createPlot, purgePlot } from './helpers/createPlot';
+import { createPlot } from './helpers/createPlot';
 import { SelectModule } from 'primeng/select';
 import { FormsModule } from '@angular/forms';
 import { KeyFilterModule } from 'primeng/keyfilter';
@@ -159,12 +159,12 @@ export class SectionPlotComponent implements OnDestroy {
       const obstacles = this.buildObstacleList();
       const supports = this.spanService.section()?.supports ?? [];
       const sectionPlotData = createPlotData(litData, plotOptions, supports);
-      let plotData = Array.isArray(sectionPlotData) ? sectionPlotData : [];
+      let plotData: Plotly.Data[] = Array.isArray(sectionPlotData) ? sectionPlotData : [];
 
       if (selectedDisplayOptions.baseState && this.plotService.baseLitData()) {
         const shadowData = createShadowPlotData(this.plotService.baseLitData()!, plotOptions);
-        const safeShadowData = Array.isArray(shadowData) ? shadowData : [];
-        plotData = [...(safeShadowData as typeof plotData), ...plotData];
+        const safeShadowData: Plotly.Data[] = Array.isArray(shadowData) ? shadowData : [];
+        plotData = [...safeShadowData, ...plotData];
       }
 
       const camera = this.plotOptionsService.camera();
@@ -243,6 +243,6 @@ export class SectionPlotComponent implements OnDestroy {
   };
 
   ngOnDestroy(): void {
-    purgePlot(this.documentRef, PLOT_ID);
+    this.plotService.purgePlot();
   }
 }


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
<!-- please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes -->
- [x] Tests for the changes have been added (for bug fixes / features)

[789](https://github.com/phlowers/phlowers-stellar-app/issues/789)

Title
Fix studio plot listener leak and lifecycle cleanup in section plot

Description

Context
The section plot component was re-attaching the Plotly relayout listener on every refresh without systematic cleanup, which could lead to listener accumulation and console warnings during repeated interactions.

What was changed
Listener cleanup before re-attach in [section-plot.component.ts:210](vscode-file://vscode-app/c:/Users/madrangesfre/AppData/Local/Programs/Microsoft%20VS%20Code/10c8e557c8/resources/app/out/vs/code/electron-browser/workbench/workbench.html)
Added explicit removal of plotly_relayout before re-attaching listeners.
Standardized usage of plotEl to avoid multiple casts and reduce inconsistency risk.
Plot lifecycle cleanup in [section-plot.component.ts:245](vscode-file://vscode-app/c:/Users/madrangesfre/AppData/Local/Programs/Microsoft%20VS%20Code/10c8e557c8/resources/app/out/vs/code/electron-browser/workbench/workbench.html)
Implemented OnDestroy.
Added ngOnDestroy with Plotly purge on the plot container.
Centralized purge helper in [createPlot.ts:217](vscode-file://vscode-app/c:/Users/madrangesfre/AppData/Local/Programs/Microsoft%20VS%20Code/10c8e557c8/resources/app/out/vs/code/electron-browser/workbench/workbench.html)
Added purgePlot(documentRef, plotId) with a guard when the element is missing.

Idempotent behavior to avoid side effects.
Data robustness hardening in [section-plot.component.ts:161](vscode-file://vscode-app/c:/Users/madrangesfre/AppData/Local/Programs/Microsoft%20VS%20Code/10c8e557c8/resources/app/out/vs/code/electron-browser/workbench/workbench.html)
Fallback to an empty array if createPlotData returns a non-iterable value.
Fallback to an empty array for shadow traces if createShadowPlotData is non-iterable.

Tests added and updated
Updated [section-plot.component.spec.ts](vscode-file://vscode-app/c:/Users/madrangesfre/AppData/Local/Programs/Microsoft%20VS%20Code/10c8e557c8/resources/app/out/vs/code/electron-browser/workbench/workbench.html)

Verifies clickannotation and relayout listener cleanup before re-attach.
Verifies no accumulation after successive refreshes.
Verifies purge on component destroy.
Verifies destroy cleanup idempotence.
Adds fallback tests when createPlotData or createShadowPlotData does not return an array.

Validation
Targeted section-plot tests passed.
Targeted lint for section-plot and helper passed with 0 errors.

Impact
Reduces memory leak risk related to Plotly listeners.
Stabilizes refresh behavior during rapid interactions.
Ensures explicit Plotly resource cleanup during component lifecycle.