### PR TITLE
fix bug modebar plotly

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -120,6 +120,25 @@ ngOnDestroy(): void { Plotly.purge(this.chartContainer.nativeElement); }
 
 Chart container: `role="img"` + descriptive `aria-label`.
 
+### Studio 3D section plot — modebar camera buttons
+
+**`zoom3d` and `pan3d` MUST remain in `modeBarButtonsToRemove` and replaced by custom buttons.**
+
+Native `zoom3d`/`pan3d` call `Plotly.relayout` → `updateFx()` internally, which resets the 3D camera (POV, angle, zoom) — regression bug #703.  
+The custom replacements (`customZoom3d`, `customPan3d`) use `setDragmodeDirect()` which bypasses `relayout` and preserves the camera.  
+Same applies to `orbitRotation` / `tableRotation` → `customOrbitRotation` / `customTurntableRotation`.
+
+**Never revert these to native Plotly buttons. Never call `Plotly.relayout` with `scene.dragmode` in the section plot.**
+
+File: `src/app/shared/components/studio/section/helpers/createPlot.ts` — `getConfig()`.
+
+### Studio section plot — annotations
+
+For clickable icon annotations (FontAwesome icon + arrow), **never build the annotation object manually**.  
+Always use `buildClickableIconAnnotation` from `@shared/components/studio/section/helpers/createClickableIconAnnotation`.
+
+Exception: obstacle annotations (`obstacles.ts`) use a different model (no arrow, Unicode symbols, dynamic colors) and must **not** use this helper.
+
 ---
 
 ## Pyodide

--- a/src/app/shared/components/studio/section/helpers/createPlot.spec.ts
+++ b/src/app/shared/components/studio/section/helpers/createPlot.spec.ts
@@ -20,7 +20,9 @@ vi.mock('plotly.js-dist-min', () => ({
     relayout: vi.fn().mockResolvedValue(undefined),
     Icons: {
       '3d_rotate': { width: 1000, height: 1000, path: '' },
-      'z-axis': { width: 1000, height: 1000, path: '' }
+      'z-axis': { width: 1000, height: 1000, path: '' },
+      zoombox: { width: 1000, height: 1000, path: '' },
+      pan: { width: 1000, height: 1000, path: '' }
     }
   },
   react: vi.fn(),
@@ -443,6 +445,122 @@ describe('createPlot', () => {
 
       const configArg = (Plotly.react as Mock).mock.calls[0][3];
       expect(configArg.modeBarButtonsToRemove).toContain('resetScale2d');
+    });
+
+    it('should include zoom3d in modeBarButtonsToRemove', () => {
+      createPlot({ ...createDefaultParams() });
+
+      const configArg = (Plotly.react as Mock).mock.calls[0][3];
+      expect(configArg.modeBarButtonsToRemove).toContain('zoom3d');
+    });
+
+    it('should include pan3d in modeBarButtonsToRemove', () => {
+      createPlot({ ...createDefaultParams() });
+
+      const configArg = (Plotly.react as Mock).mock.calls[0][3];
+      expect(configArg.modeBarButtonsToRemove).toContain('pan3d');
+    });
+  });
+
+  describe('custom zoom/pan modebar buttons', () => {
+    it('should include a custom zoom3d button in modeBarButtonsToAdd', () => {
+      createPlot({ ...createDefaultParams() });
+
+      const configArg = (Plotly.react as Mock).mock.calls[0][3];
+      const addedButtons = configArg.modeBarButtonsToAdd as { name: string }[];
+      expect(addedButtons.some((btn) => btn.name === 'customZoom3d')).toBe(true);
+    });
+
+    it('should include a custom pan3d button in modeBarButtonsToAdd', () => {
+      createPlot({ ...createDefaultParams() });
+
+      const configArg = (Plotly.react as Mock).mock.calls[0][3];
+      const addedButtons = configArg.modeBarButtonsToAdd as { name: string }[];
+      expect(addedButtons.some((btn) => btn.name === 'customPan3d')).toBe(true);
+    });
+
+    it('should set attr=scene.dragmode and val=zoom on the custom zoom3d button', () => {
+      createPlot({ ...createDefaultParams() });
+
+      const configArg = (Plotly.react as Mock).mock.calls[0][3];
+      const addedButtons = configArg.modeBarButtonsToAdd as { name: string; attr?: string; val?: string }[];
+      const zoom3dBtn = addedButtons.find((btn) => btn.name === 'customZoom3d');
+      expect(zoom3dBtn?.attr).toBe('scene.dragmode');
+      expect(zoom3dBtn?.val).toBe('zoom');
+    });
+
+    it('should set attr=scene.dragmode and val=pan on the custom pan3d button', () => {
+      createPlot({ ...createDefaultParams() });
+
+      const configArg = (Plotly.react as Mock).mock.calls[0][3];
+      const addedButtons = configArg.modeBarButtonsToAdd as { name: string; attr?: string; val?: string }[];
+      const pan3dBtn = addedButtons.find((btn) => btn.name === 'customPan3d');
+      expect(pan3dBtn?.attr).toBe('scene.dragmode');
+      expect(pan3dBtn?.val).toBe('pan');
+    });
+
+    it('should set attr=scene.dragmode and val=orbit on the custom orbit button', () => {
+      createPlot({ ...createDefaultParams() });
+
+      const configArg = (Plotly.react as Mock).mock.calls[0][3];
+      const addedButtons = configArg.modeBarButtonsToAdd as { name: string; attr?: string; val?: string }[];
+      const orbitBtn = addedButtons.find((btn) => btn.name === 'customOrbitRotation');
+      expect(orbitBtn?.attr).toBe('scene.dragmode');
+      expect(orbitBtn?.val).toBe('orbit');
+    });
+
+    it('should set attr=scene.dragmode and val=turntable on the custom turntable button', () => {
+      createPlot({ ...createDefaultParams() });
+
+      const configArg = (Plotly.react as Mock).mock.calls[0][3];
+      const addedButtons = configArg.modeBarButtonsToAdd as { name: string; attr?: string; val?: string }[];
+      const turntableBtn = addedButtons.find((btn) => btn.name === 'customTurntableRotation');
+      expect(turntableBtn?.attr).toBe('scene.dragmode');
+      expect(turntableBtn?.val).toBe('turntable');
+    });
+
+    it('should call setDragmodeDirect with zoom mode when custom zoom button is clicked', () => {
+      createPlot({ ...createDefaultParams() });
+
+      const configArg = (Plotly.react as Mock).mock.calls[0][3];
+      const addedButtons = configArg.modeBarButtonsToAdd as { name: string; click: (gd: unknown) => void }[];
+      const zoom3dBtn = addedButtons.find((btn) => btn.name === 'customZoom3d');
+
+      const updateActiveButton = vi.fn();
+      const mockGd = {
+        layout: { scene: { dragmode: 'orbit' } },
+        _fullLayout: { scene: { dragmode: 'orbit', _scene: { camera: { mode: 'orbit', keyBindingMode: 'rotate' } } } },
+        _modeBar: { updateActiveButton }
+      };
+      zoom3dBtn!.click(mockGd);
+
+      expect(mockGd._fullLayout.scene._scene.camera.mode).toBe('zoom');
+      expect(mockGd._fullLayout.scene._scene.camera.keyBindingMode).toBe('zoom');
+      expect(mockGd._fullLayout.scene.dragmode).toBe('zoom');
+      expect(mockGd.layout.scene.dragmode).toBe('zoom');
+      expect(updateActiveButton).toHaveBeenCalledOnce();
+    });
+
+    it('should call setDragmodeDirect with pan mode when custom pan button is clicked', () => {
+      createPlot({ ...createDefaultParams() });
+
+      const configArg = (Plotly.react as Mock).mock.calls[0][3];
+      const addedButtons = configArg.modeBarButtonsToAdd as { name: string; click: (gd: unknown) => void }[];
+      const pan3dBtn = addedButtons.find((btn) => btn.name === 'customPan3d');
+
+      const updateActiveButton = vi.fn();
+      const mockGd = {
+        layout: { scene: { dragmode: 'orbit' } },
+        _fullLayout: { scene: { dragmode: 'orbit', _scene: { camera: { mode: 'orbit', keyBindingMode: 'rotate' } } } },
+        _modeBar: { updateActiveButton }
+      };
+      pan3dBtn!.click(mockGd);
+
+      expect(mockGd._fullLayout.scene._scene.camera.mode).toBe('pan');
+      expect(mockGd._fullLayout.scene._scene.camera.keyBindingMode).toBe('pan');
+      expect(mockGd._fullLayout.scene.dragmode).toBe('pan');
+      expect(mockGd.layout.scene.dragmode).toBe('pan');
+      expect(updateActiveButton).toHaveBeenCalledOnce();
     });
   });
 });

