### PR TITLE
Add "zoom" button for cable length change form.

### DIFF
--- a/assets/i18n/messages.fr.xlf
+++ b/assets/i18n/messages.fr.xlf
@@ -3281,12 +3281,6 @@
         <target>Obstacle enregistré</target>
       </segment>
     </unit>
-    <unit id="3490467566453662140">
-      <segment state="initial">
-        <source>Return to span</source>
-        <target>Retour à la portée</target>
-      </segment>
-    </unit>
     <unit id="8897211906922465937">
       <segment state="initial">
         <source>Create new obstacle</source>
@@ -4713,6 +4707,12 @@
       <segment state="initial">
         <source>Pan</source>
         <target>Pan</target>
+      </segment>
+    </unit>
+    <unit id="4122048021216749117">
+      <segment state="initial">
+        <source>Distance to reference support must not exceed span length</source>
+        <target>La distance au support de référence ne peut pas dépasser la longueur de la portée</target>
       </segment>
     </unit>
   </file>

--- a/assets/i18n/messages.fr.xlf
+++ b/assets/i18n/messages.fr.xlf
@@ -4709,11 +4709,5 @@
         <target>Pan</target>
       </segment>
     </unit>
-    <unit id="4122048021216749117">
-      <segment state="initial">
-        <source>Distance to reference support must not exceed span length</source>
-        <target>La distance au support de référence ne peut pas dépasser la longueur de la portée</target>
-      </segment>
-    </unit>
   </file>
 </xliff>

--- a/assets/i18n/messages.xlf
+++ b/assets/i18n/messages.xlf
@@ -3904,10 +3904,5 @@
         <source>Pan</source>
       </segment>
     </unit>
-    <unit id="4122048021216749117">
-      <segment>
-        <source>Distance to reference support must not exceed span length</source>
-      </segment>
-    </unit>
   </file>
 </xliff>

--- a/assets/i18n/messages.xlf
+++ b/assets/i18n/messages.xlf
@@ -1758,11 +1758,6 @@
         <source>Marking</source>
       </segment>
     </unit>
-    <unit id="3490467566453662140">
-      <segment>
-        <source>Return to span</source>
-      </segment>
-    </unit>
     <unit id="8897211906922465937">
       <segment>
         <source>Create new obstacle</source>
@@ -3907,6 +3902,11 @@
     <unit id="9128067536654850026">
       <segment>
         <source>Pan</source>
+      </segment>
+    </unit>
+    <unit id="4122048021216749117">
+      <segment>
+        <source>Distance to reference support must not exceed span length</source>
       </segment>
     </unit>
   </file>

--- a/src/app/core/services/obstacles-form/obstaclesForm.service.ts
+++ b/src/app/core/services/obstacles-form/obstaclesForm.service.ts
@@ -106,10 +106,12 @@ export class ObstacleFormService {
       },
       { emitEvent: false }
     );
-    // Emit supportUuid explicitly so that components tracking supportUuidValue via
-    // valueChanges (e.g. zoom button disabled state) update correctly.
-    // uuid is already set above (emitEvent:false), so the isEditingExisting guard
-    // in supportUuidEffect will prevent any unwanted form reset.
+    // Emit supportUuid explicitly so that components tracking it via valueChanges
+    // (e.g. the zoom button disabled state in ObstaclesFormComponent) update correctly.
+    // This is safe even though ObstaclesFormComponent reacts to supportUuid changes by
+    // resetting the form: its handler skips the reset when the form's uuid matches an
+    // obstacle already saved in the current section, which is the case here (uuid was
+    // patched above with emitEvent:false).
     this.form.controls.supportUuid.setValue(obstacle.supportUuid);
     this.setPositions(obstacle.positions);
     this.obstaclesService.setCurrentPointIndex(index);

--- a/src/app/core/services/obstacles-form/obstaclesForm.service.ts
+++ b/src/app/core/services/obstacles-form/obstaclesForm.service.ts
@@ -106,6 +106,11 @@ export class ObstacleFormService {
       },
       { emitEvent: false }
     );
+    // Emit supportUuid explicitly so that components tracking supportUuidValue via
+    // valueChanges (e.g. zoom button disabled state) update correctly.
+    // uuid is already set above (emitEvent:false), so the isEditingExisting guard
+    // in supportUuidEffect will prevent any unwanted form reset.
+    this.form.controls.supportUuid.setValue(obstacle.supportUuid);
     this.setPositions(obstacle.positions);
     this.obstaclesService.setCurrentPointIndex(index);
   }

