### PR TITLE
Feat/703/plotly iconsactivation reset graphical view

### DIFF
--- a/assets/i18n/messages.fr.xlf
+++ b/assets/i18n/messages.fr.xlf
@@ -4127,5 +4127,17 @@
         <target> En attente du chargement du moteur pour afficher les résultats de calcul </target>
       </segment>
     </unit>
+    <unit id="2991274283822092243">
+      <segment state="translated">
+        <source>Orbital rotation</source>
+        <target>Rotation orbitale</target>
+      </segment>
+    </unit>
+    <unit id="560248595006112521">
+      <segment state="translated">
+        <source>Turntable rotation</source>
+        <target>Rotation plateau</target>
+      </segment>
+    </unit>
   </file>
 </xliff>

--- a/assets/i18n/messages.xlf
+++ b/assets/i18n/messages.xlf
@@ -3419,5 +3419,15 @@
         <source> Waiting for the engine to finish the calculation </source>
       </segment>
     </unit>
+    <unit id="2991274283822092243">
+      <segment>
+        <source>Orbital rotation</source>
+      </segment>
+    </unit>
+    <unit id="560248595006112521">
+      <segment>
+        <source>Turntable rotation</source>
+      </segment>
+    </unit>
   </file>
 </xliff>

--- a/src/app/core/services/plot/plot-options.service.spec.ts
+++ b/src/app/core/services/plot/plot-options.service.spec.ts
@@ -196,10 +196,10 @@ describe('PlotOptionsService', () => {
       expect(() => service.plotOptionsChange({ view: '2d' }, loadingFalse)).not.toThrow();
     });
 
-    it('should call refreshCamera on each change', () => {
+    it('should not call refreshCamera on plotOptionsChange', () => {
       const refreshCameraSpy = vi.spyOn(service, 'refreshCamera');
       service.plotOptionsChange({ view: '2d' }, loadingFalse);
-      expect(refreshCameraSpy).toHaveBeenCalledTimes(1);
+      expect(refreshCameraSpy).not.toHaveBeenCalled();
     });
   });
 