--- a/src/app/shared/components/studio/section/helpers/createPlot.ts
+++ b/src/app/shared/components/studio/section/helpers/createPlot.ts
@@ -130,9 +130,15 @@ const createScene = (
 };
 
 /**
- * Builds the Plotly config including custom orbit/turntable modebar buttons.
+ * Builds the Plotly config including custom orbit/turntable/zoom/pan modebar buttons.
  * Defined as a function so that `Plotly.Icons` is accessed at call-time
  * rather than at module-evaluation time (which breaks test mocks).
+ *
+ * ⚠️ DO NOT restore `zoom3d`, `pan3d`, `orbitRotation` or `tableRotation` to their native
+ * Plotly behaviour. The native buttons call `Plotly.relayout({"scene.dragmode": ...})`
+ * which triggers `updateFx()` and resets the 3D camera (POV, angle, zoom) — bug #703.
+ * The custom replacements use `setDragmodeDirect()` to bypass `relayout` and preserve
+ * the camera. Tests in `createPlot.spec.ts` guard against this regression.
  */
 const getConfig = () => {
   /**
@@ -140,16 +146,19 @@ const getConfig = () => {
    * orbit-camera-controller mode. This bypasses Plotly.relayout and its
    * updateFx() which forces camera.up = [0,0,1] on turntable switch,
    * causing an unwanted camera/zoom reset.
+   * @param keyBindingMode - Controls what the primary mouse drag action does.
+   *   Use 'rotate' for orbit/turntable, 'zoom' for zoom, 'pan' for pan.
    */
-  const setDragmodeDirect = (gd: Plotly.PlotlyHTMLElement, mode: string): void => {
+  const setDragmodeDirect = (gd: Plotly.PlotlyHTMLElement, mode: string, keyBindingMode = 'rotate'): void => {
     const gdInternal = gd as unknown as {
       layout?: { scene?: { dragmode?: string } };
       _fullLayout?: { scene?: { dragmode?: string; _scene?: { camera?: { mode?: string; keyBindingMode?: string } } } };
+      _modeBar?: { updateActiveButton?: () => void };
     };
     const scene = gdInternal._fullLayout?.scene;
     if (scene?._scene?.camera) {
       scene._scene.camera.mode = mode;
-      scene._scene.camera.keyBindingMode = 'rotate';
+      scene._scene.camera.keyBindingMode = keyBindingMode;
     }
     // Update layout objects so uirevision preserves the mode across Plotly.react calls
     if (scene) {
@@ -158,12 +167,16 @@ const getConfig = () => {
     if (gdInternal.layout?.scene) {
       gdInternal.layout.scene.dragmode = mode;
     }
+    // Refresh modebar active-button highlighting without triggering a full relayout
+    gdInternal._modeBar?.updateActiveButton?.();
   };
 
   const orbitButton: ModeBarButton = {
     name: 'customOrbitRotation',
     title: $localize`Orbital rotation`,
     icon: Plotly.Icons['3d_rotate'] as Icon,
+    attr: 'scene.dragmode',
+    val: 'orbit',
     click: (gd) => {
       setDragmodeDirect(gd, 'orbit');
     }
@@ -173,8 +186,32 @@ const getConfig = () => {
     name: 'customTurntableRotation',
     title: $localize`Turntable rotation`,
     icon: Plotly.Icons['z-axis'] as Icon,
+    attr: 'scene.dragmode',
+    val: 'turntable',
     click: (gd) => {
       setDragmodeDirect(gd, 'turntable');
+    }
+  };
+
+  const zoom3dButton: ModeBarButton = {
+    name: 'customZoom3d',
+    title: $localize`Zoom`,
+    icon: Plotly.Icons['zoombox'] as Icon,
+    attr: 'scene.dragmode',
+    val: 'zoom',
+    click: (gd) => {
+      setDragmodeDirect(gd, 'zoom', 'zoom');
+    }
+  };
+
+  const pan3dButton: ModeBarButton = {
+    name: 'customPan3d',
+    title: $localize`Pan`,
+    icon: Plotly.Icons['pan'] as Icon,
+    attr: 'scene.dragmode',
+    val: 'pan',
+    click: (gd) => {
+      setDragmodeDirect(gd, 'pan', 'pan');
     }
   };
 
@@ -195,9 +232,11 @@ const getConfig = () => {
       'resetCameraLastSave3d',
       'resetScale2d',
       'orbitRotation',
-      'tableRotation'
+      'tableRotation',
+      'zoom3d',
+      'pan3d'
     ] as ModeBarDefaultButtons[],
-    modeBarButtonsToAdd: [orbitButton, turntableButton]
+    modeBarButtonsToAdd: [orbitButton, turntableButton, zoom3dButton, pan3dButton]
   };
 };
 


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
<!-- please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes -->
- [x] Tests for the changes have been added (for bug fixes / features)

[703](https://github.com/phlowers/phlowers-stellar-app/issues/703)

<html>
<body>
<!--StartFragment--><h2 style="line-height: normal; font-size: 16.003px; font-weight: 600; margin: 1.5em 0px 0.875em; font-family: &quot;Segoe WPC&quot;, &quot;Segoe UI&quot;, sans-serif; color: rgb(246, 246, 244); font-style: normal; font-variant-ligatures: normal; font-variant-caps: normal; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; white-space: normal; background-color: rgb(38, 38, 38); text-decoration-thickness: initial; text-decoration-style: initial; text-decoration-color: initial;">Problem</h2><p style="margin: 0px 0px 16px; color: rgb(246, 246, 244); font-family: &quot;Segoe WPC&quot;, &quot;Segoe UI&quot;, sans-serif; font-size: 13px; font-style: normal; font-variant-ligatures: normal; font-variant-caps: normal; font-weight: 400; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; white-space: normal; background-color: rgb(38, 38, 38); text-decoration-thickness: initial; text-decoration-style: initial; text-decoration-color: initial;">Clicking the native Plotly<span> </span><code style="font-family: Consolas, &quot;Courier New&quot;, monospace; font-size: 10.998px; color: rgb(215, 186, 125); background-color: rgba(255, 255, 255, 0.1); padding: 1px 3px; border-radius: 4px; border-color: rgb(215, 186, 125); border-style: none; border-width: 0px; border-image: none 100% / 1 / 0 stretch; white-space: pre-wrap;">zoom3d</code><span> </span>or<span> </span><code style="font-family: Consolas, &quot;Courier New&quot;, monospace; font-size: 10.998px; color: rgb(215, 186, 125); background-color: rgba(255, 255, 255, 0.1); padding: 1px 3px; border-radius: 4px; border-color: rgb(215, 186, 125); border-style: none; border-width: 0px; border-image: none 100% / 1 / 0 stretch; white-space: pre-wrap;">pan3d</code><span> </span>modebar buttons in the 3D section plot was resetting the camera (point of view, angle, zoom level) — regression reported in #703.</p><p style="margin: 0px 0px 16px; color: rgb(246, 246, 244); font-family: &quot;Segoe WPC&quot;, &quot;Segoe UI&quot;, sans-serif; font-size: 13px; font-style: normal; font-variant-ligatures: normal; font-variant-caps: normal; font-weight: 400; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; white-space: normal; background-color: rgb(38, 38, 38); text-decoration-thickness: initial; text-decoration-style: initial; text-decoration-color: initial;"><strong style="font-weight: 600;">Root cause:</strong><span> </span>the native buttons call<span> </span><a href="vscode-file://vscode-app/c:/Users/madrangesfre/AppData/Local/Programs/Microsoft%20VS%20Code/0958016b2a/resources/app/out/vs/code/electron-browser/workbench/workbench.html" title="" draggable="true" data-href="vscode-remote://ssh-remote%2B10.132.22.159/home/infoger/phlowers-stellar-app/node_modules/%40types/plotly.js/index.d.ts#507%2C5" custom-hover="true" class="chat-inline-anchor-widget show-file-icons" style="border-color: rgba(255, 255, 255, 0.1); border-style: solid; border-width: 1.152px; border-image: none 100% / 1 / 0 stretch; border-radius: 4px; margin: 0px 1px; padding: 1px 3px; text-wrap: nowrap; width: fit-content; font-weight: 400; text-decoration: rgb(246, 246, 244); font-size: 11.999px; color: inherit; user-select: text;"><span class="icon-label" style="padding: 0px 3px;">Plotly.relayout({ "scene.dragmode": ... })</span></a><span> </span>internally, which triggers Plotly's<span> </span><code style="font-family: Consolas, &quot;Courier New&quot;, monospace; font-size: 10.998px; color: rgb(215, 186, 125); background-color: rgba(255, 255, 255, 0.1); padding: 1px 3px; border-radius: 4px; border-color: rgb(215, 186, 125); border-style: none; border-width: 0px; border-image: none 100% / 1 / 0 stretch; white-space: pre-wrap;">updateFx()</code>. This function forces<span> </span><a href="vscode-file://vscode-app/c:/Users/madrangesfre/AppData/Local/Programs/Microsoft%20VS%20Code/0958016b2a/resources/app/out/vs/code/electron-browser/workbench/workbench.html" title="" draggable="true" data-href="vscode-remote://ssh-remote%2B10.132.22.159/home/infoger/phlowers-stellar-app/src/app/shared/components/studio/section/helpers/createPlot.spec.ts#83%2C5" custom-hover="true" class="chat-inline-anchor-widget show-file-icons" style="border-color: rgba(255, 255, 255, 0.1); border-style: solid; border-width: 1.152px; border-image: none 100% / 1 / 0 stretch; border-radius: 4px; margin: 0px 1px; padding: 1px 3px; text-wrap: nowrap; width: fit-content; font-weight: 400; text-decoration: rgb(246, 246, 244); font-size: 11.999px; color: inherit; user-select: text;"><span class="icon-label" style="padding: 0px 3px;">camera.up = [0,0,1]</span></a><span> </span>and resets the viewport, bypassing the<span> </span><a href="vscode-file://vscode-app/c:/Users/madrangesfre/AppData/Local/Programs/Microsoft%20VS%20Code/0958016b2a/resources/app/out/vs/code/electron-browser/workbench/workbench.html" title="" draggable="true" data-href="vscode-remote://ssh-remote%2B10.132.22.159/home/infoger/phlowers-stellar-app/node_modules/%40types/plotly.js/index.d.ts#573%2C5" custom-hover="true" class="chat-inline-anchor-widget show-file-icons" style="border-color: rgba(255, 255, 255, 0.1); border-style: solid; border-width: 1.152px; border-image: none 100% / 1 / 0 stretch; border-radius: 4px; margin: 0px 1px; padding: 1px 3px; text-wrap: nowrap; width: fit-content; font-weight: 400; text-decoration: rgb(246, 246, 244); font-size: 11.999px; color: inherit; user-select: text;"><span class="icon-label" style="padding: 0px 3px;">uirevision: 'stable'</span></a><span> </span>protection.</p><p style="margin: 0px 0px 16px; color: rgb(246, 246, 244); font-family: &quot;Segoe WPC&quot;, &quot;Segoe UI&quot;, sans-serif; font-size: 13px; font-style: normal; font-variant-ligatures: normal; font-variant-caps: normal; font-weight: 400; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; white-space: normal; background-color: rgb(38, 38, 38); text-decoration-thickness: initial; text-decoration-style: initial; text-decoration-color: initial;"><code style="font-family: Consolas, &quot;Courier New&quot;, monospace; font-size: 10.998px; color: rgb(215, 186, 125); background-color: rgba(255, 255, 255, 0.1); padding: 1px 3px; border-radius: 4px; border-color: rgb(215, 186, 125); border-style: none; border-width: 0px; border-image: none 100% / 1 / 0 stretch; white-space: pre-wrap;">orbitRotation</code><span> </span>and<span> </span><code style="font-family: Consolas, &quot;Courier New&quot;, monospace; font-size: 10.998px; color: rgb(215, 186, 125); background-color: rgba(255, 255, 255, 0.1); padding: 1px 3px; border-radius: 4px; border-color: rgb(215, 186, 125); border-style: none; border-width: 0px; border-image: none 100% / 1 / 0 stretch; white-space: pre-wrap;">tableRotation</code><span> </span>already had this fix applied (custom buttons using<span> </span><a href="vscode-file://vscode-app/c:/Users/madrangesfre/AppData/Local/Programs/Microsoft%20VS%20Code/0958016b2a/resources/app/out/vs/code/electron-browser/workbench/workbench.html" title="" draggable="true" data-href="vscode-remote://ssh-remote%2B10.132.22.159/home/infoger/phlowers-stellar-app/src/app/shared/components/studio/section/helpers/createPlot.ts#152%2C9" custom-hover="true" class="chat-inline-anchor-widget show-file-icons" style="border-color: rgba(255, 255, 255, 0.1); border-style: solid; border-width: 1.152px; border-image: none 100% / 1 / 0 stretch; border-radius: 4px; margin: 0px 1px; padding: 1px 3px; text-wrap: nowrap; width: fit-content; font-weight: 400; text-decoration: rgb(246, 246, 244); font-size: 11.999px; color: inherit; user-select: text;"><span class="icon-label" style="padding: 0px 3px;">setDragmodeDirect</span></a>), but<span> </span><code style="font-family: Consolas, &quot;Courier New&quot;, monospace; font-size: 10.998px; color: rgb(215, 186, 125); background-color: rgba(255, 255, 255, 0.1); padding: 1px 3px; border-radius: 4px; border-color: rgb(215, 186, 125); border-style: none; border-width: 0px; border-image: none 100% / 1 / 0 stretch; white-space: pre-wrap;">zoom3d</code><span> </span>and<span> </span><code style="font-family: Consolas, &quot;Courier New&quot;, monospace; font-size: 10.998px; color: rgb(215, 186, 125); background-color: rgba(255, 255, 255, 0.1); padding: 1px 3px; border-radius: 4px; border-color: rgb(215, 186, 125); border-style: none; border-width: 0px; border-image: none 100% / 1 / 0 stretch; white-space: pre-wrap;">pan3d</code><span> </span>were still using the native implementation.</p><h2 style="line-height: normal; font-size: 16.003px; font-weight: 600; margin: 1.5em 0px 0.875em; font-family: &quot;Segoe WPC&quot;, &quot;Segoe UI&quot;, sans-serif; color: rgb(246, 246, 244); font-style: normal; font-variant-ligatures: normal; font-variant-caps: normal; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; white-space: normal; background-color: rgb(38, 38, 38); text-decoration-thickness: initial; text-decoration-style: initial; text-decoration-color: initial;">Solution</h2><ul style="padding-inline-start: 24px; color: rgb(246, 246, 244); font-family: &quot;Segoe WPC&quot;, &quot;Segoe UI&quot;, sans-serif; font-size: 13px; font-style: normal; font-variant-ligatures: normal; font-variant-caps: normal; font-weight: 400; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; white-space: normal; background-color: rgb(38, 38, 38); text-decoration-thickness: initial; text-decoration-style: initial; text-decoration-color: initial;"><li style="margin: 4px 0px;">Add<span> </span><code style="font-family: Consolas, &quot;Courier New&quot;, monospace; font-size: 10.998px; color: rgb(215, 186, 125); background-color: rgba(255, 255, 255, 0.1); padding: 1px 3px; border-radius: 4px; border-color: rgb(215, 186, 125); border-style: none; border-width: 0px; border-image: none 100% / 1 / 0 stretch; white-space: pre-wrap;">zoom3d</code><span> </span>and<span> </span><code style="font-family: Consolas, &quot;Courier New&quot;, monospace; font-size: 10.998px; color: rgb(215, 186, 125); background-color: rgba(255, 255, 255, 0.1); padding: 1px 3px; border-radius: 4px; border-color: rgb(215, 186, 125); border-style: none; border-width: 0px; border-image: none 100% / 1 / 0 stretch; white-space: pre-wrap;">pan3d</code><span> </span>to<span> </span><a href="vscode-file://vscode-app/c:/Users/madrangesfre/AppData/Local/Programs/Microsoft%20VS%20Code/0958016b2a/resources/app/out/vs/code/electron-browser/workbench/workbench.html" title="" draggable="true" data-href="vscode-remote://ssh-remote%2B10.132.22.159/home/infoger/phlowers-stellar-app/src/app/shared/components/studio/section/helpers/createPlot.ts#223%2C5" custom-hover="true" class="chat-inline-anchor-widget show-file-icons" style="border-color: rgba(255, 255, 255, 0.1); border-style: solid; border-width: 1.152px; border-image: none 100% / 1 / 0 stretch; border-radius: 4px; margin: 0px 1px; padding: 1px 3px; text-wrap: nowrap; width: fit-content; font-weight: 400; text-decoration: none; font-size: 11.999px; color: inherit; user-select: text;"><span class="icon-label" style="padding: 0px 3px;">modeBarButtonsToRemove</span></a></li><li style="margin: 4px 0px;">Replace them with<span> </span><code style="font-family: Consolas, &quot;Courier New&quot;, monospace; font-size: 10.998px; color: rgb(215, 186, 125); background-color: rgba(255, 255, 255, 0.1); padding: 1px 3px; border-radius: 4px; border-color: rgb(215, 186, 125); border-style: none; border-width: 0px; border-image: none 100% / 1 / 0 stretch; white-space: pre-wrap;">customZoom3d</code><span> </span>and<span> </span><code style="font-family: Consolas, &quot;Courier New&quot;, monospace; font-size: 10.998px; color: rgb(215, 186, 125); background-color: rgba(255, 255, 255, 0.1); padding: 1px 3px; border-radius: 4px; border-color: rgb(215, 186, 125); border-style: none; border-width: 0px; border-image: none 100% / 1 / 0 stretch; white-space: pre-wrap;">customPan3d</code><span> </span>buttons that call<span> </span><a href="vscode-file://vscode-app/c:/Users/madrangesfre/AppData/Local/Programs/Microsoft%20VS%20Code/0958016b2a/resources/app/out/vs/code/electron-browser/workbench/workbench.html" title="" draggable="true" data-href="vscode-remote://ssh-remote%2B10.132.22.159/home/infoger/phlowers-stellar-app/src/app/shared/components/studio/section/helpers/createPlot.ts#152%2C9" custom-hover="true" class="chat-inline-anchor-widget show-file-icons" style="border-color: rgba(255, 255, 255, 0.1); border-style: solid; border-width: 1.152px; border-image: none 100% / 1 / 0 stretch; border-radius: 4px; margin: 0px 1px; padding: 1px 3px; text-wrap: nowrap; width: fit-content; font-weight: 400; text-decoration: none; font-size: 11.999px; color: inherit; user-select: text;"><span class="icon-label" style="padding: 0px 3px;">setDragmodeDirect()</span></a>, which mutates the internal orbit-camera-controller state directly without going through<span> </span><a href="vscode-file://vscode-app/c:/Users/madrangesfre/AppData/Local/Programs/Microsoft%20VS%20Code/0958016b2a/resources/app/out/vs/code/electron-browser/workbench/workbench.html" title="" draggable="true" data-href="vscode-remote://ssh-remote%2B10.132.22.159/home/infoger/phlowers-stellar-app/src/app/shared/components/studio/section/helpers/createPlot.spec.ts#20%2C5" custom-hover="true" class="chat-inline-anchor-widget show-file-icons" style="border-color: rgba(255, 255, 255, 0.1); border-style: solid; border-width: 1.152px; border-image: none 100% / 1 / 0 stretch; border-radius: 4px; margin: 0px 1px; padding: 1px 3px; text-wrap: nowrap; width: fit-content; font-weight: 400; text-decoration: none; font-size: 11.999px; color: inherit; user-select: text;"><span class="icon-label" style="padding: 0px 3px;">relayout</span></a></li><li style="margin: 4px 0px;">Set the correct<span> </span><a href="vscode-file://vscode-app/c:/Users/madrangesfre/AppData/Local/Programs/Microsoft%20VS%20Code/0958016b2a/resources/app/out/vs/code/electron-browser/workbench/workbench.html" title="" draggable="true" data-href="vscode-remote://ssh-remote%2B10.132.22.159/home/infoger/phlowers-stellar-app/src/app/shared/components/studio/section/helpers/createPlot.spec.ts#532%2C87" custom-hover="true" class="chat-inline-anchor-widget show-file-icons" style="border-color: rgba(255, 255, 255, 0.1); border-style: solid; border-width: 1.152px; border-image: none 100% / 1 / 0 stretch; border-radius: 4px; margin: 0px 1px; padding: 1px 3px; text-wrap: nowrap; width: fit-content; font-weight: 400; text-decoration: none; font-size: 11.999px; color: inherit; user-select: text;"><span class="icon-label" style="padding: 0px 3px;">keyBindingMode</span></a><span> </span>for each mode (<a href="vscode-file://vscode-app/c:/Users/madrangesfre/AppData/Local/Programs/Microsoft%20VS%20Code/0958016b2a/resources/app/out/vs/code/electron-browser/workbench/workbench.html" title="" draggable="true" data-href="vscode-remote://ssh-remote%2B10.132.22.159/home/infoger/phlowers-stellar-app/node_modules/%40types/plotly.js/index.d.ts#203%2C5" custom-hover="true" class="chat-inline-anchor-widget show-file-icons" style="border-color: rgba(255, 255, 255, 0.1); border-style: solid; border-width: 1.152px; border-image: none 100% / 1 / 0 stretch; border-radius: 4px; margin: 0px 1px; padding: 1px 3px; text-wrap: nowrap; width: fit-content; font-weight: 400; text-decoration: none; font-size: 11.999px; color: inherit; user-select: text;"><span class="icon-label" style="padding: 0px 3px;">'zoom'</span></a>/<a href="vscode-file://vscode-app/c:/Users/madrangesfre/AppData/Local/Programs/Microsoft%20VS%20Code/0958016b2a/resources/app/out/vs/code/electron-browser/workbench/workbench.html" title="" draggable="true" data-href="vscode-remote://ssh-remote%2B10.132.22.159/home/infoger/phlowers-stellar-app/src/app/shared/components/studio/section/helpers/createPlot.spec.ts#25%2C7" custom-hover="true" class="chat-inline-anchor-widget show-file-icons" style="border-color: rgba(255, 255, 255, 0.1); border-style: solid; border-width: 1.152px; border-image: none 100% / 1 / 0 stretch; border-radius: 4px; margin: 0px 1px; padding: 1px 3px; text-wrap: nowrap; width: fit-content; font-weight: 400; text-decoration: none; font-size: 11.999px; color: inherit; user-select: text;"><span class="icon-label" style="padding: 0px 3px;">'pan'</span></a>) so primary mouse drag behaves as expected</li><li style="margin: 4px 0px;">Add<span> </span><a href="vscode-file://vscode-app/c:/Users/madrangesfre/AppData/Local/Programs/Microsoft%20VS%20Code/0958016b2a/resources/app/out/vs/code/electron-browser/workbench/workbench.html" title="" draggable="true" data-href="vscode-remote://ssh-remote%2B10.132.22.159/home/infoger/phlowers-stellar-app/src/app/shared/components/studio/section/helpers/createPlot.spec.ts#486%2C77" custom-hover="true" class="chat-inline-anchor-widget show-file-icons" style="border-color: rgba(255, 255, 255, 0.1); border-style: solid; border-width: 1.152px; border-image: none 100% / 1 / 0 stretch; border-radius: 4px; margin: 0px 1px; padding: 1px 3px; text-wrap: nowrap; width: fit-content; font-weight: 400; text-decoration: none; font-size: 11.999px; color: inherit; user-select: text;"><span class="icon-label" style="padding: 0px 3px;">attr: 'scene.dragmode'</span></a><span> </span>and<span> </span><a href="vscode-file://vscode-app/c:/Users/madrangesfre/AppData/Local/Programs/Microsoft%20VS%20Code/0958016b2a/resources/app/out/vs/code/electron-browser/workbench/workbench.html" title="" draggable="true" data-href="vscode-remote://ssh-remote%2B10.132.22.159/home/infoger/phlowers-stellar-app/src/app/shared/components/studio/section/helpers/createPlot.spec.ts#486%2C92" custom-hover="true" class="chat-inline-anchor-widget show-file-icons" style="border-color: rgba(255, 255, 255, 0.1); border-style: solid; border-width: 1.152px; border-image: none 100% / 1 / 0 stretch; border-radius: 4px; margin: 0px 1px; padding: 1px 3px; text-wrap: nowrap; width: fit-content; font-weight: 400; text-decoration: none; font-size: 11.999px; color: inherit; user-select: text;"><span class="icon-label" style="padding: 0px 3px;">val</span></a><span> </span>on all 4 custom buttons (orbit, turntable, zoom, pan) so Plotly can apply the<span> </span><a href="vscode-file://vscode-app/c:/Users/madrangesfre/AppData/Local/Programs/Microsoft%20VS%20Code/0958016b2a/resources/app/out/vs/code/electron-browser/workbench/workbench.html" title="" draggable="true" data-href="vscode-remote://ssh-remote%2B10.132.22.159/home/infoger/phlowers-stellar-app/node_modules/%40types/plotly.js/index.d.ts#2461%2C5" custom-hover="true" class="chat-inline-anchor-widget show-file-icons" style="border-color: rgba(255, 255, 255, 0.1); border-style: solid; border-width: 1.152px; border-image: none 100% / 1 / 0 stretch; border-radius: 4px; margin: 0px 1px; padding: 1px 3px; text-wrap: nowrap; width: fit-content; font-weight: 400; text-decoration: none; font-size: 11.999px; color: inherit; user-select: text;"><span class="icon-label" style="padding: 0px 3px;">.active</span></a><span> </span>CSS class (highlighted icon) on the active button</li><li style="margin: 4px 0px;">Call<span> </span><a href="vscode-file://vscode-app/c:/Users/madrangesfre/AppData/Local/Programs/Microsoft%20VS%20Code/0958016b2a/resources/app/out/vs/code/electron-browser/workbench/workbench.html" title="" draggable="true" data-href="vscode-remote://ssh-remote%2B10.132.22.159/home/infoger/phlowers-stellar-app/src/app/shared/components/studio/section/helpers/createPlot.spec.ts#555%2C21" custom-hover="true" class="chat-inline-anchor-widget show-file-icons" style="border-color: rgba(255, 255, 255, 0.1); border-style: solid; border-width: 1.152px; border-image: none 100% / 1 / 0 stretch; border-radius: 4px; margin: 0px 1px; padding: 1px 3px; text-wrap: nowrap; width: fit-content; font-weight: 400; text-decoration: none; font-size: 11.999px; color: inherit; user-select: text;"><span class="icon-label" style="padding: 0px 3px;">gd._modeBar.updateActiveButton()</span></a><span> </span>after each mode switch to refresh the visual state without triggering a relayout</li></ul><h2 style="line-height: normal; font-size: 16.003px; font-weight: 600; margin: 1.5em 0px 0.875em; font-family: &quot;Segoe WPC&quot;, &quot;Segoe UI&quot;, sans-serif; color: rgb(246, 246, 244); font-style: normal; font-variant-ligatures: normal; font-variant-caps: normal; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; white-space: normal; background-color: rgb(38, 38, 38); text-decoration-thickness: initial; text-decoration-style: initial; text-decoration-color: initial;">Regression protection</h2><p style="margin: 0px 0px 16px; color: rgb(246, 246, 244); font-family: &quot;Segoe WPC&quot;, &quot;Segoe UI&quot;, sans-serif; font-size: 13px; font-style: normal; font-variant-ligatures: normal; font-variant-caps: normal; font-weight: 400; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; white-space: normal; background-color: rgb(38, 38, 38); text-decoration-thickness: initial; text-decoration-style: initial; text-decoration-color: initial;">A<span> </span><code style="font-family: Consolas, &quot;Courier New&quot;, monospace; font-size: 10.998px; color: rgb(215, 186, 125); background-color: rgba(255, 255, 255, 0.1); padding: 1px 3px; border-radius: 4px; border-color: rgb(215, 186, 125); border-style: none; border-width: 0px; border-image: none 100% / 1 / 0 stretch; white-space: pre-wrap;">⚠️</code><span> </span>JSDoc comment was added directly above<span> </span><a href="vscode-file://vscode-app/c:/Users/madrangesfre/AppData/Local/Programs/Microsoft%20VS%20Code/0958016b2a/resources/app/out/vs/code/electron-browser/workbench/workbench.html" title="" draggable="true" data-href="vscode-remote://ssh-remote%2B10.132.22.159/home/infoger/phlowers-stellar-app/src/app/shared/components/studio/section/helpers/createPlot.ts#143%2C7" custom-hover="true" class="chat-inline-anchor-widget show-file-icons" style="border-color: rgba(255, 255, 255, 0.1); border-style: solid; border-width: 1.152px; border-image: none 100% / 1 / 0 stretch; border-radius: 4px; margin: 0px 1px; padding: 1px 3px; text-wrap: nowrap; width: fit-content; font-weight: 400; text-decoration: rgb(246, 246, 244); font-size: 11.999px; color: inherit; user-select: text;"><span class="icon-label" style="padding: 0px 3px;">getConfig()</span></a><span> </span>explaining the invariant, and a rule was added to<span> </span><a href="vscode-file://vscode-app/c:/Users/madrangesfre/AppData/Local/Programs/Microsoft%20VS%20Code/0958016b2a/resources/app/out/vs/code/electron-browser/workbench/workbench.html" title="" draggable="true" data-href="vscode-remote://ssh-remote%2B10.132.22.159/home/infoger/phlowers-stellar-app/.github/copilot-instructions.md" custom-hover="true" class="chat-inline-anchor-widget show-file-icons" style="border-color: rgba(255, 255, 255, 0.1); border-style: solid; border-width: 1.152px; border-image: none 100% / 1 / 0 stretch; border-radius: 4px; margin: 0px 1px; padding: 1px 3px; text-wrap: nowrap; width: fit-content; font-weight: 400; text-decoration: rgb(246, 246, 244); font-size: 11.999px; color: inherit; user-select: text;"><span class="icon file-icon .github-name-dir-icon copilot-instructions.md-name-file-icon name-file-icon md-ext-file-icon ext-file-icon instructions-lang-file-icon" style="vertical-align: middle; line-height: 1em; overflow: hidden; font-size: 10.7991px; top: 0px !important;"></span><span class="icon-label" style="padding: 0px 3px;">copilot-instructions.md</span></a><span> </span>to prevent future AI or human contributors from inadvertently reverting this fix.</p><h2 style="line-height: normal; font-size: 16.003px; font-weight: 600; margin: 1.5em 0px 0.875em; font-family: &quot;Segoe WPC&quot;, &quot;Segoe UI&quot;, sans-serif; color: rgb(246, 246, 244); font-style: normal; font-variant-ligatures: normal; font-variant-caps: normal; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; white-space: normal; background-color: rgb(38, 38, 38); text-decoration-thickness: initial; text-decoration-style: initial; text-decoration-color: initial;">Files changed</h2><div class="monaco-scrollable-element rendered-markdown-table-scroll-wrapper" role="presentation" style="width: 563.022px; margin-bottom: 16px; color: rgb(246, 246, 244); font-family: &quot;Segoe WPC&quot;, &quot;Segoe UI&quot;, sans-serif; font-size: 13px; font-style: normal; font-variant-ligatures: normal; font-variant-caps: normal; font-weight: 400; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; white-space: normal; background-color: rgb(38, 38, 38); text-decoration-thickness: initial; text-decoration-style: initial; text-decoration-color: initial; position: relative; overflow: hidden;"><div style="overflow: hidden;">
File | Change
-- | --
createPlot.ts | Custom zoom3d/pan3d buttons, keyBindingMode param, attr/val, updateActiveButton
createPlot.spec.ts | +10 tests: modeBarButtonsToRemove, attr/val, click behaviour, updateActiveButton call
copilot-instructions.md | Hard rule against native zoom3d/pan3d/orbitRotation/tableRotation

</div></div><!--EndFragment-->
</body>
</html>Problem
Clicking the native Plotly zoom3d or pan3d modebar buttons in the 3D section plot was resetting the camera (point of view, angle, zoom level) — regression reported in #703.

Root cause: the native buttons call [Plotly.relayout({ "scene.dragmode": ... })](vscode-file://vscode-app/c:/Users/madrangesfre/AppData/Local/Programs/Microsoft%20VS%20Code/0958016b2a/resources/app/out/vs/code/electron-browser/workbench/workbench.html) internally, which triggers Plotly's updateFx(). This function forces [camera.up = [0,0,1]](vscode-file://vscode-app/c:/Users/madrangesfre/AppData/Local/Programs/Microsoft%20VS%20Code/0958016b2a/resources/app/out/vs/code/electron-browser/workbench/workbench.html) and resets the viewport, bypassing the [uirevision: 'stable'](vscode-file://vscode-app/c:/Users/madrangesfre/AppData/Local/Programs/Microsoft%20VS%20Code/0958016b2a/resources/app/out/vs/code/electron-browser/workbench/workbench.html) protection.

orbitRotation and tableRotation already had this fix applied (custom buttons using [setDragmodeDirect](vscode-file://vscode-app/c:/Users/madrangesfre/AppData/Local/Programs/Microsoft%20VS%20Code/0958016b2a/resources/app/out/vs/code/electron-browser/workbench/workbench.html)), but zoom3d and pan3d were still using the native implementation.

Solution
Add zoom3d and pan3d to [modeBarButtonsToRemove](vscode-file://vscode-app/c:/Users/madrangesfre/AppData/Local/Programs/Microsoft%20VS%20Code/0958016b2a/resources/app/out/vs/code/electron-browser/workbench/workbench.html)
Replace them with customZoom3d and customPan3d buttons that call [setDragmodeDirect()](vscode-file://vscode-app/c:/Users/madrangesfre/AppData/Local/Programs/Microsoft%20VS%20Code/0958016b2a/resources/app/out/vs/code/electron-browser/workbench/workbench.html), which mutates the internal orbit-camera-controller state directly without going through [relayout](vscode-file://vscode-app/c:/Users/madrangesfre/AppData/Local/Programs/Microsoft%20VS%20Code/0958016b2a/resources/app/out/vs/code/electron-browser/workbench/workbench.html)
Set the correct [keyBindingMode](vscode-file://vscode-app/c:/Users/madrangesfre/AppData/Local/Programs/Microsoft%20VS%20Code/0958016b2a/resources/app/out/vs/code/electron-browser/workbench/workbench.html) for each mode (['zoom'](vscode-file://vscode-app/c:/Users/madrangesfre/AppData/Local/Programs/Microsoft%20VS%20Code/0958016b2a/resources/app/out/vs/code/electron-browser/workbench/workbench.html)/['pan'](vscode-file://vscode-app/c:/Users/madrangesfre/AppData/Local/Programs/Microsoft%20VS%20Code/0958016b2a/resources/app/out/vs/code/electron-browser/workbench/workbench.html)) so primary mouse drag behaves as expected
Add [attr: 'scene.dragmode'](vscode-file://vscode-app/c:/Users/madrangesfre/AppData/Local/Programs/Microsoft%20VS%20Code/0958016b2a/resources/app/out/vs/code/electron-browser/workbench/workbench.html) and [val](vscode-file://vscode-app/c:/Users/madrangesfre/AppData/Local/Programs/Microsoft%20VS%20Code/0958016b2a/resources/app/out/vs/code/electron-browser/workbench/workbench.html) on all 4 custom buttons (orbit, turntable, zoom, pan) so Plotly can apply the [.active](vscode-file://vscode-app/c:/Users/madrangesfre/AppData/Local/Programs/Microsoft%20VS%20Code/0958016b2a/resources/app/out/vs/code/electron-browser/workbench/workbench.html) CSS class (highlighted icon) on the active button
Call [gd._modeBar.updateActiveButton()](vscode-file://vscode-app/c:/Users/madrangesfre/AppData/Local/Programs/Microsoft%20VS%20Code/0958016b2a/resources/app/out/vs/code/electron-browser/workbench/workbench.html) after each mode switch to refresh the visual state without triggering a relayout
Regression protection
A ⚠️ JSDoc comment was added directly above [getConfig()](vscode-file://vscode-app/c:/Users/madrangesfre/AppData/Local/Programs/Microsoft%20VS%20Code/0958016b2a/resources/app/out/vs/code/electron-browser/workbench/workbench.html) explaining the invariant, and a rule was added to [copilot-instructions.md](vscode-file://vscode-app/c:/Users/madrangesfre/AppData/Local/Programs/Microsoft%20VS%20Code/0958016b2a/resources/app/out/vs/code/electron-browser/workbench/workbench.html) to prevent future AI or human contributors from inadvertently reverting this fix.

Files changed
File	Change
[createPlot.ts](vscode-file://vscode-app/c:/Users/madrangesfre/AppData/Local/Programs/Microsoft%20VS%20Code/0958016b2a/resources/app/out/vs/code/electron-browser/workbench/workbench.html)	Custom zoom3d/pan3d buttons, [keyBindingMode](vscode-file://vscode-app/c:/Users/madrangesfre/AppData/Local/Programs/Microsoft%20VS%20Code/0958016b2a/resources/app/out/vs/code/electron-browser/workbench/workbench.html) param, [attr](vscode-file://vscode-app/c:/Users/madrangesfre/AppData/Local/Programs/Microsoft%20VS%20Code/0958016b2a/resources/app/out/vs/code/electron-browser/workbench/workbench.html)/[val](vscode-file://vscode-app/c:/Users/madrangesfre/AppData/Local/Programs/Microsoft%20VS%20Code/0958016b2a/resources/app/out/vs/code/electron-browser/workbench/workbench.html), [updateActiveButton](vscode-file://vscode-app/c:/Users/madrangesfre/AppData/Local/Programs/Microsoft%20VS%20Code/0958016b2a/resources/app/out/vs/code/electron-browser/workbench/workbench.html)
[createPlot.spec.ts](vscode-file://vscode-app/c:/Users/madrangesfre/AppData/Local/Programs/Microsoft%20VS%20Code/0958016b2a/resources/app/out/vs/code/electron-browser/workbench/workbench.html)	+10 tests: [modeBarButtonsToRemove](vscode-file://vscode-app/c:/Users/madrangesfre/AppData/Local/Programs/Microsoft%20VS%20Code/0958016b2a/resources/app/out/vs/code/electron-browser/workbench/workbench.html), [attr](vscode-file://vscode-app/c:/Users/madrangesfre/AppData/Local/Programs/Microsoft%20VS%20Code/0958016b2a/resources/app/out/vs/code/electron-browser/workbench/workbench.html)/[val](vscode-file://vscode-app/c:/Users/madrangesfre/AppData/Local/Programs/Microsoft%20VS%20Code/0958016b2a/resources/app/out/vs/code/electron-browser/workbench/workbench.html), click behaviour, [updateActiveButton](vscode-file://vscode-app/c:/Users/madrangesfre/AppData/Local/Programs/Microsoft%20VS%20Code/0958016b2a/resources/app/out/vs/code/electron-browser/workbench/workbench.html) call
[copilot-instructions.md](vscode-file://vscode-app/c:/Users/madrangesfre/AppData/Local/Programs/Microsoft%20VS%20Code/0958016b2a/resources/app/out/vs/code/electron-browser/workbench/workbench.html)	Hard rule against native zoom3d/pan3d/orbitRotation/tableRotation