--- a/src/app/features/studio/loads/presentation/components/cable-length-change/cable-length-change.html
+++ b/src/app/features/studio/loads/presentation/components/cable-length-change/cable-length-change.html
@@ -5,7 +5,20 @@
   (ngSubmit)="saveForm()"
   data-testid="cable-length-change-form"
 >
-  <div class="cable-length-change__reset">
+  <div class="header-btns">
+    <button
+      app-btn
+      type="button"
+      btnStyle="outlined"
+      btnSize="s"
+      (click)="zoomToSpan()"
+      [disabled]="isLoading() || !scopeValue()"
+      data-testid="cable-length-change-zoom"
+    >
+      <app-icon icon="filter_center_focus" aria-hidden="true" />
+      <ng-container i18n>Zoom</ng-container>
+    </button>
+
     <button
       app-btn
       type="button"

--- a/src/app/features/studio/loads/presentation/components/cable-length-change/cable-length-change.scss
+++ b/src/app/features/studio/loads/presentation/components/cable-length-change/cable-length-change.scss
@@ -1,14 +1,14 @@
 @use 'abstract.extracts' as app;
 
+.header-btns {
+  @apply flex items-center justify-between col-span-2 mb-3;
+}
+
 .cable-length-change {
   &__form {
     @apply grid grid-cols-2;
     gap: 0.625rem;
     align-items: end;
-  }
-
-  &__reset {
-    @apply text-right col-span-2;
   }
 
   &__btns {

--- a/src/app/features/studio/loads/presentation/components/cable-length-change/cable-length-change.spec.ts
+++ b/src/app/features/studio/loads/presentation/components/cable-length-change/cable-length-change.spec.ts
@@ -679,6 +679,36 @@ describe('CableLengthChangeComponent', () => {
   });
 
   // ---------------------------------------------------------------------------
+  // zoomToSpan()
+  // ---------------------------------------------------------------------------
+  describe('zoomToSpan()', () => {
+    beforeEach(() => {
+      mockPlotService.plotOptionsChange.mockClear();
+    });
+
+    it('should not call plotOptionsChange when scope is null', () => {
+      component.form.controls.scope.setValue(null);
+      component.zoomToSpan();
+      expect(mockPlotService.plotOptionsChange).not.toHaveBeenCalled();
+    });
+
+    it('should not call plotOptionsChange when getSupportIndex returns -1', () => {
+      mockSpanService.getSupportIndex.mockReturnValue(-1);
+      component.form.controls.scope.setValue('support-uuid-1');
+      component.zoomToSpan();
+      expect(mockPlotService.plotOptionsChange).not.toHaveBeenCalled();
+    });
+
+    it('should call plotOptionsChange with the correct startSupport and endSupport for a valid span', () => {
+      mockSpanService.getSupportIndex.mockReturnValue(2);
+      component.form.controls.scope.setValue('support-uuid-1');
+      component.zoomToSpan();
+      expect(mockPlotService.plotOptionsChange).toHaveBeenCalledOnce();
+      expect(mockPlotService.plotOptionsChange).toHaveBeenCalledWith({ startSupport: 2, endSupport: 3 });
+    });
+  });
+
+  // ---------------------------------------------------------------------------
   // hasActiveModification computed
   // ---------------------------------------------------------------------------
   describe('hasActiveModification', () => {

--- a/src/app/features/studio/loads/presentation/components/cable-length-change/cable-length-change.spec.ts
+++ b/src/app/features/studio/loads/presentation/components/cable-length-change/cable-length-change.spec.ts
@@ -176,6 +176,12 @@ describe('CableLengthChangeComponent', () => {
       expect(form?.tagName).toBe('FORM');
     });
 
+    it('should render the zoom button', () => {
+      const btn = getByTestId('cable-length-change-zoom');
+      expect(btn).toBeTruthy();
+      expect(btn?.tagName).toBe('BUTTON');
+    });
+
     it('should render the reset button', () => {
       const btn = getByTestId('cable-length-change-reset');
       expect(btn).toBeTruthy();
@@ -232,6 +238,21 @@ describe('CableLengthChangeComponent', () => {
   // HTML rendering — button states
   // ---------------------------------------------------------------------------
   describe('HTML rendering - button states', () => {
+    it('should disable zoom button when no scope is selected', () => {
+      component.form.controls.scope.setValue(null);
+      fixture.detectChanges();
+      const btn = getByTestId('cable-length-change-zoom') as HTMLButtonElement;
+      expect(btn.disabled).toBe(true);
+    });
+
+    it('should enable zoom button when a scope is selected and not loading', () => {
+      component.form.controls.scope.setValue('support-uuid-1');
+      component.isLoading.set(false);
+      fixture.detectChanges();
+      const btn = getByTestId('cable-length-change-zoom') as HTMLButtonElement;
+      expect(btn.disabled).toBe(false);
+    });
+
     it('should disable save button when form is invalid', () => {
       const btn = getByTestId('cable-length-change-save') as HTMLButtonElement;
       expect(btn.disabled).toBe(true);
@@ -313,11 +334,13 @@ describe('CableLengthChangeComponent', () => {
       const calculate = getByTestId('cable-length-change-calculate') as HTMLButtonElement;
       const reset = getByTestId('cable-length-change-reset') as HTMLButtonElement;
       const deleteBtn = getByTestId('cable-length-change-delete') as HTMLButtonElement;
+      const zoom = getByTestId('cable-length-change-zoom') as HTMLButtonElement;
 
       expect(save.disabled).toBe(true);
       expect(calculate.disabled).toBe(true);
       expect(reset.disabled).toBe(true);
       expect(deleteBtn.disabled).toBe(true);
+      expect(zoom.disabled).toBe(true);
     });
   });
 

--- a/src/app/features/studio/loads/presentation/components/cable-length-change/cable-length-change.ts
+++ b/src/app/features/studio/loads/presentation/components/cable-length-change/cable-length-change.ts
@@ -1,6 +1,6 @@
 import { ChangeDetectionStrategy, Component, computed, effect, inject, signal, untracked } from '@angular/core';
 import { FormBuilder, FormControl, ReactiveFormsModule, Validators } from '@angular/forms';
-import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
+import { takeUntilDestroyed, toSignal } from '@angular/core/rxjs-interop';
 import { merge } from 'rxjs';
 import { ButtonComponent } from '@shared/components/atoms/button/button.component';
 import { IconComponent } from '@shared/components/atoms/icon/icon.component';
@@ -58,6 +58,10 @@ export class CableLengthChangeComponent {
     })
   });
 
+  readonly scopeValue = toSignal(this.form.controls.scope.valueChanges, {
+    initialValue: this.form.controls.scope.value
+  });
+
   /** Span options per RG.LON-CAB.POR.1. */
   readonly spansOptions = this.spanService.getSpanOptions;
 
@@ -104,7 +108,7 @@ export class CableLengthChangeComponent {
       const startIndex = untracked(() => this.plotOptionsService.plotOptions().startSupport);
       const defaultUuid = section.supports?.[startIndex]?.uuid ?? section.supports?.[0]?.uuid ?? null;
       untracked(() => {
-        this.form.controls.scope.setValue(defaultUuid, { emitEvent: false });
+        this.form.controls.scope.setValue(defaultUuid);
         if (defaultUuid) this.onScopeChange(defaultUuid);
       });
     });
@@ -116,7 +120,7 @@ export class CableLengthChangeComponent {
       const spanUuid = this.cableModificationsService.selectedSpanUuid();
       if (!spanUuid) return;
       untracked(() => {
-        this.form.controls.scope.setValue(spanUuid, { emitEvent: false });
+        this.form.controls.scope.setValue(spanUuid);
         this.onScopeChange(spanUuid);
         this.cableModificationsService.clearSelectedSpan();
       });
@@ -163,6 +167,14 @@ export class CableLengthChangeComponent {
     }
     this.statesFormControls();
     this.isDirtySinceLastSave.set(false);
+  }
+
+  zoomToSpan(): void {
+    const uuid = this.form.controls.scope.value;
+    if (!uuid) return;
+    const index = this.spanService.getSupportIndex(uuid);
+    if (index < 0) return;
+    this.plotService.plotOptionsChange({ startSupport: index, endSupport: index + 1 });
   }
 
   resetForm(): void {

--- a/src/app/features/studio/loads/presentation/components/cable-span-manip/cable-span-manip.html
+++ b/src/app/features/studio/loads/presentation/components/cable-span-manip/cable-span-manip.html
@@ -6,7 +6,7 @@
       btnStyle="outlined"
       btnSize="s"
       (click)="zoomToSpan()"
-      [disabled]="isLoading()"
+      [disabled]="isLoading() || !scopeValue()"
       data-testid="cable-span-manip-zoom"
     >
       <app-icon icon="filter_center_focus" />

--- a/src/app/features/studio/loads/presentation/components/cable-span-manip/cable-span-manip.html
+++ b/src/app/features/studio/loads/presentation/components/cable-span-manip/cable-span-manip.html
@@ -9,7 +9,7 @@
       [disabled]="isLoading() || !scopeValue()"
       data-testid="cable-span-manip-zoom"
     >
-      <app-icon icon="filter_center_focus" />
+      <app-icon icon="filter_center_focus" aria-hidden="true" />
       <ng-container i18n>Zoom</ng-container>
     </button>
 
@@ -22,7 +22,7 @@
       [disabled]="isLoading()"
       data-testid="cable-span-manip-reset"
     >
-      <app-icon icon="refresh" />
+      <app-icon icon="refresh" aria-hidden="true" />
       <ng-container i18n>Reset</ng-container>
     </button>
   </div>
@@ -245,7 +245,7 @@
 
     <div class="distance-calc-line">
       <button app-btn type="button" disabled aria-disabled="true" data-testid="cable-span-manip-dist-calc-btn">
-        <app-icon icon="rocket_launch" />
+        <app-icon icon="rocket_launch" aria-hidden="true" />
         <ng-container i18n="@@distCalcBetweenPoints">Dist. calc. between points</ng-container>
       </button>
 
@@ -377,7 +377,7 @@
       [disabled]="!hasSavedManipulation() || isLoading()"
       data-testid="cable-span-manip-delete"
     >
-      <app-icon icon="delete" />
+      <app-icon icon="delete" aria-hidden="true" />
     </button>
 
     <button
@@ -388,7 +388,7 @@
       [btnLoading]="isCalculating()"
       data-testid="cable-span-manip-save"
     >
-      <app-icon icon="save" />
+      <app-icon icon="save" aria-hidden="true" />
       <ng-container i18n>Save</ng-container>
     </button>
 
@@ -400,7 +400,7 @@
       (click)="calculate()"
       data-testid="cable-span-manip-calculate"
     >
-      <app-icon icon="rocket_launch" />
+      <app-icon icon="rocket_launch" aria-hidden="true" />
       <ng-container i18n>Calculate</ng-container>
     </button>
   </div>

--- a/src/app/features/studio/loads/presentation/components/cable-span-manip/cable-span-manip.spec.ts
+++ b/src/app/features/studio/loads/presentation/components/cable-span-manip/cable-span-manip.spec.ts
@@ -284,6 +284,21 @@ describe('CableSpanManipComponent', () => {
       expect(btn.disabled).toBe(false);
     });
 
+    it('should disable zoom button when no scope is selected', () => {
+      component.form.controls.scope.setValue(null);
+      fixture.detectChanges();
+      const btn = getByTestId('cable-span-manip-zoom') as HTMLButtonElement;
+      expect(btn.disabled).toBe(true);
+    });
+
+    it('should enable zoom button when a scope is selected and not loading', () => {
+      component.form.controls.scope.setValue('support-uuid-1');
+      component.isLoading.set(false);
+      fixture.detectChanges();
+      const btn = getByTestId('cable-span-manip-zoom') as HTMLButtonElement;
+      expect(btn.disabled).toBe(false);
+    });
+
     it('should disable buttons when isLoading is true', () => {
       component.form.patchValue({
         scope: 'support-uuid-1',

--- a/src/app/features/studio/loads/presentation/components/cable-span-manip/cable-span-manip.ts
+++ b/src/app/features/studio/loads/presentation/components/cable-span-manip/cable-span-manip.ts
@@ -76,6 +76,7 @@ export class CableSpanManipComponent implements OnInit {
   private readonly scopeValueSignal = toSignal(this.form.controls.scope.valueChanges, {
     initialValue: this.form.controls.scope.value
   });
+  readonly scopeValue = computed(() => this.scopeValueSignal());
 
   /** Support data for the currently selected span's left support, reactive to section changes. */
   private readonly selectedSupportData = computed(() => {

--- a/src/app/features/studio/loads/presentation/components/cable-support-manip/cable-support-manip.component.html
+++ b/src/app/features/studio/loads/presentation/components/cable-support-manip/cable-support-manip.component.html
@@ -6,7 +6,7 @@
       btnStyle="outlined"
       btnSize="s"
       (click)="zoomToSupport()"
-      [disabled]="isLoading()"
+      [disabled]="isLoading() || !supportValue()"
       data-testid="cable-support-manip-zoom"
     >
       <app-icon icon="filter_center_focus" aria-hidden="true" />

--- a/src/app/features/studio/loads/presentation/components/cable-support-manip/cable-support-manip.component.spec.ts
+++ b/src/app/features/studio/loads/presentation/components/cable-support-manip/cable-support-manip.component.spec.ts
@@ -126,6 +126,21 @@ describe('CableSupportManipComponent', () => {
   // HTML rendering — button states
   // ---------------------------------------------------------------------------
   describe('HTML rendering - button states', () => {
+    it('should disable zoom button when no support is selected', () => {
+      component.form.controls.support.setValue(null);
+      fixture.detectChanges();
+      const btn = getByTestId('cable-support-manip-zoom') as HTMLButtonElement;
+      expect(btn.disabled).toBe(true);
+    });
+
+    it('should enable zoom button when a support is selected and not loading', () => {
+      component.form.controls.support.setValue('support-uuid-1');
+      component.isLoading.set(false);
+      fixture.detectChanges();
+      const btn = getByTestId('cable-support-manip-zoom') as HTMLButtonElement;
+      expect(btn.disabled).toBe(false);
+    });
+
     it('should disable save button when form is invalid', () => {
       const btn = getByTestId('cable-support-manip-save') as HTMLButtonElement;
       expect(btn.disabled).toBe(true);

--- a/src/app/features/studio/loads/presentation/components/cable-support-manip/cable-support-manip.component.ts
+++ b/src/app/features/studio/loads/presentation/components/cable-support-manip/cable-support-manip.component.ts
@@ -117,6 +117,10 @@ export class CableSupportManipComponent {
     })
   });
 
+  readonly supportValue = toSignal(this.form.controls.support.valueChanges, {
+    initialValue: this.form.controls.support.value
+  });
+
   /** All supports from the current section as select options. */
   readonly supportsOptions = computed<{ label: string; value: string }[]>(() => {
     const supports = this.spanService.section()?.supports ?? [];

--- a/src/app/features/studio/loads/presentation/components/load-marking/load-marking.component.html
+++ b/src/app/features/studio/loads/presentation/components/load-marking/load-marking.component.html
@@ -10,12 +10,12 @@
       (click)="zoomToSpan()"
       data-testid="span-zoom"
     >
-      <app-icon icon="filter_center_focus" />
+      <app-icon icon="filter_center_focus" aria-hidden="true" />
       <ng-container i18n>Zoom</ng-container>
     </button>
 
     <button app-btn type="button" btnStyle="outlined" btnSize="s" (click)="resetForm()" data-testid="span-reset">
-      <app-icon icon="refresh" />
+      <app-icon icon="refresh" aria-hidden="true" />
       <ng-container i18n>Reset</ng-container>
     </button>
   </div>
@@ -97,7 +97,7 @@
       (click)="deleteCharge()"
       data-testid="delete-load"
     >
-      <app-icon icon="delete" />
+      <app-icon icon="delete" aria-hidden="true" />
     </button>
 
     <button
@@ -109,7 +109,7 @@
       [btnLoading]="isSaving()"
       data-testid="save-load"
     >
-      <app-icon icon="save" />
+      <app-icon icon="save" aria-hidden="true" />
       <ng-container i18n>Save</ng-container>
     </button>
 
@@ -121,7 +121,7 @@
       (click)="calculateLoadCase()"
       data-testid="calculate-load"
     >
-      <app-icon icon="rocket_launch" />
+      <app-icon icon="rocket_launch" aria-hidden="true" />
       <ng-container i18n>Calculate</ng-container>
     </button>
   </div>

--- a/src/app/features/studio/loads/presentation/components/load-marking/load-marking.component.html
+++ b/src/app/features/studio/loads/presentation/components/load-marking/load-marking.component.html
@@ -1,5 +1,19 @@
 <form [formGroup]="form" class="span__form" data-testid="span-form">
-  <div class="span__reset">
+  <div class="header-btns">
+    <button
+      class="flex items-center m-0"
+      app-btn
+      type="button"
+      btnStyle="outlined"
+      btnSize="s"
+      [disabled]="!spanSelectValue()"
+      (click)="zoomToSpan()"
+      data-testid="span-zoom"
+    >
+      <app-icon icon="filter_center_focus" />
+      <ng-container i18n>Zoom</ng-container>
+    </button>
+
     <button app-btn type="button" btnStyle="outlined" btnSize="s" (click)="resetForm()" data-testid="span-reset">
       <app-icon icon="refresh" />
       <ng-container i18n>Reset</ng-container>
@@ -7,22 +21,7 @@
   </div>
 
   <div>
-    <div class="flex items-baseline justify-between mb-0.5">
-      <label for="spanSelect" class="mb-0" i18n>Span</label>
-
-      <button
-        class="flex items-center m-0"
-        app-btn
-        type="button"
-        btnStyle="outlined"
-        btnSize="s"
-        (click)="zoomToSpan()"
-        data-testid="span-zoom"
-      >
-        <app-icon icon="filter_center_focus" />
-        <ng-container i18n>Zoom</ng-container>
-      </button>
-    </div>
+    <label for="spanSelect" class="mb-0" i18n>Span</label>
     <p-select
       inputId="spanSelect"
       [options]="spansOptions()"

--- a/src/app/features/studio/loads/presentation/components/load-marking/load-marking.component.scss
+++ b/src/app/features/studio/loads/presentation/components/load-marking/load-marking.component.scss
@@ -1,14 +1,14 @@
 @use 'abstract.extracts' as app;
 
+.header-btns {
+  @apply flex items-center justify-between col-span-2 mb-3;
+}
+
 .span {
   &__form {
     @apply grid grid-cols-2;
     gap: 0.625rem;
     align-items: end;
-  }
-
-  &__reset {
-    @apply text-right col-span-2;
   }
 
   &__btns {

--- a/src/app/features/studio/loads/presentation/components/load-marking/load-marking.component.scss
+++ b/src/app/features/studio/loads/presentation/components/load-marking/load-marking.component.scss
@@ -8,7 +8,7 @@
   &__form {
     @apply grid grid-cols-2;
     gap: 0.625rem;
-    align-items: end;
+    align-items: start;
   }
 
   &__btns {

--- a/src/app/features/studio/loads/presentation/components/load-marking/load-marking.component.spec.ts
+++ b/src/app/features/studio/loads/presentation/components/load-marking/load-marking.component.spec.ts
@@ -319,18 +319,6 @@ describe('LoadMarkingComponent', () => {
       expect(component.form.controls.loadWeight.value).toBe(0);
     });
 
-    it('resets type to default when type value is null', () => {
-      const temporaryLoadData = createTemporaryLoadData({ type: LoadType.MARKING });
-      mockPlotService['temporaryLoadData'] = temporaryLoadData;
-
-      component.form.controls.spanSelect.setValue('support-1');
-      fixture.detectChanges();
-
-      component.form.controls.type.setValue(null as unknown as LoadType);
-      fixture.detectChanges();
-
-      expect(temporaryLoadData.spanLoads[0].type).toBe(LoadType.PUNCTUAL);
-    });
 
     it('resets referenceSupport to default when value is null', () => {
       const temporaryLoadData = createTemporaryLoadData({ referenceSupport: 'RIGHT' });

--- a/src/app/features/studio/loads/presentation/components/load-marking/load-marking.component.spec.ts
+++ b/src/app/features/studio/loads/presentation/components/load-marking/load-marking.component.spec.ts
@@ -326,7 +326,7 @@ describe('LoadMarkingComponent', () => {
       component.form.controls.spanSelect.setValue('support-1');
       fixture.detectChanges();
 
-      component.form.controls.type.setValue(null);
+      component.form.controls.type.setValue(null as unknown as LoadType);
       fixture.detectChanges();
 
       expect(temporaryLoadData.spanLoads[0].type).toBe(LoadType.PUNCTUAL);
@@ -579,6 +579,20 @@ describe('LoadMarkingComponent', () => {
       btn.click();
 
       expect(mockPlotService['plotOptionsChange']).not.toHaveBeenCalled();
+    });
+
+    it('should disable zoom button when no span is selected', () => {
+      component.form.controls.spanSelect.setValue(null);
+      fixture.detectChanges();
+      const btn = getByTestId('span-zoom') as HTMLButtonElement;
+      expect(btn.disabled).toBe(true);
+    });
+
+    it('should enable zoom button when a span is selected', () => {
+      component.form.controls.spanSelect.setValue('support-1');
+      fixture.detectChanges();
+      const btn = getByTestId('span-zoom') as HTMLButtonElement;
+      expect(btn.disabled).toBe(false);
     });
   });
 

--- a/src/app/features/studio/loads/presentation/components/load-marking/load-marking.component.spec.ts
+++ b/src/app/features/studio/loads/presentation/components/load-marking/load-marking.component.spec.ts
@@ -319,7 +319,6 @@ describe('LoadMarkingComponent', () => {
       expect(component.form.controls.loadWeight.value).toBe(0);
     });
 
-
     it('resets referenceSupport to default when value is null', () => {
       const temporaryLoadData = createTemporaryLoadData({ referenceSupport: 'RIGHT' });
       mockPlotService['temporaryLoadData'] = temporaryLoadData;

--- a/src/app/features/studio/loads/presentation/components/load-marking/load-marking.component.ts
+++ b/src/app/features/studio/loads/presentation/components/load-marking/load-marking.component.ts
@@ -228,11 +228,7 @@ export class LoadMarkingComponent {
         load.loadWeight = typeof value === 'number' ? value : emptySpanLoad.loadWeight;
         break;
       case 'type':
-        if (value === LoadType.PUNCTUAL || value === LoadType.MARKING) {
-          load.type = value;
-        } else {
-          load.type = emptySpanLoad.type;
-        }
+        load.type = value === LoadType.MARKING ? LoadType.MARKING : LoadType.PUNCTUAL;
         if (load.type === LoadType.MARKING) {
           load.loadWeight = 0;
           this.form.controls.loadWeight.setValue(0, { emitEvent: false });

--- a/src/app/features/studio/loads/presentation/components/load-marking/load-marking.component.ts
+++ b/src/app/features/studio/loads/presentation/components/load-marking/load-marking.component.ts
@@ -68,6 +68,7 @@ export class LoadMarkingComponent {
   private readonly spanSelectSignal = toSignal(this.form.controls.spanSelect.valueChanges, {
     initialValue: this.form.controls.spanSelect.value
   });
+  readonly spanSelectValue = computed(() => this.spanSelectSignal());
 
   private readonly loadControlSignals: Record<LoadControlName, Signal<unknown>> = {
     loadPosition: toSignal(this.form.controls.loadPosition.valueChanges, {

--- a/src/app/features/studio/obstacles/presentation/components/obstaclesForm/obstaclesForm.component.html
+++ b/src/app/features/studio/obstacles/presentation/components/obstaclesForm/obstaclesForm.component.html
@@ -9,7 +9,8 @@
       btnSize="s"
       data-testid="return-to-span"
     >
-      <ng-container i18n>Return to span</ng-container>
+      <app-icon icon="filter_center_focus" />
+      <ng-container i18n>Zoom</ng-container>
     </button>
 
     <button

--- a/src/app/features/studio/obstacles/presentation/components/obstaclesForm/obstaclesForm.component.html
+++ b/src/app/features/studio/obstacles/presentation/components/obstaclesForm/obstaclesForm.component.html
@@ -9,7 +9,7 @@
       btnSize="s"
       data-testid="return-to-span"
     >
-      <app-icon icon="filter_center_focus" />
+      <app-icon icon="filter_center_focus" aria-hidden="true" />
       <ng-container i18n>Zoom</ng-container>
     </button>
 


### PR DESCRIPTION
Move "zoom" button on form header for load marking. Change obstacles' zoom button label (return to span > zoom). Add logic for all zoom buttons to be disabled when there's no span or support selected

**Please check if the PR fulfills these requirements**
<!-- please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes -->
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**Does this PR already have an issue describing the problem?**
PR for bug #749 