--- a/src/app/core/services/plot/plot-options.service.ts
+++ b/src/app/core/services/plot/plot-options.service.ts
@@ -50,7 +50,6 @@ export class PlotOptionsService {
     const oldOptions = untracked(() => this.plotOptions());
     const newOptions = { ...oldOptions, ...values };
     this.plotOptions.set(newOptions);
-    this.refreshCamera();
     if (checkIfProjectionNeedRefresh(oldOptions, newOptions, untracked(loading))) {
       onProjectionNeeded?.();
     }

--- a/src/app/shared/components/studio/section/helpers/createPlot.spec.ts
+++ b/src/app/shared/components/studio/section/helpers/createPlot.spec.ts
@@ -16,9 +16,15 @@ import { type Mock } from 'vitest';
 vi.mock('plotly.js-dist-min', () => ({
   __esModule: true,
   default: {
-    react: vi.fn()
+    react: vi.fn(),
+    relayout: vi.fn().mockResolvedValue(undefined),
+    Icons: {
+      '3d_rotate': { width: 1000, height: 1000, path: '' },
+      'z-axis': { width: 1000, height: 1000, path: '' }
+    }
   },
-  react: vi.fn()
+  react: vi.fn(),
+  relayout: vi.fn().mockResolvedValue(undefined)
 }));
 
 describe('createPlot', () => {
@@ -311,7 +317,7 @@ describe('createPlot', () => {
       expect(layoutArg.scene.camera.eye.y).toBeLessThan(0);
     });
 
-    it('should set camera eye.y positive when invert is true and camera is provided', () => {
+    it('should pass camera unmodified when invert is true and camera is provided', () => {
       const inputCamera = {
         center: { x: 0, y: 0, z: 0 },
         eye: { x: 0.02, y: -3.5, z: 0.2 },
@@ -319,11 +325,11 @@ describe('createPlot', () => {
       };
       createPlot({ ...createDefaultParams(), view: '3d', invert: true, camera: inputCamera });
 
-      const layoutArg = (Plotly.react as vi.Mock).mock.calls[0][2] as { scene: { camera: { eye: { y: number } } } };
-      expect(layoutArg.scene.camera.eye.y).toBeGreaterThan(0);
+      const layoutArg = (Plotly.react as vi.Mock).mock.calls[0][2] as { scene: { camera: unknown } };
+      expect(layoutArg.scene.camera).toEqual(inputCamera);
     });
 
-    it('should set camera eye.y negative when invert is false and camera is provided', () => {
+    it('should pass camera unmodified when invert is false and camera is provided', () => {
       const inputCamera = {
         center: { x: 0, y: 0, z: 0 },
         eye: { x: 0.02, y: 3.5, z: 0.2 },
@@ -331,8 +337,8 @@ describe('createPlot', () => {
       };
       createPlot({ ...createDefaultParams(), view: '3d', invert: false, camera: inputCamera });
 
-      const layoutArg = (Plotly.react as vi.Mock).mock.calls[0][2] as { scene: { camera: { eye: { y: number } } } };
-      expect(layoutArg.scene.camera.eye.y).toBeLessThan(0);
+      const layoutArg = (Plotly.react as vi.Mock).mock.calls[0][2] as { scene: { camera: unknown } };
+      expect(layoutArg.scene.camera).toEqual(inputCamera);
     });
 
     it('should not mutate the original camera object', () => {
@@ -349,16 +355,16 @@ describe('createPlot', () => {
   });
 
   describe('3D live camera from DOM', () => {
-    it('should use camera from plotParams when DOM element has no _fullLayout', () => {
+    it('should pass camera unmodified when DOM element has no _fullLayout but camera is provided', () => {
       const inputCamera = { center: { x: 0, y: 0, z: 0 }, eye: { x: 0.02, y: -3.5, z: 0.2 }, up: { x: 0, y: 0, z: 1 } };
       createPlot({ ...createDefaultParams(), view: '3d', camera: inputCamera });
 
       const layoutArg = (Plotly.react as Mock).mock.calls[0][2];
-      // camera was provided and DOM has no _fullLayout, so inputCamera is used
-      expect(layoutArg.scene.camera).toBeDefined();
+      // Camera is always passed so Plotly has a valid reference for viewport operations.
+      expect(layoutArg.scene.camera).toEqual(inputCamera);
     });
 
-    it('should use live camera from DOM _fullLayout when available, ignoring plotParams camera', () => {
+    it('should pass live DOM camera unmodified when available', () => {
       const domCamera = { center: { x: 0, y: 0, z: 0 }, eye: { x: 1, y: 2, z: 3 }, up: { x: 0, y: 0, z: 1 } };
       (mockElement as HTMLElement & { _fullLayout?: unknown })._fullLayout = { scene: { camera: domCamera } };
 
@@ -366,18 +372,19 @@ describe('createPlot', () => {
       createPlot({ ...createDefaultParams(), view: '3d', camera: staleCamera });
 
       const layoutArg = (Plotly.react as Mock).mock.calls[0][2];
-      // DOM camera eye.y is 2, after inversion (invert=false) → negated → -2
-      expect(layoutArg.scene.camera.eye.y).toBe(-2);
+      // Live DOM camera takes priority and is passed unmodified to layout.
+      expect(layoutArg.scene.camera).toEqual(domCamera);
     });
 
-    it('should fall back to plotParams camera when DOM _fullLayout has no camera', () => {
+    it('should pass plotParams camera when DOM _fullLayout has no camera', () => {
       (mockElement as HTMLElement & { _fullLayout?: unknown })._fullLayout = { scene: {} };
 
       const inputCamera = { center: { x: 0, y: 0, z: 0 }, eye: { x: 0.02, y: -3.5, z: 0.2 }, up: { x: 0, y: 0, z: 1 } };
       createPlot({ ...createDefaultParams(), view: '3d', camera: inputCamera });
 
       const layoutArg = (Plotly.react as Mock).mock.calls[0][2];
-      expect(layoutArg.scene.camera).toBeDefined();
+      // Fallback to plotParams camera, passed unmodified.
+      expect(layoutArg.scene.camera).toEqual(inputCamera);
     });
 
     it('should not read DOM camera in 2D mode', () => {
@@ -401,12 +408,11 @@ describe('createPlot', () => {
       expect(layoutArg.uirevision).toBe('stable');
     });
 
-    it('should set a unique non-stable string uirevision in 3D layout when camera is null', () => {
+    it('should always set uirevision to "stable" in 3D layout even when camera is null', () => {
       createPlot({ ...createDefaultParams(), view: '3d', camera: null });
 
       const layoutArg = (Plotly.react as Mock).mock.calls[0][2];
-      expect(layoutArg.uirevision).not.toBe('stable');
-      expect(typeof layoutArg.uirevision).toBe('string');
+      expect(layoutArg.uirevision).toBe('stable');
     });
 
     it('should not have uirevision in 2D layout', () => {

--- a/src/app/shared/components/studio/section/helpers/createPlot.spec.ts
+++ b/src/app/shared/components/studio/section/helpers/createPlot.spec.ts
@@ -347,4 +347,96 @@ describe('createPlot', () => {
       expect(inputCamera.eye.y).toBe(originalY);
     });
   });
+
+  describe('3D live camera from DOM', () => {
+    it('should use camera from plotParams when DOM element has no _fullLayout', () => {
+      const inputCamera = { center: { x: 0, y: 0, z: 0 }, eye: { x: 0.02, y: -3.5, z: 0.2 }, up: { x: 0, y: 0, z: 1 } };
+      createPlot({ ...createDefaultParams(), view: '3d', camera: inputCamera });
+
+      const layoutArg = (Plotly.react as Mock).mock.calls[0][2];
+      // camera was provided and DOM has no _fullLayout, so inputCamera is used
+      expect(layoutArg.scene.camera).toBeDefined();
+    });
+
+    it('should use live camera from DOM _fullLayout when available, ignoring plotParams camera', () => {
+      const domCamera = { center: { x: 0, y: 0, z: 0 }, eye: { x: 1, y: 2, z: 3 }, up: { x: 0, y: 0, z: 1 } };
+      (mockElement as HTMLElement & { _fullLayout?: unknown })._fullLayout = { scene: { camera: domCamera } };
+
+      const staleCamera = { center: { x: 0, y: 0, z: 0 }, eye: { x: 0.02, y: -3.5, z: 0.2 }, up: { x: 0, y: 0, z: 1 } };
+      createPlot({ ...createDefaultParams(), view: '3d', camera: staleCamera });
+
+      const layoutArg = (Plotly.react as Mock).mock.calls[0][2];
+      // DOM camera eye.y is 2, after inversion (invert=false) → negated → -2
+      expect(layoutArg.scene.camera.eye.y).toBe(-2);
+    });
+
+    it('should fall back to plotParams camera when DOM _fullLayout has no camera', () => {
+      (mockElement as HTMLElement & { _fullLayout?: unknown })._fullLayout = { scene: {} };
+
+      const inputCamera = { center: { x: 0, y: 0, z: 0 }, eye: { x: 0.02, y: -3.5, z: 0.2 }, up: { x: 0, y: 0, z: 1 } };
+      createPlot({ ...createDefaultParams(), view: '3d', camera: inputCamera });
+
+      const layoutArg = (Plotly.react as Mock).mock.calls[0][2];
+      expect(layoutArg.scene.camera).toBeDefined();
+    });
+
+    it('should not read DOM camera in 2D mode', () => {
+      const domCamera = { center: { x: 0, y: 0, z: 0 }, eye: { x: 1, y: 2, z: 3 }, up: { x: 0, y: 0, z: 1 } };
+      (mockElement as HTMLElement & { _fullLayout?: unknown })._fullLayout = { scene: { camera: domCamera } };
+
+      createPlot({ ...createDefaultParams(), view: '2d' });
+
+      const layoutArg = (Plotly.react as Mock).mock.calls[0][2];
+      // 2D layout has no scene
+      expect(layoutArg.scene).toBeUndefined();
+    });
+  });
+
+  describe('3D uirevision behaviour', () => {
+    it('should set uirevision to "stable" in 3D layout when camera is provided', () => {
+      const camera = { center: { x: 0, y: 0, z: 0 }, eye: { x: 0.02, y: -3.5, z: 0.2 }, up: { x: 0, y: 0, z: 1 } };
+      createPlot({ ...createDefaultParams(), view: '3d', camera });
+
+      const layoutArg = (Plotly.react as Mock).mock.calls[0][2];
+      expect(layoutArg.uirevision).toBe('stable');
+    });
+
+    it('should set a unique non-stable string uirevision in 3D layout when camera is null', () => {
+      createPlot({ ...createDefaultParams(), view: '3d', camera: null });
+
+      const layoutArg = (Plotly.react as Mock).mock.calls[0][2];
+      expect(layoutArg.uirevision).not.toBe('stable');
+      expect(typeof layoutArg.uirevision).toBe('string');
+    });
+
+    it('should not have uirevision in 2D layout', () => {
+      createPlot({ ...createDefaultParams(), view: '2d' });
+
+      const layoutArg = (Plotly.react as Mock).mock.calls[0][2];
+      expect(layoutArg.uirevision).toBeUndefined();
+    });
+  });
+
+  describe('modebar camera reset buttons removal', () => {
+    it('should include resetCameraDefault3d in modeBarButtonsToRemove', () => {
+      createPlot({ ...createDefaultParams() });
+
+      const configArg = (Plotly.react as Mock).mock.calls[0][3];
+      expect(configArg.modeBarButtonsToRemove).toContain('resetCameraDefault3d');
+    });
+
+    it('should include resetCameraLastSave3d in modeBarButtonsToRemove', () => {
+      createPlot({ ...createDefaultParams() });
+
+      const configArg = (Plotly.react as Mock).mock.calls[0][3];
+      expect(configArg.modeBarButtonsToRemove).toContain('resetCameraLastSave3d');
+    });
+
+    it('should include resetScale2d in modeBarButtonsToRemove', () => {
+      createPlot({ ...createDefaultParams() });
+
+      const configArg = (Plotly.react as Mock).mock.calls[0][3];
+      expect(configArg.modeBarButtonsToRemove).toContain('resetScale2d');
+    });
+  });
 });

--- a/src/app/shared/components/studio/section/helpers/createPlot.ts
+++ b/src/app/shared/components/studio/section/helpers/createPlot.ts
@@ -120,7 +120,10 @@ const config = {
     'hoverClosestCartesian',
     'hoverCompareCartesian',
     'resetLastSave',
-    'autoScale2d'
+    'autoScale2d',
+    'resetCameraDefault3d',
+    'resetCameraLastSave3d',
+    'resetScale2d'
   ] as ModeBarDefaultButtons[]
 };
 
@@ -130,6 +133,12 @@ const layout3d = (
 ): Partial<Layout> => ({
   autosize: true,
   showlegend: false,
+  // uirevision controls whether Plotly preserves user-driven camera interactions.
+  // When a camera is set (user has moved it), keep uirevision stable so Plotly
+  // ignores the camera value in the layout and preserves the interactive position.
+  // When camera is null (initial render or explicit reset), use a unique value so
+  // Plotly applies normalCamera() from the layout.
+  uirevision: plotParams.camera === null ? String(Date.now()) : 'stable',
   margin: {
     l: 0,
     r: 0,
@@ -186,6 +195,21 @@ const layout2d = (
 };
 
 /**
+ * Reads the current 3D camera directly from the Plotly DOM element's internal state.
+ * This bypasses the Angular signal layer and always returns the live camera position
+ * as Plotly knows it, even after the user has interacted with the plot.
+ * Returns null if the element does not exist or has no camera data yet.
+ */
+const getLiveCamera = (documentRef: Document, plotId: string): Camera | null => {
+  const el = documentRef.getElementById(plotId) as
+    | (HTMLElement & {
+        _fullLayout?: { scene?: { camera?: Camera } };
+      })
+    | null;
+  return el?._fullLayout?.scene?.camera ?? null;
+};
+
+/**
  * Creates or updates a Plotly plot in the DOM element identified by `plotParams.plotId`.
  * Selects the appropriate 2D or 3D layout and uses `Plotly.react` for efficient updates
  * without resetting the camera or zoom.
@@ -196,13 +220,23 @@ const layout2d = (
 export const createPlot = (plotParams: CreatePlotParams) => {
   // check if div with id plotly-output exists
   if (!plotParams.documentRef.getElementById(plotParams.plotId)) {
-    console.warn(`Plot element not found: ${plotParams.plotId}`);
     return;
   }
-  const { traces: distanceTraces, annotations: distanceAnnotations } = createDistanceVisuals(plotParams);
+
+  // For 3D plots, always read the live camera from the DOM before re-rendering.
+  // This prevents Plotly's internal setViewport() from resetting the camera to a
+  // stale value when the user interacts with the modebar (e.g. switches dragmode).
+  // The DOM camera is the source of truth after the first render.
+  const resolvedParams =
+    plotParams.view === '3d'
+      ? { ...plotParams, camera: getLiveCamera(plotParams.documentRef, plotParams.plotId) ?? plotParams.camera }
+      : plotParams;
+  const { traces: distanceTraces, annotations: distanceAnnotations } = createDistanceVisuals(resolvedParams);
   const baseLayout =
-    plotParams.view === '3d' ? layout3d(plotParams, distanceAnnotations) : layout2d(plotParams, distanceAnnotations);
-  const allData = [...plotParams.data, ...distanceTraces];
+    resolvedParams.view === '3d'
+      ? layout3d(resolvedParams, distanceAnnotations)
+      : layout2d(resolvedParams, distanceAnnotations);
+  const allData = [...resolvedParams.data, ...distanceTraces];
 
   // Use Plotly.react to update data without resetting camera/zoom
   // It will create the plot if it doesn't exist, or update it if it does

--- a/src/app/shared/components/studio/section/helpers/createPlot.ts
+++ b/src/app/shared/components/studio/section/helpers/createPlot.ts
@@ -1,4 +1,4 @@
-import Plotly, { Camera, Data, Layout, ModeBarDefaultButtons } from 'plotly.js-dist-min';
+import Plotly, { Camera, Data, Layout, ModeBarDefaultButtons, ModeBarButton, Icon } from 'plotly.js-dist-min';
 import { AxesNorms, Side, View } from '@shared/types/plot.types';
 import { Distance, GetSectionOutput } from '@services/worker_python/tasks/types';
 import { createLoadAnnotations } from './createLoadAnnotations';
@@ -74,15 +74,26 @@ const createScene = (
   plotParams: CreatePlotParams,
   distanceAnnotations: Partial<Plotly.Annotations>[]
 ): Partial<Layout['scene']> => {
-  const baseCamera = plotParams.camera ?? normalCamera();
-  const y = Math.abs(baseCamera.eye?.y || 0);
-  const camera: Partial<Camera> = {
-    ...baseCamera,
-    eye: {
-      ...baseCamera.eye,
-      y: plotParams.invert ? y : y * -1
-    }
-  };
+  // On initial render (camera === null), apply the default camera with the invert
+  // flip so the scene faces the correct direction. On subsequent renders, pass the
+  // live interactive camera UNMODIFIED so Plotly's stored layout camera always
+  // matches the user's current view. This prevents any modebar viewport operation
+  // from resetting to a stale or default camera value.
+  let sceneCamera: Partial<Camera>;
+  if (plotParams.camera === null) {
+    const base = normalCamera();
+    const y = Math.abs(base.eye?.y || 0);
+    sceneCamera = {
+      ...base,
+      eye: {
+        ...base.eye,
+        y: plotParams.invert ? y : y * -1
+      }
+    };
+  } else {
+    sceneCamera = plotParams.camera;
+  }
+
   return {
     aspectmode:
       plotParams.axesNorms?.aspectMode &&
@@ -104,27 +115,80 @@ const createScene = (
       ...createObstaclesAnnotations(plotParams),
       ...distanceAnnotations
     ],
-    camera
+    camera: sceneCamera
   };
 };
 
-const config = {
-  displayModeBar: true,
-  displaylogo: false,
-  fillFrame: false,
-  responsive: true,
-  modeBarButtonsToRemove: [
-    'lasso2d',
-    'select2d',
-    'sendDataToCloud',
-    'hoverClosestCartesian',
-    'hoverCompareCartesian',
-    'resetLastSave',
-    'autoScale2d',
-    'resetCameraDefault3d',
-    'resetCameraLastSave3d',
-    'resetScale2d'
-  ] as ModeBarDefaultButtons[]
+/**
+ * Builds the Plotly config including custom orbit/turntable modebar buttons.
+ * Defined as a function so that `Plotly.Icons` is accessed at call-time
+ * rather than at module-evaluation time (which breaks test mocks).
+ */
+const getConfig = () => {
+  /**
+   * Switches the 3D scene dragmode by directly setting the internal
+   * orbit-camera-controller mode. This bypasses Plotly.relayout and its
+   * updateFx() which forces camera.up = [0,0,1] on turntable switch,
+   * causing an unwanted camera/zoom reset.
+   */
+  const setDragmodeDirect = (gd: Plotly.PlotlyHTMLElement, mode: string): void => {
+    const gdInternal = gd as unknown as {
+      layout?: { scene?: { dragmode?: string } };
+      _fullLayout?: { scene?: { dragmode?: string; _scene?: { camera?: { mode?: string; keyBindingMode?: string } } } };
+    };
+    const scene = gdInternal._fullLayout?.scene;
+    if (scene?._scene?.camera) {
+      scene._scene.camera.mode = mode;
+      scene._scene.camera.keyBindingMode = 'rotate';
+    }
+    // Update layout objects so uirevision preserves the mode across Plotly.react calls
+    if (scene) {
+      scene.dragmode = mode;
+    }
+    if (gdInternal.layout?.scene) {
+      gdInternal.layout.scene.dragmode = mode;
+    }
+  };
+
+  const orbitButton: ModeBarButton = {
+    name: 'customOrbitRotation',
+    title: $localize`Orbital rotation`,
+    icon: Plotly.Icons['3d_rotate'] as Icon,
+    click: (gd) => {
+      setDragmodeDirect(gd, 'orbit');
+    }
+  };
+
+  const turntableButton: ModeBarButton = {
+    name: 'customTurntableRotation',
+    title: $localize`Turntable rotation`,
+    icon: Plotly.Icons['z-axis'] as Icon,
+    click: (gd) => {
+      setDragmodeDirect(gd, 'turntable');
+    }
+  };
+
+  return {
+    displayModeBar: true,
+    displaylogo: false,
+    fillFrame: false,
+    responsive: true,
+    modeBarButtonsToRemove: [
+      'lasso2d',
+      'select2d',
+      'sendDataToCloud',
+      'hoverClosestCartesian',
+      'hoverCompareCartesian',
+      'resetLastSave',
+      'autoScale2d',
+      'resetCameraDefault3d',
+      'resetCameraLastSave3d',
+      'resetScale2d',
+      'orbitRotation',
+      'tableRotation'
+    ] as ModeBarDefaultButtons[],
+    modeBarButtonsToAdd: [orbitButton, turntableButton]
+  };
 };
 
 const layout3d = (
@@ -133,12 +197,12 @@ const layout3d = (
 ): Partial<Layout> => ({
   autosize: true,
   showlegend: false,
-  // uirevision controls whether Plotly preserves user-driven camera interactions.
-  // When a camera is set (user has moved it), keep uirevision stable so Plotly
-  // ignores the camera value in the layout and preserves the interactive position.
-  // When camera is null (initial render or explicit reset), use a unique value so
-  // Plotly applies normalCamera() from the layout.
-  uirevision: plotParams.camera === null ? String(Date.now()) : 'stable',
+  // Keep uirevision constant so Plotly never resets user-driven camera state.
+  // On the very first render the plot element doesn't exist yet, so Plotly creates
+  // it from scratch and applies the layout camera regardless of uirevision.
+  // On subsequent Plotly.react() calls (e.g. after a slider change), the same
+  // uirevision tells Plotly to preserve the interactive camera position.
+  uirevision: 'stable',
   margin: {
     l: 0,
     r: 0,
@@ -240,7 +304,7 @@ export const createPlot = (plotParams: CreatePlotParams) => {
 
   // Use Plotly.react to update data without resetting camera/zoom
   // It will create the plot if it doesn't exist, or update it if it does
-  return Plotly.react(plotParams.plotId, allData, baseLayout, config);
+  return Plotly.react(plotParams.plotId, allData, baseLayout, getConfig());
 };
 
 /**

--- a/src/app/shared/components/studio/section/section-plot.component.spec.ts
+++ b/src/app/shared/components/studio/section/section-plot.component.spec.ts
@@ -973,6 +973,50 @@ describe('SectionPlotComponent', () => {
     });
   });
 
+  describe('addEventListenersToPlot — plotly_relayout camera filtering', () => {
+    let capturedRelayoutHandler: ((eventData: Record<string, unknown>) => void) | null = null;
+
+    const makePlotCapturingRelayout = () => {
+      capturedRelayoutHandler = null;
+      return {
+        removeAllListeners: vi.fn(),
+        on: (event: string, fn: (eventData: Record<string, unknown>) => void) => {
+          if (event === 'plotly_relayout') {
+            capturedRelayoutHandler = fn;
+          }
+        }
+      } as unknown as PlotlyHTMLElement;
+    };
+
+    it('should not call refreshCamera when relayout event has no camera key', () => {
+      component.addEventListenersToPlot(makePlotCapturingRelayout());
+      capturedRelayoutHandler!({ 'scene.dragmode': 'orbit' });
+
+      expect(plotOptionsServiceMock.refreshCamera).not.toHaveBeenCalled();
+    });
+
+    it('should call refreshCamera when relayout event contains a scene.camera key', () => {
+      component.addEventListenersToPlot(makePlotCapturingRelayout());
+      capturedRelayoutHandler!({ 'scene.camera': { eye: { x: 1, y: 2, z: 3 } } });
+
+      expect(plotOptionsServiceMock.refreshCamera).toHaveBeenCalledTimes(1);
+    });
+
+    it('should not call refreshCamera when relayout event is empty', () => {
+      component.addEventListenersToPlot(makePlotCapturingRelayout());
+      capturedRelayoutHandler!({});
+
+      expect(plotOptionsServiceMock.refreshCamera).not.toHaveBeenCalled();
+    });
+
+    it('should call refreshCamera when relayout event contains a partial camera key', () => {
+      component.addEventListenersToPlot(makePlotCapturingRelayout());
+      capturedRelayoutHandler!({ 'scene.camera.eye.x': 1.5 });
+
+      expect(plotOptionsServiceMock.refreshCamera).toHaveBeenCalledTimes(1);
+    });
+  });
+
   describe('addEventListenersToPlot — listener cleanup', () => {
     it('should remove stale click and relayout listeners before reattaching', () => {
       const removeAllListeners = vi.fn();

--- a/src/app/shared/components/studio/section/section-plot.component.ts
+++ b/src/app/shared/components/studio/section/section-plot.component.ts
@@ -210,7 +210,7 @@ export class SectionPlotComponent implements OnDestroy {
     }
     const plotEl = plot as Plotly.PlotlyHTMLElement & {
       on(e: 'plotly_clickannotation', fn: (event: ClickAnnotationEvent) => void): void;
-      on(e: 'plotly_relayout', fn: () => void): void;
+      on(e: 'plotly_relayout', fn: (eventData: Record<string, unknown>) => void): void;
       removeAllListeners(e: string): void;
     };
     // Remove stale listeners before re-adding — the plot element is reused across refreshes,
@@ -237,8 +237,17 @@ export class SectionPlotComponent implements OnDestroy {
       }
     });
 
-    plotEl.on('plotly_relayout', () => {
-      this.plotOptionsService.refreshCamera();
+    plotEl.on('plotly_relayout', (eventData: Record<string, unknown>) => {
+      // Only synchronise the camera signal when the relayout event actually contains
+      // camera data. Clicking modebar buttons like "Orbital rotation", "Zoom", or "Pan"
+      // fires relayout with only { 'scene.dragmode': '...' }. Calling refreshCamera()
+      // on those events can read a transient or stale camera from the DOM and corrupt
+      // the camera signal, which would then change uirevision on the next react() call
+      // and cause an unwanted camera reset.
+      const hasCameraKey = Object.keys(eventData ?? {}).some((k) => k.includes('camera'));
+      if (hasCameraKey) {
+        this.plotOptionsService.refreshCamera();
+      }
     });
   };
 

--- a/src/app/shared/components/studio/section/section-plot.component.ts
+++ b/src/app/shared/components/studio/section/section-plot.component.ts
@@ -239,11 +239,10 @@ export class SectionPlotComponent implements OnDestroy {
 
     plotEl.on('plotly_relayout', (eventData: Record<string, unknown>) => {
       // Only synchronise the camera signal when the relayout event actually contains
-      // camera data. Clicking modebar buttons like "Orbital rotation", "Zoom", or "Pan"
-      // fires relayout with only { 'scene.dragmode': '...' }. Calling refreshCamera()
-      // on those events can read a transient or stale camera from the DOM and corrupt
-      // the camera signal, which would then change uirevision on the next react() call
-      // and cause an unwanted camera reset.
+      // camera data. Clicking modebar buttons like "Zoom" or "Pan" fires relayout
+      // with only { 'scene.dragmode': '...' }. Calling refreshCamera() on those
+      // events can read a transient or stale camera from the DOM and corrupt the
+      // camera signal.
       const hasCameraKey = Object.keys(eventData ?? {}).some((k) => k.includes('camera'));
       if (hasCameraKey) {
         this.plotOptionsService.refreshCamera();


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
<!-- please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes -->
- [X] Tests for the changes have been added (for bug fixes / features)

[703](https://github.com/phlowers/phlowers-stellar-app/issues/703)

<html>
<body>
<!--StartFragment--><h2 style="line-height: normal; font-size: 16.003px; font-weight: 600; margin: 1.5em 0px 0.875em; font-family: &quot;Segoe WPC&quot;, &quot;Segoe UI&quot;, sans-serif; color: rgb(246, 246, 244); font-style: normal; font-variant-ligatures: normal; font-variant-caps: normal; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; white-space: normal; background-color: rgb(38, 38, 38); text-decoration-thickness: initial; text-decoration-style: initial; text-decoration-color: initial;">Fix: Plotly 3D modebar buttons reset camera/zoom view</h2><h3 style="line-height: normal; font-size: 13px; font-weight: 600; margin: 1.5em 0px 0.875em; font-family: &quot;Segoe WPC&quot;, &quot;Segoe UI&quot;, sans-serif; color: rgb(246, 246, 244); font-style: normal; font-variant-ligatures: normal; font-variant-caps: normal; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; white-space: normal; background-color: rgb(38, 38, 38); text-decoration-thickness: initial; text-decoration-style: initial; text-decoration-color: initial;">Problem</h3><p style="margin: 0px 0px 16px; color: rgb(246, 246, 244); font-family: &quot;Segoe WPC&quot;, &quot;Segoe UI&quot;, sans-serif; font-size: 13px; font-style: normal; font-variant-ligatures: normal; font-variant-caps: normal; font-weight: 400; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; white-space: normal; background-color: rgb(38, 38, 38); text-decoration-thickness: initial; text-decoration-style: initial; text-decoration-color: initial;">In the 3D studio view, clicking any modebar button (Orbital rotation, Turntable rotation, Zoom, Pan) after zooming with the mouse wheel would reset the camera back to the default position. The issue was particularly visible in this sequence:<span> </span><strong style="font-weight: 600;">zoom → change slider → click modebar button → camera resets</strong>.</p><h3 style="line-height: normal; font-size: 13px; font-weight: 600; margin: 1.5em 0px 0.875em; font-family: &quot;Segoe WPC&quot;, &quot;Segoe UI&quot;, sans-serif; color: rgb(246, 246, 244); font-style: normal; font-variant-ligatures: normal; font-variant-caps: normal; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; white-space: normal; background-color: rgb(38, 38, 38); text-decoration-thickness: initial; text-decoration-style: initial; text-decoration-color: initial;">Root Cause</h3><p style="margin: 0px 0px 16px; color: rgb(246, 246, 244); font-family: &quot;Segoe WPC&quot;, &quot;Segoe UI&quot;, sans-serif; font-size: 13px; font-style: normal; font-variant-ligatures: normal; font-variant-caps: normal; font-weight: 400; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; white-space: normal; background-color: rgb(38, 38, 38); text-decoration-thickness: initial; text-decoration-style: initial; text-decoration-color: initial;">Three issues were combining to produce the bug:</p><ol style="padding-inline-start: 28px; color: rgb(246, 246, 244); font-family: &quot;Segoe WPC&quot;, &quot;Segoe UI&quot;, sans-serif; font-size: 13px; font-style: normal; font-variant-ligatures: normal; font-variant-caps: normal; font-weight: 400; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; white-space: normal; background-color: rgb(38, 38, 38); text-decoration-thickness: initial; text-decoration-style: initial; text-decoration-color: initial;"><li style="margin: 4px 0px;"><p style="margin: 0px;"><strong style="font-weight: 600;"><a href="vscode-file://vscode-app/c:/Users/madrangesfre/AppData/Local/Programs/Microsoft%20VS%20Code/0958016b2a/resources/app/out/vs/code/electron-browser/workbench/workbench.html" title="" draggable="true" data-href="vscode-remote://ssh-remote%2B10.132.22.159/home/infoger/phlowers-stellar-app/src/app/shared/components/studio/section/helpers/createPlot.ts#73%2C7" custom-hover="true" class="chat-inline-anchor-widget show-file-icons" style="border-color: rgba(255, 255, 255, 0.1); border-style: solid; border-width: 1.152px; border-image: none 100% / 1 / 0 stretch; border-radius: 4px; margin: 0px 1px; padding: 1px 3px; text-wrap: nowrap; width: fit-content; font-weight: 400; text-decoration: none; font-size: 11.999px; color: inherit; user-select: text;"><span class="icon-label" style="padding: 0px 3px;">createScene()</span></a><span> </span>corrupted the camera</strong><span> </span>— On every re-render, it applied<span> </span><a href="vscode-file://vscode-app/c:/Users/madrangesfre/AppData/Local/Programs/Microsoft%20VS%20Code/0958016b2a/resources/app/out/vs/code/electron-browser/workbench/workbench.html" title="" draggable="true" data-href="vscode-remote://ssh-remote%2B10.132.22.159/home/infoger/.vscode-server/cli/servers/Stable-0958016b2af9f09bb4257e0df4a95e2f90590f9f/server/extensions/node_modules/typescript/lib/lib.es2015.core.d.ts#98%2C11" custom-hover="true" class="chat-inline-anchor-widget show-file-icons" style="border-color: rgba(255, 255, 255, 0.1); border-style: solid; border-width: 1.152px; border-image: none 100% / 1 / 0 stretch; border-radius: 4px; margin: 0px 1px; padding: 1px 3px; text-wrap: nowrap; width: fit-content; font-weight: 400; text-decoration: rgb(246, 246, 244); font-size: 11.999px; color: inherit; user-select: text;"><span class="icon-label" style="padding: 0px 3px;">Math.abs(eye.y)</span></a><span> </span>+ negate to the camera, even when the user had orbited the view (changing the sign of<span> </span><a href="vscode-file://vscode-app/c:/Users/madrangesfre/AppData/Local/Programs/Microsoft%20VS%20Code/0958016b2a/resources/app/out/vs/code/electron-browser/workbench/workbench.html" title="" draggable="true" data-href="vscode-remote://ssh-remote%2B10.132.22.159/home/infoger/phlowers-stellar-app/src/app/shared/components/studio/section/helpers/createPlot.spec.ts#346%2C25" custom-hover="true" class="chat-inline-anchor-widget show-file-icons" style="border-color: rgba(255, 255, 255, 0.1); border-style: solid; border-width: 1.152px; border-image: none 100% / 1 / 0 stretch; border-radius: 4px; margin: 0px 1px; padding: 1px 3px; text-wrap: nowrap; width: fit-content; font-weight: 400; text-decoration: rgb(246, 246, 244); font-size: 11.999px; color: inherit; user-select: text;"><span class="icon-label" style="padding: 0px 3px;">eye.y</span></a>). This corrupted value was stored by Plotly as the "saved state", and modebar clicks would restore it.</p></li><li style="margin: 4px 0px;"><p style="margin: 0px;"><strong style="font-weight: 600;"><a href="vscode-file://vscode-app/c:/Users/madrangesfre/AppData/Local/Programs/Microsoft%20VS%20Code/0958016b2a/resources/app/out/vs/code/electron-browser/workbench/workbench.html" title="" draggable="true" data-href="vscode-remote://ssh-remote%2B10.132.22.159/home/infoger/phlowers-stellar-app/src/app/core/services/plot/plot-options.service.ts#75%2C3" custom-hover="true" class="chat-inline-anchor-widget show-file-icons" style="border-color: rgba(255, 255, 255, 0.1); border-style: solid; border-width: 1.152px; border-image: none 100% / 1 / 0 stretch; border-radius: 4px; margin: 0px 1px; padding: 1px 3px; text-wrap: nowrap; width: fit-content; font-weight: 400; text-decoration: none; font-size: 11.999px; color: inherit; user-select: text;"><span class="icon-label" style="padding: 0px 3px;">refreshCamera()</span></a><span> </span>called in<span> </span><a href="vscode-file://vscode-app/c:/Users/madrangesfre/AppData/Local/Programs/Microsoft%20VS%20Code/0958016b2a/resources/app/out/vs/code/electron-browser/workbench/workbench.html" title="" draggable="true" data-href="vscode-remote://ssh-remote%2B10.132.22.159/home/infoger/phlowers-stellar-app/src/app/core/services/plot/plot-options.service.ts#49%2C3" custom-hover="true" class="chat-inline-anchor-widget show-file-icons" style="border-color: rgba(255, 255, 255, 0.1); border-style: solid; border-width: 1.152px; border-image: none 100% / 1 / 0 stretch; border-radius: 4px; margin: 0px 1px; padding: 1px 3px; text-wrap: nowrap; width: fit-content; font-weight: 400; text-decoration: none; font-size: 11.999px; color: inherit; user-select: text;"><span class="icon-label" style="padding: 0px 3px;">plotOptionsChange()</span></a></strong><span> </span>— Every slider change triggered a camera signal write, which could inject a stale value into the next render cycle.</p></li><li style="margin: 4px 0px;"><p style="margin: 0px;"><strong style="font-weight: 600;">Native orbit/turntable buttons triggered<span> </span><a href="vscode-file://vscode-app/c:/Users/madrangesfre/AppData/Local/Programs/Microsoft%20VS%20Code/0958016b2a/resources/app/out/vs/code/electron-browser/workbench/workbench.html" title="" draggable="true" data-href="vscode-remote://ssh-remote%2B10.132.22.159/home/infoger/phlowers-stellar-app/node_modules/%40types/plotly.js/index.d.ts#360%2C17" custom-hover="true" class="chat-inline-anchor-widget show-file-icons" style="border-color: rgba(255, 255, 255, 0.1); border-style: solid; border-width: 1.152px; border-image: none 100% / 1 / 0 stretch; border-radius: 4px; margin: 0px 1px; padding: 1px 3px; text-wrap: nowrap; width: fit-content; font-weight: 400; text-decoration: none; font-size: 11.999px; color: inherit; user-select: text;"><span class="icon-label" style="padding: 0px 3px;">Plotly.relayout()</span></a></strong><span> </span>— This function internally calls<span> </span><code style="font-family: Consolas, &quot;Courier New&quot;, monospace; font-size: 10.998px; color: rgb(215, 186, 125); background-color: rgba(255, 255, 255, 0.1); padding: 1px 3px; border-radius: 4px; border-color: rgb(215, 186, 125); border-style: none; border-width: 0px; border-image: none 100% / 1 / 0 stretch; white-space: pre-wrap;">updateFx()</code><span> </span>which forces<span> </span><a href="vscode-file://vscode-app/c:/Users/madrangesfre/AppData/Local/Programs/Microsoft%20VS%20Code/0958016b2a/resources/app/out/vs/code/electron-browser/workbench/workbench.html" title="" draggable="true" data-href="vscode-remote://ssh-remote%2B10.132.22.159/home/infoger/phlowers-stellar-app/src/app/core/services/plot/plot-options.service.ts#38%2C12" custom-hover="true" class="chat-inline-anchor-widget show-file-icons" style="border-color: rgba(255, 255, 255, 0.1); border-style: solid; border-width: 1.152px; border-image: none 100% / 1 / 0 stretch; border-radius: 4px; margin: 0px 1px; padding: 1px 3px; text-wrap: nowrap; width: fit-content; font-weight: 400; text-decoration: rgb(246, 246, 244); font-size: 11.999px; color: inherit; user-select: text;"><span class="icon-label" style="padding: 0px 3px;">camera.up = [0,0,1]</span></a><span> </span>on turntable mode switch, causing an unwanted camera reset.</p></li></ol><h3 style="line-height: normal; font-size: 13px; font-weight: 600; margin: 1.5em 0px 0.875em; font-family: &quot;Segoe WPC&quot;, &quot;Segoe UI&quot;, sans-serif; color: rgb(246, 246, 244); font-style: normal; font-variant-ligatures: normal; font-variant-caps: normal; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; white-space: normal; background-color: rgb(38, 38, 38); text-decoration-thickness: initial; text-decoration-style: initial; text-decoration-color: initial;">Solution</h3><div class="monaco-scrollable-element rendered-markdown-table-scroll-wrapper" role="presentation" style="width: 918.018px; margin-bottom: 16px; color: rgb(246, 246, 244); font-family: &quot;Segoe WPC&quot;, &quot;Segoe UI&quot;, sans-serif; font-size: 13px; font-style: normal; font-variant-ligatures: normal; font-variant-caps: normal; font-weight: 400; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; white-space: normal; background-color: rgb(38, 38, 38); text-decoration-thickness: initial; text-decoration-style: initial; text-decoration-color: initial; position: relative; overflow: hidden;"><div style="overflow: hidden;">
Change | File | Purpose
-- | -- | --
Pass live camera unmodified | createPlot.ts → createScene() | When camera is non-null, pass it directly (no abs/negate). Only apply the invert flip on initial render (camera === null).
Always include camera in layout | createPlot.ts → createScene() | Ensures Plotly always has a valid reference camera. Prevents fallback to built-in defaults on viewport operations.
Read DOM camera before re-render | createPlot.ts → createPlot() | getLiveCamera() reads _fullLayout.scene.camera as source of truth before each Plotly.react() call.
uirevision: 'stable' | createPlot.ts → layout3d() | Constant value tells Plotly to preserve user-driven camera state across re-renders.
Custom orbit/turntable buttons | createPlot.ts → getConfig() | Replace native buttons with custom ones that set dragmode directly on the internal camera controller, bypassing Plotly.relayout() and its updateFx() reset.
Remove refreshCamera() from plotOptionsChange() | plot-options.service.ts | Slider changes no longer trigger spurious camera signal writes.
Filter plotly_relayout handler | section-plot.component.ts | Only call refreshCamera() when the event actually contains camera keys, ignoring dragmode-only events.

</div><div role="presentation" aria-hidden="true" class="invisible scrollbar horizontal" style="opacity: 0; pointer-events: none; background: none 0% 0% / auto repeat scroll padding-box border-box rgba(0, 0, 0, 0); position: absolute; width: 918px; height: 10px; left: 0px; bottom: 0px;"><div class="slider" style="background: none 0% 0% / auto repeat scroll padding-box border-box rgba(121, 121, 121, 0.4); position: absolute; top: 0px; left: 0px; height: 10px; transform: translate3d(0px, 0px, 0px); contain: strict; width: 918px;"></div></div><div role="presentation" aria-hidden="true" class="invisible scrollbar vertical" style="opacity: 0; pointer-events: none; background: none 0% 0% / auto repeat scroll padding-box border-box rgba(0, 0, 0, 0); z-index: 14; position: absolute; width: 0px; height: 387px; right: 0px; top: 0px;"><div class="slider" style="background: none 0% 0% / auto repeat scroll padding-box border-box rgba(121, 121, 121, 0.4); position: absolute; top: 0px; left: 0px; width: 10px; transform: translate3d(0px, 0px, 0px); contain: strict; height: 387px;"></div></div></div><h3 style="line-height: normal; font-size: 13px; font-weight: 600; margin: 1.5em 0px 0.875em; font-family: &quot;Segoe WPC&quot;, &quot;Segoe UI&quot;, sans-serif; color: rgb(246, 246, 244); font-style: normal; font-variant-ligatures: normal; font-variant-caps: normal; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; white-space: normal; background-color: rgb(38, 38, 38); text-decoration-thickness: initial; text-decoration-style: initial; text-decoration-color: initial;">Tests</h3><ul style="padding-inline-start: 24px; color: rgb(246, 246, 244); font-family: &quot;Segoe WPC&quot;, &quot;Segoe UI&quot;, sans-serif; font-size: 13px; font-style: normal; font-variant-ligatures: normal; font-variant-caps: normal; font-weight: 400; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; white-space: normal; background-color: rgb(38, 38, 38); text-decoration-thickness: initial; text-decoration-style: initial; text-decoration-color: initial;"><li style="margin: 4px 0px;">All 2893 existing tests pass</li><li style="margin: 4px 0px;">Updated<span> </span><a href="vscode-file://vscode-app/c:/Users/madrangesfre/AppData/Local/Programs/Microsoft%20VS%20Code/0958016b2a/resources/app/out/vs/code/electron-browser/workbench/workbench.html" title="" draggable="true" data-href="vscode-remote://ssh-remote%2B10.132.22.159/home/infoger/phlowers-stellar-app/src/app/shared/components/studio/section/helpers/createPlot.spec.ts" custom-hover="true" class="chat-inline-anchor-widget show-file-icons" style="border-color: rgba(255, 255, 255, 0.1); border-style: solid; border-width: 1.152px; border-image: none 100% / 1 / 0 stretch; border-radius: 4px; margin: 0px 1px; padding: 1px 3px; text-wrap: nowrap; width: fit-content; font-weight: 400; text-decoration: none; font-size: 11.999px; color: inherit; user-select: text;"><span class="icon file-icon helpers-name-dir-icon createplot.spec.ts-name-file-icon name-file-icon spec.ts-ext-file-icon ts-ext-file-icon ext-file-icon typescript-lang-file-icon" style="vertical-align: middle; line-height: 1em; overflow: hidden; font-size: 10.7991px; top: 0px !important;"></span><span class="icon-label" style="padding: 0px 3px;">createPlot.spec.ts</span></a><span> </span>— verifies camera is passed unmodified when non-null</li><li style="margin: 4px 0px;">Updated<span> </span><a href="vscode-file://vscode-app/c:/Users/madrangesfre/AppData/Local/Programs/Microsoft%20VS%20Code/0958016b2a/resources/app/out/vs/code/electron-browser/workbench/workbench.html" title="" draggable="true" data-href="vscode-remote://ssh-remote%2B10.132.22.159/home/infoger/phlowers-stellar-app/src/app/core/services/plot/plot-options.service.ts#63%2C11" custom-hover="true" class="chat-inline-anchor-widget show-file-icons" style="border-color: rgba(255, 255, 255, 0.1); border-style: solid; border-width: 1.152px; border-image: none 100% / 1 / 0 stretch; border-radius: 4px; margin: 0px 1px; padding: 1px 3px; text-wrap: nowrap; width: fit-content; font-weight: 400; text-decoration: none; font-size: 11.999px; color: inherit; user-select: text;"><span class="icon-label" style="padding: 0px 3px;">plot-options.service.spec.ts</span></a><span> </span>— verifies<span> </span><a href="vscode-file://vscode-app/c:/Users/madrangesfre/AppData/Local/Programs/Microsoft%20VS%20Code/0958016b2a/resources/app/out/vs/code/electron-browser/workbench/workbench.html" title="" draggable="true" data-href="vscode-remote://ssh-remote%2B10.132.22.159/home/infoger/phlowers-stellar-app/src/app/core/services/plot/plot-options.service.ts#75%2C3" custom-hover="true" class="chat-inline-anchor-widget show-file-icons" style="border-color: rgba(255, 255, 255, 0.1); border-style: solid; border-width: 1.152px; border-image: none 100% / 1 / 0 stretch; border-radius: 4px; margin: 0px 1px; padding: 1px 3px; text-wrap: nowrap; width: fit-content; font-weight: 400; text-decoration: none; font-size: 11.999px; color: inherit; user-select: text;"><span class="icon-label" style="padding: 0px 3px;">refreshCamera()</span></a><span> </span>is no longer called on option changes</li><li style="margin: 4px 0px;">Updated<span> </span><a href="vscode-file://vscode-app/c:/Users/madrangesfre/AppData/Local/Programs/Microsoft%20VS%20Code/0958016b2a/resources/app/out/vs/code/electron-browser/workbench/workbench.html" title="" draggable="true" data-href="vscode-remote://ssh-remote%2B10.132.22.159/home/infoger/phlowers-stellar-app/src/app/shared/components/studio/section/section-plot.component.ts#123%2C11" custom-hover="true" class="chat-inline-anchor-widget show-file-icons" style="border-color: rgba(255, 255, 255, 0.1); border-style: solid; border-width: 1.152px; border-image: none 100% / 1 / 0 stretch; border-radius: 4px; margin: 0px 1px; padding: 1px 3px; text-wrap: nowrap; width: fit-content; font-weight: 400; text-decoration: none; font-size: 11.999px; color: inherit; user-select: text;"><span class="icon-label" style="padding: 0px 3px;">section-plot.component.spec.ts</span></a><span> </span>— verifies<span> </span><code style="font-family: Consolas, &quot;Courier New&quot;, monospace; font-size: 10.998px; color: rgb(215, 186, 125); background-color: rgba(255, 255, 255, 0.1); padding: 1px 3px; border-radius: 4px; border-color: rgb(215, 186, 125); border-style: none; border-width: 0px; border-image: none 100% / 1 / 0 stretch; white-space: pre-wrap;">plotly_relayout</code><span> </span>handler filters non-camera events</li></ul><h3 style="line-height: normal; font-size: 13px; font-weight: 600; margin: 1.5em 0px 0.875em; font-family: &quot;Segoe WPC&quot;, &quot;Segoe UI&quot;, sans-serif; color: rgb(246, 246, 244); font-style: normal; font-variant-ligatures: normal; font-variant-caps: normal; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; white-space: normal; background-color: rgb(38, 38, 38); text-decoration-thickness: initial; text-decoration-style: initial; text-decoration-color: initial;">How to verify manually</h3><ol style="padding-inline-start: 28px; margin-bottom: 0px; color: rgb(246, 246, 244); font-family: &quot;Segoe WPC&quot;, &quot;Segoe UI&quot;, sans-serif; font-size: 13px; font-style: normal; font-variant-ligatures: normal; font-variant-caps: normal; font-weight: 400; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; white-space: normal; background-color: rgb(38, 38, 38); text-decoration-thickness: initial; text-decoration-style: initial; text-decoration-color: initial;"><li style="margin: 4px 0px;">Open Studio → 3D view</li><li style="margin: 4px 0px;">Zoom with mouse wheel + orbit/pan</li><li style="margin: 4px 0px;">Move the ngx-slider (change support range)</li><li style="margin: 4px 0px;">Click any modebar button (orbit, turntable, zoom, pan)</li></ol><!--EndFragment-->
</body>
</html>Fix: Plotly 3D modebar buttons reset camera/zoom view
Problem
In the 3D studio view, clicking any modebar button (Orbital rotation, Turntable rotation, Zoom, Pan) after zooming with the mouse wheel would reset the camera back to the default position. The issue was particularly visible in this sequence: zoom → change slider → click modebar button → camera resets.

Root Cause
Three issues were combining to produce the bug:

[createScene()](vscode-file://vscode-app/c:/Users/madrangesfre/AppData/Local/Programs/Microsoft%20VS%20Code/0958016b2a/resources/app/out/vs/code/electron-browser/workbench/workbench.html) corrupted the camera — On every re-render, it applied [Math.abs(eye.y)](vscode-file://vscode-app/c:/Users/madrangesfre/AppData/Local/Programs/Microsoft%20VS%20Code/0958016b2a/resources/app/out/vs/code/electron-browser/workbench/workbench.html) + negate to the camera, even when the user had orbited the view (changing the sign of [eye.y](vscode-file://vscode-app/c:/Users/madrangesfre/AppData/Local/Programs/Microsoft%20VS%20Code/0958016b2a/resources/app/out/vs/code/electron-browser/workbench/workbench.html)). This corrupted value was stored by Plotly as the "saved state", and modebar clicks would restore it.

[refreshCamera()](vscode-file://vscode-app/c:/Users/madrangesfre/AppData/Local/Programs/Microsoft%20VS%20Code/0958016b2a/resources/app/out/vs/code/electron-browser/workbench/workbench.html) called in [plotOptionsChange()](vscode-file://vscode-app/c:/Users/madrangesfre/AppData/Local/Programs/Microsoft%20VS%20Code/0958016b2a/resources/app/out/vs/code/electron-browser/workbench/workbench.html) — Every slider change triggered a camera signal write, which could inject a stale value into the next render cycle.

Native orbit/turntable buttons triggered [Plotly.relayout()](vscode-file://vscode-app/c:/Users/madrangesfre/AppData/Local/Programs/Microsoft%20VS%20Code/0958016b2a/resources/app/out/vs/code/electron-browser/workbench/workbench.html) — This function internally calls updateFx() which forces [camera.up = [0,0,1]](vscode-file://vscode-app/c:/Users/madrangesfre/AppData/Local/Programs/Microsoft%20VS%20Code/0958016b2a/resources/app/out/vs/code/electron-browser/workbench/workbench.html) on turntable mode switch, causing an unwanted camera reset.

Solution
Change	File	Purpose
Pass live camera unmodified	[createPlot.ts](vscode-file://vscode-app/c:/Users/madrangesfre/AppData/Local/Programs/Microsoft%20VS%20Code/0958016b2a/resources/app/out/vs/code/electron-browser/workbench/workbench.html) → [createScene()](vscode-file://vscode-app/c:/Users/madrangesfre/AppData/Local/Programs/Microsoft%20VS%20Code/0958016b2a/resources/app/out/vs/code/electron-browser/workbench/workbench.html)	When camera is non-null, pass it directly (no abs/negate). Only apply the invert flip on initial render (camera === null).
Always include camera in layout	[createPlot.ts](vscode-file://vscode-app/c:/Users/madrangesfre/AppData/Local/Programs/Microsoft%20VS%20Code/0958016b2a/resources/app/out/vs/code/electron-browser/workbench/workbench.html) → [createScene()](vscode-file://vscode-app/c:/Users/madrangesfre/AppData/Local/Programs/Microsoft%20VS%20Code/0958016b2a/resources/app/out/vs/code/electron-browser/workbench/workbench.html)	Ensures Plotly always has a valid reference camera. Prevents fallback to built-in defaults on viewport operations.
Read DOM camera before re-render	[createPlot.ts](vscode-file://vscode-app/c:/Users/madrangesfre/AppData/Local/Programs/Microsoft%20VS%20Code/0958016b2a/resources/app/out/vs/code/electron-browser/workbench/workbench.html) → [createPlot()](vscode-file://vscode-app/c:/Users/madrangesfre/AppData/Local/Programs/Microsoft%20VS%20Code/0958016b2a/resources/app/out/vs/code/electron-browser/workbench/workbench.html)	[getLiveCamera()](vscode-file://vscode-app/c:/Users/madrangesfre/AppData/Local/Programs/Microsoft%20VS%20Code/0958016b2a/resources/app/out/vs/code/electron-browser/workbench/workbench.html) reads [_fullLayout.scene.camera](vscode-file://vscode-app/c:/Users/madrangesfre/AppData/Local/Programs/Microsoft%20VS%20Code/0958016b2a/resources/app/out/vs/code/electron-browser/workbench/workbench.html) as source of truth before each [Plotly.react()](vscode-file://vscode-app/c:/Users/madrangesfre/AppData/Local/Programs/Microsoft%20VS%20Code/0958016b2a/resources/app/out/vs/code/electron-browser/workbench/workbench.html) call.
[uirevision: 'stable'](vscode-file://vscode-app/c:/Users/madrangesfre/AppData/Local/Programs/Microsoft%20VS%20Code/0958016b2a/resources/app/out/vs/code/electron-browser/workbench/workbench.html)	[createPlot.ts](vscode-file://vscode-app/c:/Users/madrangesfre/AppData/Local/Programs/Microsoft%20VS%20Code/0958016b2a/resources/app/out/vs/code/electron-browser/workbench/workbench.html) → [layout3d()](vscode-file://vscode-app/c:/Users/madrangesfre/AppData/Local/Programs/Microsoft%20VS%20Code/0958016b2a/resources/app/out/vs/code/electron-browser/workbench/workbench.html)	Constant value tells Plotly to preserve user-driven camera state across re-renders.
Custom orbit/turntable buttons	[createPlot.ts](vscode-file://vscode-app/c:/Users/madrangesfre/AppData/Local/Programs/Microsoft%20VS%20Code/0958016b2a/resources/app/out/vs/code/electron-browser/workbench/workbench.html) → [getConfig()](vscode-file://vscode-app/c:/Users/madrangesfre/AppData/Local/Programs/Microsoft%20VS%20Code/0958016b2a/resources/app/out/vs/code/electron-browser/workbench/workbench.html)	Replace native buttons with custom ones that set dragmode directly on the internal camera controller, bypassing [Plotly.relayout()](vscode-file://vscode-app/c:/Users/madrangesfre/AppData/Local/Programs/Microsoft%20VS%20Code/0958016b2a/resources/app/out/vs/code/electron-browser/workbench/workbench.html) and its updateFx() reset.
Remove [refreshCamera()](vscode-file://vscode-app/c:/Users/madrangesfre/AppData/Local/Programs/Microsoft%20VS%20Code/0958016b2a/resources/app/out/vs/code/electron-browser/workbench/workbench.html) from [plotOptionsChange()](vscode-file://vscode-app/c:/Users/madrangesfre/AppData/Local/Programs/Microsoft%20VS%20Code/0958016b2a/resources/app/out/vs/code/electron-browser/workbench/workbench.html)	[plot-options.service.ts](vscode-file://vscode-app/c:/Users/madrangesfre/AppData/Local/Programs/Microsoft%20VS%20Code/0958016b2a/resources/app/out/vs/code/electron-browser/workbench/workbench.html)	Slider changes no longer trigger spurious camera signal writes.
Filter plotly_relayout handler	[section-plot.component.ts](vscode-file://vscode-app/c:/Users/madrangesfre/AppData/Local/Programs/Microsoft%20VS%20Code/0958016b2a/resources/app/out/vs/code/electron-browser/workbench/workbench.html)	Only call [refreshCamera()](vscode-file://vscode-app/c:/Users/madrangesfre/AppData/Local/Programs/Microsoft%20VS%20Code/0958016b2a/resources/app/out/vs/code/electron-browser/workbench/workbench.html) when the event actually contains camera keys, ignoring dragmode-only events.

Tests
All 2893 existing tests pass
Updated [createPlot.spec.ts](vscode-file://vscode-app/c:/Users/madrangesfre/AppData/Local/Programs/Microsoft%20VS%20Code/0958016b2a/resources/app/out/vs/code/electron-browser/workbench/workbench.html) — verifies camera is passed unmodified when non-null
Updated [plot-options.service.spec.ts](vscode-file://vscode-app/c:/Users/madrangesfre/AppData/Local/Programs/Microsoft%20VS%20Code/0958016b2a/resources/app/out/vs/code/electron-browser/workbench/workbench.html) — verifies [refreshCamera()](vscode-file://vscode-app/c:/Users/madrangesfre/AppData/Local/Programs/Microsoft%20VS%20Code/0958016b2a/resources/app/out/vs/code/electron-browser/workbench/workbench.html) is no longer called on option changes
Updated [section-plot.component.spec.ts](vscode-file://vscode-app/c:/Users/madrangesfre/AppData/Local/Programs/Microsoft%20VS%20Code/0958016b2a/resources/app/out/vs/code/electron-browser/workbench/workbench.html) — verifies plotly_relayout handler filters non-camera events

How to verify manually

- Open Studio → 3D view
- Zoom with mouse wheel + orbit/pan
- Move the ngx-slider (change support range)
- Click any modebar button (orbit, turntable, zoom, pan)
- Expected: Camera position stays unchanged
