### PR TITLE
Managment annotations

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -134,10 +134,24 @@ File: `src/app/shared/components/studio/section/helpers/createPlot.ts` — `getC
 
 ### Studio section plot — annotations
 
-For clickable icon annotations (FontAwesome icon + arrow), **never build the annotation object manually**.  
+**Never build a clickable icon annotation (FontAwesome icon + arrow) manually.**  
 Always use `buildClickableIconAnnotation` from `@shared/components/studio/section/helpers/createClickableIconAnnotation`.
 
-Exception: obstacle annotations (`obstacles.ts`) use a different model (no arrow, Unicode symbols, dynamic colors) and must **not** use this helper.
+```typescript
+import { buildClickableIconAnnotation } from '@shared/components/studio/section/helpers/createClickableIconAnnotation';
+
+buildClickableIconAnnotation({
+  x, y, z,
+  icon: '&#xf5cd;',   // FontAwesome HTML entity
+  color: '#4A355A',
+  arrowYOffset: -50,
+  arrowXOffset: 0,        // optional, defaults to 0
+  data: { type: 'myType', uuid: '...' }  // payload for plotly_clickannotation
+});
+```
+
+Applies to: span load annotations, cable modification annotations, and any new clickable icon annotation on the studio section plot.  
+**Exception:** obstacle annotations use a different rendering model (Unicode markers + label, `showarrow: false`) and must NOT use this helper.
 
 ---
 

--- a/src/app/shared/components/studio/section/helpers/createCableModificationAnnotations.constantes.ts
+++ b/src/app/shared/components/studio/section/helpers/createCableModificationAnnotations.constantes.ts
@@ -4,9 +4,9 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/.
  */
+import { ANNOTATION_COLOR } from './studio-annotations.tokens';
 
-/** Color of the cable modification annotation (matches the loads palette). */
-export const CABLE_MOD_COLOR = '#4A355A';
+export { ANNOTATION_COLOR as CABLE_MOD_COLOR };
 
 /**
  * FontAwesome glyph for the cable modification annotation.
@@ -21,7 +21,7 @@ export const CABLE_MOD_ICON = '&#xe4ba;';
  * Kept at `0` (same as the load annotation) so the icon stays vertically
  * aligned with its anchor point on the cable polyline.
  */
-export const CABLE_MOD_AX_OFFSET = 0;
+export const CABLE_MOD_ARROW_X_OFFSET = 0;
 
 /**
  * Vertical pixel offset applied to the annotation's arrow tail (`ay`).
@@ -34,7 +34,7 @@ export const CABLE_MOD_AX_OFFSET = 0;
  * drawn by Plotly exactly like for the load annotation, giving a coherent
  * visual style.
  */
-export const CABLE_MOD_AY_OFFSET = -90;
+export const CABLE_MOD_ARROW_Y_OFFSET = -90;
 
 /**
  * Vertical pixel offset applied to the modification label

--- a/src/app/shared/components/studio/section/helpers/createCableModificationAnnotations.spec.ts
+++ b/src/app/shared/components/studio/section/helpers/createCableModificationAnnotations.spec.ts
@@ -9,8 +9,8 @@ import type * as Plotly from 'plotly.js-dist-min';
 import { CableModification } from '@shared/domain';
 import { createCableModificationAnnotations } from './createCableModificationAnnotations';
 import {
-  CABLE_MOD_AX_OFFSET,
-  CABLE_MOD_AY_OFFSET,
+  CABLE_MOD_ARROW_X_OFFSET,
+  CABLE_MOD_ARROW_Y_OFFSET,
   CABLE_MOD_ICON,
   CABLE_MOD_LABEL_Y_SHIFT,
   getCableModificationLabel
@@ -242,8 +242,8 @@ describe('createCableModificationAnnotations', () => {
       expect(icon.showarrow).toBe(true);
       expect(icon.arrowhead).toBe(0);
       expect(icon.arrowwidth).toBe(1);
-      expect(icon.ax).toBe(CABLE_MOD_AX_OFFSET);
-      expect(icon.ay).toBe(CABLE_MOD_AY_OFFSET);
+      expect(icon.ax).toBe(CABLE_MOD_ARROW_X_OFFSET);
+      expect(icon.ay).toBe(CABLE_MOD_ARROW_Y_OFFSET);
       expect(icon.captureevents).toBe(true);
     });
 
@@ -298,7 +298,7 @@ describe('createCableModificationAnnotations', () => {
       expect(label.captureevents).toBe(false);
       expect(label.yshift).toBe(CABLE_MOD_LABEL_Y_SHIFT);
       // |ay| = 90, label yshift = 110 → label sits above the icon.
-      expect((label.yshift as number) > Math.abs(CABLE_MOD_AY_OFFSET)).toBe(true);
+      expect((label.yshift as number) > Math.abs(CABLE_MOD_ARROW_Y_OFFSET)).toBe(true);
     });
 
     it('should anchor the label on the same data point as the icon', () => {

--- a/src/app/shared/components/studio/section/helpers/createCableModificationAnnotations.ts
+++ b/src/app/shared/components/studio/section/helpers/createCableModificationAnnotations.ts
@@ -7,45 +7,15 @@
 import * as Plotly from 'plotly.js-dist-min';
 import { CableModification } from '@shared/domain';
 import { CreatePlotParams } from './createPlot';
-import { CableModificationAnnotationData } from './createCableModificationAnnotations.interfaces';
 import {
-  CABLE_MOD_AX_OFFSET,
-  CABLE_MOD_AY_OFFSET,
+  CABLE_MOD_ARROW_X_OFFSET,
+  CABLE_MOD_ARROW_Y_OFFSET,
   CABLE_MOD_COLOR,
   CABLE_MOD_ICON,
   CABLE_MOD_LABEL_Y_SHIFT,
   getCableModificationLabel
 } from './createCableModificationAnnotations.constantes';
-
-/**
- * Base Plotly annotation shape for the cable modification icon.
- *
- * @remarks
- * Mirrors `createLoadAnnotations`' base annotation (same `xref`, `yref`,
- * `arrowhead`, `arrowcolor`, `borderpad`, `bgcolor`, `font`, `arrowwidth`)
- * for visual consistency. Only `ay` differs (`-90` vs `-50`) so the icon
- * sits clearly above the load icon when both anchor on the same point.
- */
-const BASE_ICON_ANNOTATION: Partial<Plotly.Annotations> = {
-  xref: 'x' as const,
-  yref: 'y' as const,
-  ax: CABLE_MOD_AX_OFFSET,
-  ay: CABLE_MOD_AY_OFFSET,
-  showarrow: true,
-  arrowhead: 0,
-  startarrowhead: 6,
-  arrowcolor: CABLE_MOD_COLOR,
-  captureevents: true,
-  bordercolor: CABLE_MOD_COLOR,
-  borderpad: 6,
-  bgcolor: 'rgba(0,0,0,0)',
-  font: {
-    family: 'FontAwesome',
-    color: CABLE_MOD_COLOR,
-    size: 8
-  },
-  arrowwidth: 1
-};
+import { buildClickableIconAnnotation } from './createClickableIconAnnotation';
 
 /**
  * Returns the 3D point on a span polyline whose horizontal abscissa
@@ -84,7 +54,7 @@ const findPointAtAbscissa = (polyline: number[][] | undefined, targetX: number):
   }
   // Clamp: pick the endpoint whose x is closest to targetX.
   const first = polyline[0];
-  const last = polyline[polyline.length - 1];
+  const last = polyline.at(-1)!;
   return Math.abs(targetX - first[0]) <= Math.abs(targetX - last[0]) ? first : last;
 };
 
@@ -112,7 +82,7 @@ const resolveAnchorCoord = (
 
   const distance = Math.max(0, modification.distanceSupportRef);
   const leftX = polyline[0][0];
-  const rightX = polyline[polyline.length - 1][0];
+  const rightX = polyline.at(-1)![0];
   // Line direction sign: +1 when x increases from left to right, -1 otherwise.
   const direction = rightX >= leftX ? 1 : -1;
   const targetX = modification.supportRef === 'LEFT' ? leftX + direction * distance : rightX - direction * distance;
@@ -143,19 +113,20 @@ const buildIconAnnotation = (
   side: CreatePlotParams['side']
 ): Partial<Plotly.Annotations> => {
   const mapped = mapAnchorToAxes(anchor, view, side);
-  return {
-    ...BASE_ICON_ANNOTATION,
-    x: mapped.x,
-    y: mapped.y,
-    // z and data are non-standard Plotly annotation properties used for 3D rendering and event handling
-    z: mapped.z,
-    text: CABLE_MOD_ICON,
+  return buildClickableIconAnnotation({
+    arrowTipX: mapped.x,
+    arrowTipY: mapped.y,
+    arrowTipZ: mapped.z,
+    icon: CABLE_MOD_ICON,
+    color: CABLE_MOD_COLOR,
+    arrowYOffset: CABLE_MOD_ARROW_Y_OFFSET,
+    arrowXOffset: CABLE_MOD_ARROW_X_OFFSET,
     data: {
       type: 'cableModification',
       spanUuid: modification.spanUuid,
       cableModificationUuid: modification.uuid
-    } as CableModificationAnnotationData
-  } as Partial<Plotly.Annotations>;
+    }
+  });
 };
 
 /**
@@ -179,7 +150,7 @@ const buildLabelAnnotation = (
     // z is a non-standard Plotly annotation property used for 3D rendering
     z: mapped.z,
     showarrow: false,
-    xshift: CABLE_MOD_AX_OFFSET,
+    xshift: CABLE_MOD_ARROW_X_OFFSET,
     yshift: CABLE_MOD_LABEL_Y_SHIFT,
     text: getCableModificationLabel(modification.widthCable),
     captureevents: false,
@@ -234,8 +205,10 @@ export const createCableModificationAnnotations = (
     const anchor = resolveAnchorCoord(plotParams, absoluteSpanIndex, modification);
     if (!anchor) return;
 
-    annotations.push(buildIconAnnotation(anchor, modification, view, side));
-    annotations.push(buildLabelAnnotation(anchor, modification, view, side));
+    annotations.push(
+      buildIconAnnotation(anchor, modification, view, side),
+      buildLabelAnnotation(anchor, modification, view, side)
+    );
   });
 
   return annotations;

--- a/src/app/shared/components/studio/section/helpers/createClickableIconAnnotation.interfaces.ts
+++ b/src/app/shared/components/studio/section/helpers/createClickableIconAnnotation.interfaces.ts
@@ -1,0 +1,29 @@
+/**
+ * Parameters required to build a clickable FontAwesome-icon annotation with an arrow line
+ * on a Plotly studio section plot.
+ * @category Studio
+ */
+export interface ClickableIconAnnotationParams {
+  /** X coordinate on the plot axes. */
+  arrowTipX: number;
+  /** Y coordinate on the plot axes. */
+  arrowTipY: number;
+  /** Z coordinate (non-standard Plotly property used for 3D rendering). */
+  arrowTipZ: number;
+  /** FontAwesome glyph as an HTML entity string (e.g. `'&#xf5cd;'`). */
+  icon: string;
+  /** Color applied to the icon, arrow line, and border. */
+  color: string;
+  /**
+   * Vertical pixel offset of the annotation icon above its anchor point.
+   * Negative values move the icon upward (e.g. `-50` for load icons, `-90` for cable-mod icons).
+   */
+  arrowYOffset: number;
+  /**
+   * Horizontal pixel offset of the annotation icon from its anchor point.
+   * Defaults to `0` when omitted.
+   */
+  arrowXOffset?: number;
+  /** Arbitrary data payload attached to the annotation for `plotly_clickannotation` event handling. */
+  data: Record<string, unknown>;
+}

--- a/src/app/shared/components/studio/section/helpers/createClickableIconAnnotation.spec.ts
+++ b/src/app/shared/components/studio/section/helpers/createClickableIconAnnotation.spec.ts
@@ -1,0 +1,147 @@
+import { describe, it, expect } from 'vitest';
+import { buildClickableIconAnnotation } from './createClickableIconAnnotation';
+import { ClickableIconAnnotationParams } from './createClickableIconAnnotation.interfaces';
+
+type AnnotationWithExtras = ReturnType<typeof buildClickableIconAnnotation> & {
+  z?: number;
+  data?: Record<string, unknown>;
+};
+
+const makeParams = (overrides: Partial<ClickableIconAnnotationParams> = {}): ClickableIconAnnotationParams => ({
+  arrowTipX: 1,
+  arrowTipY: 2,
+  arrowTipZ: 3,
+  icon: '&#xf5cd;',
+  color: '#4A355A',
+  arrowYOffset: -50,
+  data: { type: 'spanLoad', supportUuid: 'uuid-1' },
+  ...overrides
+});
+
+describe('buildClickableIconAnnotation', () => {
+  describe('structural fixed fields', () => {
+    it('should set xref and yref to data-space coordinates', () => {
+      const result = buildClickableIconAnnotation(makeParams());
+      expect(result.xref).toBe('x');
+      expect(result.yref).toBe('y');
+    });
+
+    it('should set showarrow to true', () => {
+      const result = buildClickableIconAnnotation(makeParams());
+      expect(result.showarrow).toBe(true);
+    });
+
+    it('should set arrowhead to 0 (no arrowhead on the cable end)', () => {
+      const result = buildClickableIconAnnotation(makeParams());
+      expect(result.arrowhead).toBe(0);
+    });
+
+    it('should set startarrowhead to 6 (filled arrowhead on the icon end)', () => {
+      const result = buildClickableIconAnnotation(makeParams());
+      expect(result.startarrowhead).toBe(6);
+    });
+
+    it('should set arrowwidth to 1', () => {
+      const result = buildClickableIconAnnotation(makeParams());
+      expect(result.arrowwidth).toBe(1);
+    });
+
+    it('should set captureevents to true so the annotation is clickable', () => {
+      const result = buildClickableIconAnnotation(makeParams());
+      expect(result.captureevents).toBe(true);
+    });
+
+    it('should set borderpad to 6', () => {
+      const result = buildClickableIconAnnotation(makeParams());
+      expect(result.borderpad).toBe(6);
+    });
+
+    it('should set bgcolor to transparent', () => {
+      const result = buildClickableIconAnnotation(makeParams());
+      expect(result.bgcolor).toBe('rgba(0,0,0,0)');
+    });
+
+    it('should set font.family to FontAwesome', () => {
+      const result = buildClickableIconAnnotation(makeParams());
+      expect(result.font?.family).toBe('FontAwesome');
+    });
+
+    it('should set font.size to 8', () => {
+      const result = buildClickableIconAnnotation(makeParams());
+      expect(result.font?.size).toBe(8);
+    });
+  });
+
+  describe('position parameters', () => {
+    it('should set x, y from params', () => {
+      const result = buildClickableIconAnnotation(makeParams({ arrowTipX: 10, arrowTipY: 20 }));
+      expect(result.x).toBe(10);
+      expect(result.y).toBe(20);
+    });
+
+    it('should set z (non-standard 3D property) from params', () => {
+      const result = buildClickableIconAnnotation(makeParams({ arrowTipZ: 42 })) as AnnotationWithExtras;
+      expect(result.z).toBe(42);
+    });
+  });
+
+  describe('offset parameters', () => {
+    it('should set ay from arrowYOffset', () => {
+      const result = buildClickableIconAnnotation(makeParams({ arrowYOffset: -90 }));
+      expect(result.ay).toBe(-90);
+    });
+
+    it('should default ax to 0 when arrowXOffset is omitted', () => {
+      const params = makeParams();
+      delete params.arrowXOffset;
+      const result = buildClickableIconAnnotation(params);
+      expect(result.ax).toBe(0);
+    });
+
+    it('should set ax from arrowXOffset when provided', () => {
+      const result = buildClickableIconAnnotation(makeParams({ arrowXOffset: 15 }));
+      expect(result.ax).toBe(15);
+    });
+
+    it('should set ax to 0 when arrowXOffset is explicitly 0', () => {
+      const result = buildClickableIconAnnotation(makeParams({ arrowXOffset: 0 }));
+      expect(result.ax).toBe(0);
+    });
+  });
+
+  describe('color propagation', () => {
+    it('should propagate color to arrowcolor', () => {
+      const result = buildClickableIconAnnotation(makeParams({ color: '#ff0000' }));
+      expect(result.arrowcolor).toBe('#ff0000');
+    });
+
+    it('should propagate color to bordercolor', () => {
+      const result = buildClickableIconAnnotation(makeParams({ color: '#ff0000' }));
+      expect(result.bordercolor).toBe('#ff0000');
+    });
+
+    it('should propagate color to font.color', () => {
+      const result = buildClickableIconAnnotation(makeParams({ color: '#ff0000' }));
+      expect(result.font?.color).toBe('#ff0000');
+    });
+  });
+
+  describe('icon and data payload', () => {
+    it('should set text from icon param', () => {
+      const result = buildClickableIconAnnotation(makeParams({ icon: '&#xe4ba;' }));
+      expect(result.text).toBe('&#xe4ba;');
+    });
+
+    it('should attach the data payload as-is', () => {
+      const data = { type: 'cableModification', spanUuid: 'span-1', cableModificationUuid: 'mod-1' };
+      const result = buildClickableIconAnnotation(makeParams({ data })) as AnnotationWithExtras;
+      expect(result.data).toEqual(data);
+    });
+
+    it('should preserve all fields in an arbitrary data payload', () => {
+      const data = { type: 'obstacle', obstacleUuid: 'obs-1', obstaclePositionIndex: 2 };
+      const result = buildClickableIconAnnotation(makeParams({ data })) as AnnotationWithExtras;
+      expect(result.data).toStrictEqual(data);
+    });
+  });
+});

--- a/src/app/shared/components/studio/section/helpers/createClickableIconAnnotation.ts
+++ b/src/app/shared/components/studio/section/helpers/createClickableIconAnnotation.ts
@@ -1,0 +1,45 @@
+import * as Plotly from 'plotly.js-dist-min';
+import { ClickableIconAnnotationParams } from './createClickableIconAnnotation.interfaces';
+
+/**
+ * Builds a Plotly annotation representing a clickable FontAwesome icon with an arrow line
+ * connecting it to an anchor point on the plot.
+ *
+ * @remarks
+ * Encapsulates the shared visual structure common to all clickable icon annotations on the
+ * studio section plot (span loads, cable modifications). The `data` payload is attached to
+ * the annotation so that the `plotly_clickannotation` event handler can identify which
+ * feature was clicked via the discriminated `type` field.
+ *
+ * Pure function — no Angular DI, no side effects.
+ *
+ * @category Studio
+ * @param params - Position, icon, color, offsets and click data for the annotation.
+ * @returns A partial `Plotly.Annotations` object ready to pass to `newPlot` or `react`.
+ */
+export const buildClickableIconAnnotation = (params: ClickableIconAnnotationParams): Partial<Plotly.Annotations> =>
+  ({
+    xref: 'x' as const,
+    yref: 'y' as const,
+    x: params.arrowTipX, // arrow tip — data coordinates
+    y: params.arrowTipY, // arrow tip — data coordinates
+    z: params.arrowTipZ, // arrow tip — non-standard Plotly property for 3D rendering
+    ax: params.arrowXOffset ?? 0, // icon position — horizontal pixel offset from tip
+    ay: params.arrowYOffset, // icon position — vertical pixel offset from tip (negative = above)
+    text: params.icon,
+    showarrow: true,
+    arrowhead: 0,
+    startarrowhead: 6,
+    arrowcolor: params.color,
+    captureevents: true,
+    bordercolor: params.color,
+    borderpad: 6,
+    bgcolor: 'rgba(0,0,0,0)',
+    font: {
+      family: 'FontAwesome',
+      color: params.color,
+      size: 8
+    },
+    arrowwidth: 1,
+    data: params.data
+  }) as Partial<Plotly.Annotations>;

--- a/src/app/shared/components/studio/section/helpers/createLoadAnnotations.constantes.ts
+++ b/src/app/shared/components/studio/section/helpers/createLoadAnnotations.constantes.ts
@@ -1,0 +1,27 @@
+/**
+ * Copyright (c) 2025, RTE (http://www.rte-france.com)
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+import { ANNOTATION_COLOR } from './studio-annotations.tokens';
+
+export { ANNOTATION_COLOR as LOAD_COLOR };
+
+/**
+ * FontAwesome glyph for a punctual span load annotation.
+ * `location-dot` from FontAwesome Free 6+ Solid (unicode `f5cd`).
+ */
+export const LOAD_ICON = '&#xf5cd;';
+
+/**
+ * FontAwesome glyph for a marking span load annotation.
+ * `thumbtack` from FontAwesome Free 6+ Solid (unicode `f08d`).
+ */
+export const MARKING_ICON = '&#xf08d;';
+
+/**
+ * Vertical pixel offset applied to the load annotation icon above its anchor (`ay`).
+ * Negative value moves the icon upward (50 px above the anchor point on the cable).
+ */
+export const LOAD_ARROW_Y_OFFSET = -50;

--- a/src/app/shared/components/studio/section/helpers/createLoadAnnotations.spec.ts
+++ b/src/app/shared/components/studio/section/helpers/createLoadAnnotations.spec.ts
@@ -1,0 +1,209 @@
+import { describe, it, expect } from 'vitest';
+import type * as Plotly from 'plotly.js-dist-min';
+import { createLoadAnnotations, LoadType, SpanLoadAnnotationData } from './createLoadAnnotations';
+import { CreatePlotParams } from './createPlot';
+import { SpanLoad } from '@shared/domain';
+import { LOAD_COLOR, LOAD_ICON, MARKING_ICON } from './createLoadAnnotations.constantes';
+
+type AnnotationWithExtras = Partial<Plotly.Annotations> & {
+  z?: number;
+  data?: SpanLoadAnnotationData;
+};
+
+const makeSpanLoad = (overrides: Partial<SpanLoad> = {}): SpanLoad =>
+  ({
+    uuid: 'load-1',
+    supportUuid: 'support-1',
+    type: LoadType.PUNCTUAL,
+    loadPosition: 10,
+    loadWeight: 100,
+    ...overrides
+  }) as SpanLoad;
+
+const makePlotParams = (overrides: Partial<CreatePlotParams> = {}): CreatePlotParams => ({
+  documentRef: globalThis.document,
+  plotId: 'test-plot',
+  data: [],
+  invert: false,
+  view: '3d',
+  camera: null,
+  side: 'profile',
+  spanLoads: [],
+  startSupport: 0,
+  endSupport: 2,
+  obstacles: [],
+  currentObstacleUuid: null,
+  currentObstaclePointIndex: 0,
+  distances: [],
+  distanceType: null,
+  litData: {
+    loads_coords: {
+      0: [5, 3, 10]
+    }
+  } as unknown as CreatePlotParams['litData'],
+  ...overrides
+});
+
+describe('createLoadAnnotations', () => {
+  describe('empty cases', () => {
+    it('should return [] when spanLoads is empty', () => {
+      const result = createLoadAnnotations(makePlotParams({ spanLoads: [] }));
+      expect(result).toEqual([]);
+    });
+
+    it('should return [] when all spanLoads entries are null', () => {
+      const result = createLoadAnnotations(makePlotParams({ spanLoads: [null, null] }));
+      expect(result).toEqual([]);
+    });
+
+    it('should return [] when spanLoad exists but its index+startSupport is not in loads_coords', () => {
+      const result = createLoadAnnotations(
+        makePlotParams({
+          spanLoads: [makeSpanLoad()],
+          startSupport: 5,
+          litData: { loads_coords: {} } as unknown as CreatePlotParams['litData']
+        })
+      );
+      expect(result).toEqual([]);
+    });
+  });
+
+  describe('icon selection by LoadType', () => {
+    it('should use LOAD_ICON for LoadType.PUNCTUAL', () => {
+      const result = createLoadAnnotations(
+        makePlotParams({ spanLoads: [makeSpanLoad({ type: LoadType.PUNCTUAL })] })
+      ) as AnnotationWithExtras[];
+      expect(result[0].text).toBe(LOAD_ICON);
+    });
+
+    it('should use MARKING_ICON for LoadType.MARKING', () => {
+      const result = createLoadAnnotations(
+        makePlotParams({ spanLoads: [makeSpanLoad({ type: LoadType.MARKING })] })
+      ) as AnnotationWithExtras[];
+      expect(result[0].text).toBe(MARKING_ICON);
+    });
+  });
+
+  describe('coordinate mapping — 3D view', () => {
+    it('should use coord[0] as x and coord[1] as y in 3D view', () => {
+      const result = createLoadAnnotations(
+        makePlotParams({ view: '3d', side: 'profile', spanLoads: [makeSpanLoad()] })
+      ) as AnnotationWithExtras[];
+      // loads_coords[0] = [5, 3, 10] → x=coord[0]=5, y=coord[1]=3
+      expect(result[0].x).toBe(5);
+      expect(result[0].y).toBe(3);
+      expect(result[0].z).toBe(10);
+    });
+  });
+
+  describe('coordinate mapping — 2D profile view', () => {
+    it('should use coord[0] as x and coord[2] as y in 2D profile view', () => {
+      const result = createLoadAnnotations(
+        makePlotParams({ view: '2d', side: 'profile', spanLoads: [makeSpanLoad()] })
+      ) as AnnotationWithExtras[];
+      // loads_coords[0] = [5, 3, 10] → x=coord[0]=5, y=coord[2]=10
+      expect(result[0].x).toBe(5);
+      expect(result[0].y).toBe(10);
+      expect(result[0].z).toBe(10);
+    });
+  });
+
+  describe('coordinate mapping — 2D face view', () => {
+    it('should use coord[1] as x and coord[2] as y in 2D face view', () => {
+      const result = createLoadAnnotations(
+        makePlotParams({ view: '2d', side: 'face', spanLoads: [makeSpanLoad()] })
+      ) as AnnotationWithExtras[];
+      // loads_coords[0] = [5, 3, 10] → x=coord[1]=3, y=coord[2]=10
+      expect(result[0].x).toBe(3);
+      expect(result[0].y).toBe(10);
+      expect(result[0].z).toBe(10);
+    });
+  });
+
+  describe('data payload', () => {
+    it('should set data.type to spanLoad', () => {
+      const result = createLoadAnnotations(
+        makePlotParams({ spanLoads: [makeSpanLoad({ supportUuid: 'support-abc' })] })
+      ) as AnnotationWithExtras[];
+      expect(result[0].data?.type).toBe('spanLoad');
+    });
+
+    it('should set data.supportUuid from the spanLoad', () => {
+      const result = createLoadAnnotations(
+        makePlotParams({ spanLoads: [makeSpanLoad({ supportUuid: 'support-xyz' })] })
+      ) as AnnotationWithExtras[];
+      expect(result[0].data?.supportUuid).toBe('support-xyz');
+    });
+  });
+
+  describe('arrow and click style (via buildClickableIconAnnotation)', () => {
+    it('should set captureevents to true', () => {
+      const result = createLoadAnnotations(makePlotParams({ spanLoads: [makeSpanLoad()] }));
+      expect(result[0].captureevents).toBe(true);
+    });
+
+    it('should set arrowhead to 0', () => {
+      const result = createLoadAnnotations(makePlotParams({ spanLoads: [makeSpanLoad()] }));
+      expect(result[0].arrowhead).toBe(0);
+    });
+
+    it('should set arrowwidth to 1', () => {
+      const result = createLoadAnnotations(makePlotParams({ spanLoads: [makeSpanLoad()] }));
+      expect(result[0].arrowwidth).toBe(1);
+    });
+
+    it('should set ay to -50', () => {
+      const result = createLoadAnnotations(makePlotParams({ spanLoads: [makeSpanLoad()] }));
+      expect(result[0].ay).toBe(-50);
+    });
+
+    it('should set ax to 0', () => {
+      const result = createLoadAnnotations(makePlotParams({ spanLoads: [makeSpanLoad()] }));
+      expect(result[0].ax).toBe(0);
+    });
+
+    it('should apply LOAD_COLOR to arrowcolor, bordercolor and font.color', () => {
+      const result = createLoadAnnotations(makePlotParams({ spanLoads: [makeSpanLoad()] }));
+      expect(result[0].arrowcolor).toBe(LOAD_COLOR);
+      expect(result[0].bordercolor).toBe(LOAD_COLOR);
+      expect(result[0].font?.color).toBe(LOAD_COLOR);
+    });
+  });
+
+  describe('startSupport offset', () => {
+    it('should offset spanIndex by startSupport to look up loads_coords', () => {
+      const result = createLoadAnnotations(
+        makePlotParams({
+          startSupport: 2,
+          spanLoads: [makeSpanLoad()],
+          litData: {
+            loads_coords: {
+              2: [99, 88, 77]
+            }
+          } as unknown as CreatePlotParams['litData']
+        })
+      ) as AnnotationWithExtras[];
+      // spanIndex=0, startSupport=2 → key=2 → coord[0]=99
+      expect(result[0].x).toBe(99);
+    });
+  });
+
+  describe('multiple spanLoads', () => {
+    it('should produce one annotation per non-null spanLoad with a matching coord', () => {
+      const result = createLoadAnnotations(
+        makePlotParams({
+          spanLoads: [makeSpanLoad({ supportUuid: 'a' }), null, makeSpanLoad({ supportUuid: 'b' })],
+          litData: {
+            loads_coords: {
+              0: [1, 2, 3],
+              2: [4, 5, 6]
+            }
+          } as unknown as CreatePlotParams['litData']
+        })
+      ) as AnnotationWithExtras[];
+      expect(result).toHaveLength(2);
+      expect(result[0].data?.supportUuid).toBe('a');
+      expect(result[1].data?.supportUuid).toBe('b');
+    });
+  });
+});

--- a/src/app/shared/components/studio/section/helpers/createLoadAnnotations.ts
+++ b/src/app/shared/components/studio/section/helpers/createLoadAnnotations.ts
@@ -1,10 +1,8 @@
 import * as Plotly from 'plotly.js-dist-min';
 import { CreatePlotParams } from './createPlot';
 import { cloneDeep } from 'lodash';
-
-const LOAD_COLOR = '#4A355A';
-const LOAD_ICON = '&#xf5cd;';
-const MARKING_ICON = '&#xf08d;';
+import { buildClickableIconAnnotation } from './createClickableIconAnnotation';
+import { LOAD_ARROW_Y_OFFSET, LOAD_COLOR, LOAD_ICON, MARKING_ICON } from './createLoadAnnotations.constantes';
 
 /**
  * Data payload attached to a Plotly span load annotation for click event handling.
@@ -28,27 +26,6 @@ export enum LoadType {
   MARKING = 'marking'
 }
 
-const BASE_ANNOTATION: Partial<Plotly.Annotations> = {
-  xref: 'x' as const,
-  yref: 'y' as const,
-  ax: 0,
-  ay: -50,
-  showarrow: true,
-  arrowhead: 0,
-  startarrowhead: 6,
-  arrowcolor: LOAD_COLOR,
-  captureevents: true,
-  bordercolor: LOAD_COLOR,
-  borderpad: 6,
-  bgcolor: 'rgba(0,0,0,0)',
-  font: {
-    family: 'FontAwesome',
-    color: LOAD_COLOR,
-    size: 8
-  },
-  arrowwidth: 1
-};
-
 /**
  * Creates Plotly annotation objects representing span loads on the section plot.
  * Each annotation displays an icon (load or marking) positioned at the load coordinates.
@@ -63,15 +40,17 @@ export const createLoadAnnotations = (plotParams: CreatePlotParams): Partial<Plo
   plotParams.spanLoads.forEach((spanLoad, spanIndex) => {
     if (spanLoad && spanIndex + plotParams.startSupport in load_coords) {
       const current_load_coord = load_coords[spanIndex + plotParams.startSupport];
-      annotations.push({
-        ...BASE_ANNOTATION,
-        x: side === 'face' && view === '2d' ? current_load_coord[1] : current_load_coord[0],
-        y: plotParams.view === '2d' ? current_load_coord[2] : current_load_coord[1],
-        // z and data are non-standard Plotly annotation properties used for 3D rendering and event handling
-        z: current_load_coord[2],
-        text: spanLoad.type === LoadType.PUNCTUAL ? LOAD_ICON : MARKING_ICON,
-        data: { type: 'spanLoad', supportUuid: spanLoad.supportUuid } as SpanLoadAnnotationData
-      } as Partial<Plotly.Annotations>);
+      annotations.push(
+        buildClickableIconAnnotation({
+          arrowTipX: side === 'face' && view === '2d' ? current_load_coord[1] : current_load_coord[0],
+          arrowTipY: plotParams.view === '2d' ? current_load_coord[2] : current_load_coord[1],
+          arrowTipZ: current_load_coord[2],
+          icon: spanLoad.type === LoadType.PUNCTUAL ? LOAD_ICON : MARKING_ICON,
+          color: LOAD_COLOR,
+          arrowYOffset: LOAD_ARROW_Y_OFFSET,
+          data: { type: 'spanLoad', supportUuid: spanLoad.supportUuid }
+        })
+      );
     }
   });
   return annotations;

--- a/src/app/shared/components/studio/section/helpers/studio-annotations.tokens.ts
+++ b/src/app/shared/components/studio/section/helpers/studio-annotations.tokens.ts
@@ -1,0 +1,12 @@
+/**
+ * Copyright (c) 2025, RTE (http://www.rte-france.com)
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+
+/**
+ * Shared color used by all studio section plot annotations
+ * (span loads, cable modifications).
+ */
+export const ANNOTATION_COLOR = '#4A355A';


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
<!-- please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes -->
- [X] Tests for the changes have been added (for bug fixes / features)

[946](https://github.com/phlowers/phlowers-stellar-app/issues/946)

feat: centralize clickable icon annotation builder for studio section plot

Extracted the shared visual structure of clickable icon annotations (FontAwesome icon + arrow line) into a single pure helper function [buildClickableIconAnnotation](vscode-file://vscode-app/c:/Users/madrangesfre/AppData/Local/Programs/Microsoft%20VS%20Code/0958016b2a/resources/app/out/vs/code/electron-browser/workbench/workbench.html). Both [createLoadAnnotations](vscode-file://vscode-app/c:/Users/madrangesfre/AppData/Local/Programs/Microsoft%20VS%20Code/0958016b2a/resources/app/out/vs/code/electron-browser/workbench/workbench.html) and [createCableModificationAnnotations](vscode-file://vscode-app/c:/Users/madrangesfre/AppData/Local/Programs/Microsoft%20VS%20Code/0958016b2a/resources/app/out/vs/code/electron-browser/workbench/workbench.html) now delegate to this function instead of duplicating the Plotly annotation object shape.

What changed

Added [createClickableIconAnnotation.ts](vscode-file://vscode-app/c:/Users/madrangesfre/AppData/Local/Programs/Microsoft%20VS%20Code/0958016b2a/resources/app/out/vs/code/electron-browser/workbench/workbench.html) — pure function, no Angular DI, no side effects.
Added [createClickableIconAnnotation.interfaces.ts](vscode-file://vscode-app/c:/Users/madrangesfre/AppData/Local/Programs/Microsoft%20VS%20Code/0958016b2a/resources/app/out/vs/code/electron-browser/workbench/workbench.html) — typed params ([ClickableIconAnnotationParams](vscode-file://vscode-app/c:/Users/madrangesfre/AppData/Local/Programs/Microsoft%20VS%20Code/0958016b2a/resources/app/out/vs/code/electron-browser/workbench/workbench.html)).
[createLoadAnnotations](vscode-file://vscode-app/c:/Users/madrangesfre/AppData/Local/Programs/Microsoft%20VS%20Code/0958016b2a/resources/app/out/vs/code/electron-browser/workbench/workbench.html) and [createCableModificationAnnotations](vscode-file://vscode-app/c:/Users/madrangesfre/AppData/Local/Programs/Microsoft%20VS%20Code/0958016b2a/resources/app/out/vs/code/electron-browser/workbench/workbench.html) updated to use the helper.
Copilot instructions updated to enforce usage of this helper for any future clickable icon annotation.
Constraints — obstacle annotations are out of scope

Obstacle annotations intentionally do not use this helper. Their rendering model is fundamentally different:

They use Unicode symbols (●/◆/○), not FontAwesome glyphs.
They have [showarrow: false](vscode-file://vscode-app/c:/Users/madrangesfre/AppData/Local/Programs/Microsoft%20VS%20Code/0958016b2a/resources/app/out/vs/code/electron-browser/workbench/workbench.html) — no arrow line.
Each point produces two annotations: a dot marker + a text label, both with independent [captureevents](vscode-file://vscode-app/c:/Users/madrangesfre/AppData/Local/Programs/Microsoft%20VS%20Code/0958016b2a/resources/app/out/vs/code/electron-browser/workbench/workbench.html) values.
Their color is dynamic, driven by the current selection state (3 possible states).
Forcing obstacles into [buildClickableIconAnnotation](vscode-file://vscode-app/c:/Users/madrangesfre/AppData/Local/Programs/Microsoft%20VS%20Code/0958016b2a/resources/app/out/vs/code/electron-browser/workbench/workbench.html) would require adding too many optional parameters and would break the single-responsibility of the helper. The separation is intentional and must be preserved.