### PR TITLE
Feat/769/load case not update form loads

### DIFF
--- a/src/app/core/services/plot/plot.service.ts
+++ b/src/app/core/services/plot/plot.service.ts
@@ -187,11 +187,6 @@ export class PlotService {
   refreshProjection = async () => {
     this.loading.set(true);
 
-    // Preserve the current camera position before any geometry or aspect ratio changes.
-    // The aspect ratio recalculation below can cause Plotly to resize the plot, which
-    // may visually reset the camera zoom and angle if we don't explicitly restore it.
-    const preservedCamera = this.plotOptionsService.getCamera();
-
     const plotOptions = this.plotOptionsService.plotOptions();
     const { result, error, diagnostics } = await this.workerPythonService.runTask(Task.refreshProjection, {
       startSupport: plotOptions.startSupport,

--- a/src/app/core/services/plot/plot.service.ts
+++ b/src/app/core/services/plot/plot.service.ts
@@ -31,6 +31,7 @@ export class PlotService {
 
   litData = signal<GetSectionOutput | null>(null);
   baseLitData = signal<GetSectionOutput | null>(null);
+  readonly litDataCache = new Map<string, GetSectionOutput>();
   /** Distance/angle measurement point groups registered in the position engine, rendered like obstacles. */
   distanceMeasuringPoints = signal<ObstacleOutput['obstacles']>([]);
   loading = signal<boolean>(true);
@@ -121,6 +122,7 @@ export class PlotService {
 
   initSectionStudio = async (section: Section) => {
     this.currentSectionUuid = section?.uuid ?? null;
+    this.litDataCache.clear();
     this.error.set(null);
     this.diagnostics.set([]);
     this.litData.set(null);
@@ -172,6 +174,12 @@ export class PlotService {
 
   refreshProjection = async () => {
     this.loading.set(true);
+
+    // Preserve the current camera position before any geometry or aspect ratio changes.
+    // The aspect ratio recalculation below can cause Plotly to resize the plot, which
+    // may visually reset the camera zoom and angle if we don't explicitly restore it.
+    const preservedCamera = this.plotOptionsService.getCamera();
+
     const plotOptions = this.plotOptionsService.plotOptions();
     const { result, error, diagnostics } = await this.workerPythonService.runTask(Task.refreshProjection, {
       startSupport: plotOptions.startSupport,
@@ -192,6 +200,12 @@ export class PlotService {
 
     const scalingFactors = untracked(() => this.plotOptionsService.scalingFactors());
     await this.updateAspectRatio(scalingFactors, plotOptions);
+
+    // Restore the preserved camera to maintain the user's viewport after aspect ratio
+    // updates. This prevents unwanted zoom/angle resets when the plot geometry changes.
+    if (preservedCamera) {
+      this.plotOptionsService.camera.set(preservedCamera);
+    }
 
     this.loading.set(false);
   };

--- a/src/app/core/services/plot/plot.service.ts
+++ b/src/app/core/services/plot/plot.service.ts
@@ -56,6 +56,16 @@ export class PlotService {
   /** UUID of the section currently loaded in the Python engine — used to skip redundant initSectionStudio calls. */
   private currentSectionUuid: string | null = null;
 
+  /** Last aspect ratio calculation inputs — used to skip redundant getAspectRatio calls when geometry hasn't changed. */
+  private lastAspectRatioInputs: {
+    x: number;
+    y: number;
+    z: number;
+    startSupport: number;
+    endSupport: number;
+    view: string;
+  } | null = null;
+
   constructor() {
     this.subscription = this.workerPythonService.ready$.subscribe((value) => {
       this.workerReady.set(value);
@@ -83,6 +93,7 @@ export class PlotService {
     this.spanService.section.set(null);
     this.study.set(null);
     this.currentSectionUuid = null;
+    this.lastAspectRatioInputs = null;
     this.obstacleStateService.reset();
     this.obstaclesService.setSelectedObstacle(null, null);
     this.sideTabsService.sideTabs.set(null);
@@ -123,6 +134,7 @@ export class PlotService {
   initSectionStudio = async (section: Section) => {
     this.currentSectionUuid = section?.uuid ?? null;
     this.litDataCache.clear();
+    this.lastAspectRatioInputs = null;
     this.error.set(null);
     this.diagnostics.set([]);
     this.litData.set(null);
@@ -199,12 +211,8 @@ export class PlotService {
     this.diagnostics.set(diagnostics);
 
     const scalingFactors = untracked(() => this.plotOptionsService.scalingFactors());
-    await this.updateAspectRatio(scalingFactors, plotOptions);
-
-    // Restore the preserved camera to maintain the user's viewport after aspect ratio
-    // updates. This prevents unwanted zoom/angle resets when the plot geometry changes.
-    if (preservedCamera) {
-      this.plotOptionsService.camera.set(preservedCamera);
+    if (this.hasAspectRatioInputsChanged(scalingFactors, plotOptions)) {
+      await this.updateAspectRatio(scalingFactors, plotOptions);
     }
 
     this.loading.set(false);
@@ -223,6 +231,29 @@ export class PlotService {
     this.loading.set(false);
   };
 
+  /**
+   * Checks if the aspect ratio calculation inputs have changed since the last computation.
+   * @param scalingFactors - Current scaling factors
+   * @param plotOptions - Current plot options
+   * @returns `true` if inputs changed or no previous calculation exists, `false` otherwise
+   */
+  private hasAspectRatioInputsChanged(
+    scalingFactors: { x: number; y: number; z: number },
+    plotOptions: PlotOptions
+  ): boolean {
+    if (this.lastAspectRatioInputs === null) {
+      return true;
+    }
+    return (
+      this.lastAspectRatioInputs.x !== scalingFactors.x ||
+      this.lastAspectRatioInputs.y !== scalingFactors.y ||
+      this.lastAspectRatioInputs.z !== scalingFactors.z ||
+      this.lastAspectRatioInputs.startSupport !== plotOptions.startSupport ||
+      this.lastAspectRatioInputs.endSupport !== plotOptions.endSupport ||
+      this.lastAspectRatioInputs.view !== plotOptions.view
+    );
+  }
+
   private async updateAspectRatio(
     scalingFactors: { x: number; y: number; z: number },
     plotOptions: PlotOptions
@@ -235,6 +266,14 @@ export class PlotService {
     });
     if (result) {
       this.plotOptionsService.setAspectRatio(result);
+      this.lastAspectRatioInputs = {
+        x: scalingFactors.x,
+        y: scalingFactors.y,
+        z: scalingFactors.z,
+        startSupport: plotOptions.startSupport,
+        endSupport: plotOptions.endSupport,
+        view: plotOptions.view
+      };
     }
   }
 }

--- a/src/app/core/services/worker_python/python-packages.json
+++ b/src/app/core/services/worker_python/python-packages.json
@@ -90,7 +90,7 @@
     "source": "cdn"
   },
   "stellar-engine": {
-    "file_name": "stellar_engine-0.2.1-py3-none-any.whl",
+    "file_name": "stellar_engine-0.2.1-cp313-none-any.whl",
     "name": "stellar_engine",
     "source": "local"
   },

--- a/src/app/core/services/worker_python/tasks/types.ts
+++ b/src/app/core/services/worker_python/tasks/types.ts
@@ -291,6 +291,7 @@ export interface TaskInputs {
   /** Inputs for changeState task */
   [Task.changeState]: {
     climate: ClimateCharge;
+    spanLoads?: SpanLoad[];
     reload?: boolean;
   };
   /** Inputs for refreshProjection task */

--- a/src/app/features/studio/core/presentation/components/menu-bar/menu-bar.component.spec.ts
+++ b/src/app/features/studio/core/presentation/components/menu-bar/menu-bar.component.spec.ts
@@ -518,16 +518,16 @@ describe('StudioMenuBarComponent', () => {
   });
 
   describe('deleteChargeCase', () => {
-    it('should call deleteLoad then deleteCharge when deleting the selected charge', async () => {
+    it('should call deleteLoad when deleting the selected charge', async () => {
       const charge = { label: 'Charge 1', value: 'charge-uuid-1' }; // charge-uuid-1 is selected
 
       await component.deleteChargeCase(charge);
 
       expect(mockLoadFormsService.deleteLoad).toHaveBeenCalled();
-      expect(mockChargesService.deleteCharge).toHaveBeenCalledWith('study-uuid-1', 'section-uuid-1', 'charge-uuid-1');
+      expect(mockChargesService.deleteCharge).not.toHaveBeenCalled();
     });
 
-    it('should call deleteLoad before deleteCharge when deleting the selected charge', async () => {
+    it('should call only deleteLoad when deleting the selected charge', async () => {
       const charge = { label: 'Charge 1', value: 'charge-uuid-1' };
       const callOrder: string[] = [];
       (mockLoadFormsService.deleteLoad as ReturnType<typeof vi.fn>).mockImplementation(() => {
@@ -541,7 +541,7 @@ describe('StudioMenuBarComponent', () => {
 
       await component.deleteChargeCase(charge);
 
-      expect(callOrder).toEqual(['deleteLoad', 'deleteCharge']);
+      expect(callOrder).toEqual(['deleteLoad']);
     });
 
     it('should skip deleteLoad when deleting a non-selected charge', async () => {

--- a/src/app/features/studio/core/presentation/components/menu-bar/menu-bar.component.ts
+++ b/src/app/features/studio/core/presentation/components/menu-bar/menu-bar.component.ts
@@ -93,11 +93,13 @@ export class StudioMenuBarComponent {
     const chargeUuid = charge?.value ?? '';
     if (!chargeUuid) return;
     const litDataSnapshot = this.plotService.litData();
-    this.chargesService.duplicateCharge(this.study()?.uuid ?? '', this.section()?.uuid ?? '', chargeUuid).then((newCharge) => {
-      if (litDataSnapshot) {
-        this.plotService.litDataCache.set(newCharge.uuid, litDataSnapshot);
-      }
-    });
+    this.chargesService
+      .duplicateCharge(this.study()?.uuid ?? '', this.section()?.uuid ?? '', chargeUuid)
+      .then((newCharge) => {
+        if (litDataSnapshot) {
+          this.plotService.litDataCache.set(newCharge.uuid, litDataSnapshot);
+        }
+      });
   }
 
   viewOrEditChargeCase(charge: { label: string; value: string }, mode: 'view' | 'edit') {

--- a/src/app/features/studio/core/presentation/components/menu-bar/menu-bar.component.ts
+++ b/src/app/features/studio/core/presentation/components/menu-bar/menu-bar.component.ts
@@ -84,8 +84,9 @@ export class StudioMenuBarComponent {
     const isSelectedCharge = charge.value === this.selectedChargeCaseUuid();
     if (isSelectedCharge) {
       await this.loadFormsService.deleteLoad();
+    } else {
+      await this.chargesService.deleteCharge(this.study()?.uuid ?? '', this.section()?.uuid ?? '', charge.value);
     }
-    await this.chargesService.deleteCharge(this.study()?.uuid ?? '', this.section()?.uuid ?? '', charge.value);
   }
 
   duplicateChargeCase(charge?: { label: string; value: string }) {

--- a/src/app/features/studio/core/presentation/components/menu-bar/menu-bar.component.ts
+++ b/src/app/features/studio/core/presentation/components/menu-bar/menu-bar.component.ts
@@ -2,6 +2,7 @@ import { ChangeDetectionStrategy, Component, computed, inject, input, output } f
 import { RouterLink } from '@angular/router';
 import { FormsModule } from '@angular/forms';
 import { ChargesService } from '@services/charges/charges.service';
+import { PlotService } from '@services/plot/plot.service';
 import { Section, Study } from '@shared/domain';
 import { SelectWithButtonsComponent } from '@shared/components/atoms/select-with-buttons/select-with-buttons.component';
 import { SelectButtonModule } from 'primeng/selectbutton';
@@ -63,6 +64,7 @@ export class StudioMenuBarComponent {
   private readonly toolbarDialogService = inject(ToolbarDialogService);
   private readonly chargesService = inject(ChargesService);
   private readonly loadFormsService = inject(LoadFormsService);
+  private readonly plotService = inject(PlotService);
 
   launchChargeFunction(
     functionToLaunch: (studyUuid: string, sectionUuid: string, value: string) => void,
@@ -87,7 +89,14 @@ export class StudioMenuBarComponent {
   }
 
   duplicateChargeCase(charge?: { label: string; value: string }) {
-    this.launchChargeFunction(this.chargesService.duplicateCharge.bind(this.chargesService), charge?.value ?? '');
+    const chargeUuid = charge?.value ?? '';
+    if (!chargeUuid) return;
+    const litDataSnapshot = this.plotService.litData();
+    this.chargesService.duplicateCharge(this.study()?.uuid ?? '', this.section()?.uuid ?? '', chargeUuid).then((newCharge) => {
+      if (litDataSnapshot) {
+        this.plotService.litDataCache.set(newCharge.uuid, litDataSnapshot);
+      }
+    });
   }
 
   viewOrEditChargeCase(charge: { label: string; value: string }, mode: 'view' | 'edit') {

--- a/src/app/features/studio/core/presentation/pages/studio-page/studio-page.component.ts
+++ b/src/app/features/studio/core/presentation/pages/studio-page/studio-page.component.ts
@@ -48,7 +48,7 @@ import { PlotResolutionService } from '@services/plot/plot-resolution.service';
 import { LoadFormsService } from '@features/studio/loads/presentation/services/loadForms.service';
 import { ObstacleStateService } from '@services/obstacle-state/obstacle-state.service';
 import { ObstaclesFormComponent } from '@features/studio/obstacles/presentation/components/obstaclesForm/obstaclesForm.component';
-import { STUDIO_PLOT_DEBOUNCE_DELAY } from '@shared/components/studio/section/helpers/plot.constants';
+import { STUDIO_SLIDER_DEBOUNCE_DELAY } from '@shared/components/studio/section/helpers/plot.constants';
 import { CableLengthChangeComponent } from '@features/studio/loads/presentation/components/cable-length-change/cable-length-change';
 import { formatSupportNumber } from '@shared/helpers/formatSupportNumber';
 import { CableSpanManipComponent } from '@features/studio/loads/presentation/components/cable-span-manip/cable-span-manip';
@@ -363,7 +363,7 @@ export class StudioPageComponent implements OnInit, OnDestroy {
     const diff = Math.abs(options.endSupport - options.startSupport);
     const spanAmount = this.getSpanAmount(diff);
     this.spanService.spanAmountChoice.set(spanAmount);
-  }, STUDIO_PLOT_DEBOUNCE_DELAY);
+  }, STUDIO_SLIDER_DEBOUNCE_DELAY);
 
   private getSpanAmount(diff: number): SpanAmountChoice {
     if (diff === 1) return 'single';

--- a/src/app/features/studio/loads/presentation/components/climate/climate.component.spec.ts
+++ b/src/app/features/studio/loads/presentation/components/climate/climate.component.spec.ts
@@ -107,7 +107,10 @@ describe('ClimateComponent effect edge cases', () => {
     const plotServiceMock = {
       study: signal(null),
       workerReady: signal(false),
-      litData: signal(null)
+      litData: signal(null),
+      baseLitData: signal(null),
+      loading: signal(false),
+      litDataCache: new Map()
     } as unknown as PlotService;
     const spanServiceMock = {
       section: signal({ uuid: 'section-uuid-1', supports: [] })
@@ -143,7 +146,10 @@ describe('ClimateComponent effect edge cases', () => {
     const plotServiceMock = {
       study: signal({ uuid: 'study-uuid-1' }),
       workerReady: signal(false),
-      litData: signal(null)
+      litData: signal(null),
+      baseLitData: signal(null),
+      loading: signal(false),
+      litDataCache: new Map()
     } as unknown as PlotService;
     const spanServiceMock = {
       section: signal({ uuid: 'section-uuid-1', supports: [] })

--- a/src/app/features/studio/loads/presentation/components/climate/climate.component.spec.ts
+++ b/src/app/features/studio/loads/presentation/components/climate/climate.component.spec.ts
@@ -331,12 +331,10 @@ describe('ClimateComponent', () => {
   });
 
   describe('deleteCharge', () => {
-    it('should call loadFormsService.deleteLoad then chargesService.deleteCharge', async () => {
+    it('should call loadFormsService.deleteLoad', async () => {
       const loadFormsService = TestBed.inject(LoadFormsService);
-      const chargesService = TestBed.inject(ChargesService);
       await component.deleteCharge();
       expect(loadFormsService.deleteLoad).toHaveBeenCalled();
-      expect(chargesService.deleteCharge).toHaveBeenCalledWith('study-uuid-1', 'section-uuid-1', 'test-charge-uuid');
     });
 
     it('should throw error when study is not found', async () => {

--- a/src/app/features/studio/loads/presentation/components/climate/climate.component.ts
+++ b/src/app/features/studio/loads/presentation/components/climate/climate.component.ts
@@ -165,7 +165,6 @@ export class ClimateComponent {
       throw new Error('Study or section not found');
     }
     await this.loadFormsService.deleteLoad();
-    await this.chargesService.deleteCharge(studyUuid, sectionUuid, this.chargeUuid());
   }
 
   async saveForm() {

--- a/src/app/features/studio/loads/presentation/components/load-marking/load-marking.component.spec.ts
+++ b/src/app/features/studio/loads/presentation/components/load-marking/load-marking.component.spec.ts
@@ -6,6 +6,7 @@ import { PlotSpanService } from '@services/plot/plot-span.service';
 import { LoadFormsService } from '../../services/loadForms.service';
 import { ChargeData, LoadType, SpanLoad, SymmetryType } from '@shared/domain/models/charge.model';
 import { SpanOption } from '@src/app/shared/types/plot.types';
+import { Section } from '@shared/domain';
 
 const mockSpanOptions: SpanOption[] = [
   { label: '1 - 2', value: 'support-1' },
@@ -59,7 +60,8 @@ describe('LoadMarkingComponent', () => {
     mockSpanService = {
       getSpanOptions: signal<SpanOption[]>(mockSpanOptions),
       getSupportIndex: vi.fn().mockReturnValue(0),
-      getSupportOptions: vi.fn().mockReturnValue(mockSupportOptions)
+      getSupportOptions: vi.fn().mockReturnValue(mockSupportOptions),
+      section: signal<Section | null>(null)
     };
 
     mockLoadFormsService = {
@@ -162,6 +164,24 @@ describe('LoadMarkingComponent', () => {
       component.resetForm();
       fixture.detectChanges();
 
+      expect(component.form.get('spanSelect')?.value).toBeNull();
+      expect(component.form.get('referenceSupport')?.disabled).toBe(true);
+      expect(mockLoadFormsService['initTemporaryLoadData']).toHaveBeenCalled();
+    });
+
+    it('resets form immediately regardless of loading state', () => {
+      // Set loading to true
+      (mockPlotService.loading as ReturnType<typeof signal<boolean>>).set(true);
+      
+      component.form.controls.spanSelect.setValue('support-1');
+      component.form.controls.referenceSupport.enable();
+      component.form.controls.referenceSupport.setValue('LEFT');
+      fixture.detectChanges();
+
+      component.resetForm();
+      fixture.detectChanges();
+
+      // Verify form is reset immediately, even though loading is true
       expect(component.form.get('spanSelect')?.value).toBeNull();
       expect(component.form.get('referenceSupport')?.disabled).toBe(true);
       expect(mockLoadFormsService['initTemporaryLoadData']).toHaveBeenCalled();
@@ -634,6 +654,119 @@ describe('LoadMarkingComponent', () => {
       expect(
         (mockLoadFormsService['selectedSpanSupportUuid'] as ReturnType<typeof signal<string | null>>)()
       ).toBeNull();
+    });
+  });
+
+  describe('_reloadOnChargeChange effect', () => {
+    it('should reset form when selected charge UUID changes', () => {
+      const mockSectionWithCharge: Section = {
+        uuid: 'section-uuid-1',
+        name: 'Test Section',
+        cable_name: 'Test Cable',
+        supports: [
+          {
+            uuid: 'support-1',
+            number: '1',
+            name: 'Support 1',
+            spanLength: 100,
+            spanAngle: 0
+          } as Section['supports'][0]
+        ],
+        obstacles: [],
+        initial_conditions: [],
+        charges: [
+          {
+            uuid: 'charge-uuid-1',
+            name: 'Charge 1',
+            personnelPresence: false,
+            description: '',
+            data: createTemporaryLoadData()
+          },
+          {
+            uuid: 'charge-uuid-2',
+            name: 'Charge 2',
+            personnelPresence: false,
+            description: '',
+            data: createTemporaryLoadData()
+          }
+        ],
+        selected_charge_uuid: 'charge-uuid-1'
+      } as Section;
+
+      // Set initial section with charge-uuid-1
+      (mockSpanService.section as ReturnType<typeof signal<Section | null>>).set(mockSectionWithCharge);
+      TestBed.flushEffects();
+      fixture.detectChanges();
+
+      // Set form values
+      component.form.controls.spanSelect.setValue('support-1');
+      component.form.controls.referenceSupport.enable();
+      component.form.controls.referenceSupport.setValue('LEFT');
+      fixture.detectChanges();
+
+      // Change the selected charge UUID
+      (mockSpanService.section as ReturnType<typeof signal<Section | null>>).set({
+        ...mockSectionWithCharge,
+        selected_charge_uuid: 'charge-uuid-2'
+      });
+      TestBed.flushEffects();
+      fixture.detectChanges();
+
+      // Verify form was reset
+      expect(component.form.get('spanSelect')?.value).toBeNull();
+      expect(component.form.get('referenceSupport')?.disabled).toBe(true);
+    });
+
+    it('should not reset form when charge UUID stays the same', () => {
+      const mockSectionWithCharge: Section = {
+        uuid: 'section-uuid-1',
+        name: 'Test Section',
+        cable_name: 'Test Cable',
+        supports: [
+          {
+            uuid: 'support-1',
+            number: '1',
+            name: 'Support 1',
+            spanLength: 100,
+            spanAngle: 0
+          } as Section['supports'][0]
+        ],
+        obstacles: [],
+        initial_conditions: [],
+        charges: [
+          {
+            uuid: 'charge-uuid-1',
+            name: 'Charge 1',
+            personnelPresence: false,
+            description: '',
+            data: createTemporaryLoadData()
+          }
+        ],
+        selected_charge_uuid: 'charge-uuid-1'
+      } as Section;
+
+      // Set initial section
+      (mockSpanService.section as ReturnType<typeof signal<Section | null>>).set(mockSectionWithCharge);
+      TestBed.flushEffects();
+      fixture.detectChanges();
+
+      // Set form values
+      component.form.controls.spanSelect.setValue('support-1');
+      component.form.controls.referenceSupport.enable();
+      component.form.controls.referenceSupport.setValue('LEFT');
+      fixture.detectChanges();
+
+      // Update section without changing charge UUID
+      (mockSpanService.section as ReturnType<typeof signal<Section | null>>).set({
+        ...mockSectionWithCharge,
+        name: 'Updated Section Name'
+      });
+      TestBed.flushEffects();
+      fixture.detectChanges();
+
+      // Verify form was NOT reset
+      expect(component.form.get('spanSelect')?.value).toBe('support-1');
+      expect(component.form.get('referenceSupport')?.value).toBe('LEFT');
     });
   });
 });

--- a/src/app/features/studio/loads/presentation/components/load-marking/load-marking.component.spec.ts
+++ b/src/app/features/studio/loads/presentation/components/load-marking/load-marking.component.spec.ts
@@ -172,7 +172,7 @@ describe('LoadMarkingComponent', () => {
     it('resets form immediately regardless of loading state', () => {
       // Set loading to true
       (mockPlotService.loading as ReturnType<typeof signal<boolean>>).set(true);
-      
+
       component.form.controls.spanSelect.setValue('support-1');
       component.form.controls.referenceSupport.enable();
       component.form.controls.referenceSupport.setValue('LEFT');

--- a/src/app/features/studio/loads/presentation/components/load-marking/load-marking.component.ts
+++ b/src/app/features/studio/loads/presentation/components/load-marking/load-marking.component.ts
@@ -127,6 +127,15 @@ export class LoadMarkingComponent {
     { label: $localize`Marking`, value: 'marking' }
   ];
 
+  private _previousChargeUuid: string | null | undefined = undefined;
+
+  private readonly _reloadOnChargeChange = effect(() => {
+    const chargeUuid = this.spanService.section()?.selected_charge_uuid ?? null;
+    if (chargeUuid === this._previousChargeUuid) return;
+    this._previousChargeUuid = chargeUuid;
+    untracked(() => this.resetForm());
+  });
+
   resetForm() {
     this.form.reset();
     this.form.controls.referenceSupport.disable();

--- a/src/app/features/studio/loads/presentation/services/loadForms.service.spec.ts
+++ b/src/app/features/studio/loads/presentation/services/loadForms.service.spec.ts
@@ -629,7 +629,7 @@ describe('LoadFormsService', () => {
       expect(mockPlotService.litData.set).not.toHaveBeenCalled();
     });
 
-    it('should set litData to baseLitData on cache miss when baseLitData is set', () => {
+    it('should NOT set litData to baseLitData on cache miss when a charge is selected', () => {
       const mockBaseData = { litCode: 'base' } as unknown as GetSectionOutput;
       const freshPlotService = {
         ...mockPlotService,
@@ -660,6 +660,43 @@ describe('LoadFormsService', () => {
       const freshService = TestBed.inject(LoadFormsService);
       TestBed.flushEffects();
       expect(freshService).toBeTruthy();
+      // Switching to a charge case: keep current litData visible, do NOT flash the base state
+      expect(freshPlotService.litData.set).not.toHaveBeenCalledWith(mockBaseData);
+    });
+
+    it('should set litData to baseLitData when charge is deselected (chargeUuid becomes null)', () => {
+      const mockBaseData = { litCode: 'base' } as unknown as GetSectionOutput;
+      const freshPlotService = {
+        ...mockPlotService,
+        baseLitData: vi.fn().mockReturnValue(mockBaseData),
+        litData: { set: vi.fn() },
+        litDataCache: new Map()
+      };
+      // Section has no selected charge (deselected)
+      const freshSpanService = {
+        section: vi.fn().mockReturnValue({
+          ...mockSection,
+          selected_charge_uuid: null
+        } as Section)
+      };
+
+      TestBed.resetTestingModule();
+      TestBed.configureTestingModule({
+        providers: [
+          LoadFormsService,
+          { provide: PlotService, useValue: freshPlotService },
+          { provide: PlotSpanService, useValue: freshSpanService },
+          { provide: PlotOptionsService, useValue: plotOptionsServiceMock },
+          { provide: ChargesService, useValue: mockChargesService },
+          { provide: WorkerPythonService, useValue: mockWorkerPythonService },
+          { provide: ObstacleStateService, useValue: mockObstacleStateService }
+        ]
+      });
+
+      const freshService = TestBed.inject(LoadFormsService);
+      TestBed.flushEffects();
+      expect(freshService).toBeTruthy();
+      // Deselecting a charge → revert to base state immediately
       expect(freshPlotService.litData.set).toHaveBeenCalledWith(mockBaseData);
     });
 

--- a/src/app/features/studio/loads/presentation/services/loadForms.service.spec.ts
+++ b/src/app/features/studio/loads/presentation/services/loadForms.service.spec.ts
@@ -340,7 +340,7 @@ describe('LoadFormsService', () => {
       expect(plotOptionsServiceMock.refreshCamera).not.toHaveBeenCalled();
     });
 
-    it('should call refreshCamera and runTask(changeState) when temporaryLoadData is set', async () => {
+    it('should call refreshCamera and runTask(changeState) with climate AND spanLoads', async () => {
       mockPlotService.temporaryLoadData = mockChargeData;
       mockSpanService.section.mockReturnValue(mockSection);
       mockWorkerPythonService.runTask.mockResolvedValue({ result: { success: true }, error: null });
@@ -348,7 +348,34 @@ describe('LoadFormsService', () => {
       await service.calculateLoad();
 
       expect(plotOptionsServiceMock.refreshCamera).toHaveBeenCalled();
-      expect(mockWorkerPythonService.runTask).toHaveBeenCalledWith(Task.changeState, expect.any(Object));
+      expect(mockWorkerPythonService.runTask).toHaveBeenCalledWith(Task.changeState, {
+        climate: expect.any(Object),
+        spanLoads: expect.any(Array)
+      });
+    });
+
+    it('should pass empty spanLoads array to clear previous loads', async () => {
+      mockPlotService.temporaryLoadData = {
+        climate: mockChargeData.climate,
+        spanLoads: []
+      };
+      mockSpanService.section.mockReturnValue(mockSection);
+      mockWorkerPythonService.runTask.mockResolvedValue({ result: { success: true }, error: null });
+
+      await service.calculateLoad();
+
+      // recheckSpanLoads creates placeholder entries for each support with loadWeight=0
+      // This is the expected behavior - the Python engine will zero them out
+      expect(mockWorkerPythonService.runTask).toHaveBeenCalledWith(Task.changeState, {
+        climate: expect.any(Object),
+        spanLoads: expect.arrayContaining([
+          expect.objectContaining({
+            supportUuid: 'support-uuid-1',
+            loadWeight: 0,
+            loadPosition: 0
+          })
+        ])
+      });
     });
 
     it('should update temporaryLoadData spanLoads with rechecked values before delegating', async () => {

--- a/src/app/features/studio/loads/presentation/services/loadForms.service.spec.ts
+++ b/src/app/features/studio/loads/presentation/services/loadForms.service.spec.ts
@@ -1,4 +1,5 @@
 import { TestBed } from '@angular/core/testing';
+import { signal } from '@angular/core';
 import { LoadFormsService } from './loadForms.service';
 import { PlotService } from '@services/plot/plot.service';
 import { PlotSpanService } from '@services/plot/plot-span.service';
@@ -8,7 +9,7 @@ import { Section, Charge, SymmetryType } from '@shared/domain';
 import { Study } from '@shared/domain/models/study.model';
 import { ChargeData, LoadType } from '@shared/domain/models/charge.model';
 import { WorkerPythonService } from '@services/worker_python/worker-python.service';
-import { Task, PythonErrorCode } from '@services/worker_python/tasks/types';
+import { GetSectionOutput, Task } from '@services/worker_python/tasks/types';
 import { ObstacleStateService } from '@services/obstacle-state/obstacle-state.service';
 
 function createSignalMock<T>(initialValue: T) {
@@ -142,10 +143,9 @@ describe('LoadFormsService', () => {
       loading: createSignalMock(false),
       litData: createSignalMock(null),
       baseLitData: createSignalMock(null),
+      litDataCache: new Map(),
       error: createSignalMock(null),
-      diagnostics: createSignalMock([]),
       pythonErrorCode: createSignalMock(null),
-      workerReady: createSignalMock(false),
       refreshProjection: vi.fn().mockResolvedValue(undefined)
     } as unknown as vi.Mocked<PlotService>;
     mockSpanService = {
@@ -153,7 +153,9 @@ describe('LoadFormsService', () => {
     } as unknown as vi.Mocked<PlotSpanService>;
     plotOptionsServiceMock = {
       refreshCamera: vi.fn(),
-      plotOptions: createSignalMock({ startSupport: 0, endSupport: 1, view: '3d' })
+      getCamera: vi.fn().mockReturnValue(null),
+      plotOptions: createSignalMock({ startSupport: 0, endSupport: 1, view: '3d' }),
+      camera: createSignalMock(null)
     } as unknown as vi.Mocked<PlotOptionsService>;
 
     mockChargesService = {
@@ -191,53 +193,6 @@ describe('LoadFormsService', () => {
 
   it('should be created', () => {
     expect(service).toBeTruthy();
-  });
-
-  describe('constructor effect gating', () => {
-    it('should not call setLoads when worker is not ready even if a charge is selected', () => {
-      mockPlotService.workerReady.mockReturnValue(false);
-      mockPlotService.litData.mockReturnValue(null);
-      mockSpanService.section.mockReturnValue({
-        ...mockSection,
-        selected_charge_uuid: 'charge-uuid-1',
-        charges: [mockCharge]
-      } as Section);
-
-      TestBed.flushEffects();
-
-      expect(mockWorkerPythonService.runTask).not.toHaveBeenCalled();
-    });
-
-    it('should not call setLoads when worker is ready but section studio has not finished initializing (litData null)', () => {
-      mockPlotService.workerReady.mockReturnValue(true);
-      mockPlotService.litData.mockReturnValue(null);
-      mockSpanService.section.mockReturnValue({
-        ...mockSection,
-        selected_charge_uuid: 'charge-uuid-1',
-        charges: [mockCharge]
-      } as Section);
-
-      TestBed.flushEffects();
-
-      expect(mockWorkerPythonService.runTask).not.toHaveBeenCalled();
-    });
-
-    it('should call setLoads once worker is ready and litData is set (section studio initialized)', () => {
-      mockPlotService.workerReady.mockReturnValue(true);
-      mockPlotService.litData.mockReturnValue({} as ReturnType<typeof mockPlotService.litData>);
-      mockSpanService.section.mockReturnValue({
-        ...mockSection,
-        selected_charge_uuid: 'charge-uuid-1',
-        charges: [mockCharge]
-      } as Section);
-
-      TestBed.flushEffects();
-
-      expect(mockWorkerPythonService.runTask).toHaveBeenCalledWith(
-        Task.setLoads,
-        expect.objectContaining({ spanLoads: expect.any(Array) })
-      );
-    });
   });
 
   describe('initTemporaryLoadData', () => {
@@ -316,38 +271,6 @@ describe('LoadFormsService', () => {
 
       expect(mockPlotService.temporaryLoadData?.spanLoads).toBeDefined();
     });
-
-    it('should call setLoads with empty array when charge has no span loads', async () => {
-      const chargeWithNoLoads = {
-        ...mockCharge,
-        data: { ...mockChargeData, spanLoads: [] }
-      };
-      mockSpanService.section.mockReturnValue({
-        ...mockSection,
-        selected_charge_uuid: 'charge-uuid-1',
-        charges: [chargeWithNoLoads]
-      } as Section);
-
-      await service.initTemporaryLoadData();
-
-      expect(mockWorkerPythonService.runTask).toHaveBeenCalledWith(Task.setLoads, { spanLoads: [] });
-    });
-
-    it('should call setLoads with recheckSpanLoads result when charge has span loads', async () => {
-      mockSpanService.section.mockReturnValue({
-        ...mockSection,
-        selected_charge_uuid: 'charge-uuid-1',
-        charges: [mockCharge]
-      } as Section);
-
-      await service.initTemporaryLoadData();
-
-      const setLoadsCall = (mockWorkerPythonService.runTask as ReturnType<typeof vi.fn>).mock.calls.find(
-        ([task]) => task === Task.setLoads
-      );
-      expect(setLoadsCall).toBeDefined();
-      expect((setLoadsCall![1] as { spanLoads: unknown[] }).spanLoads.length).toBeGreaterThan(0);
-    });
   });
 
   describe('saveTemporaryLoadDataInSection', () => {
@@ -420,6 +343,7 @@ describe('LoadFormsService', () => {
     it('should call refreshCamera and runTask(changeState) when temporaryLoadData is set', async () => {
       mockPlotService.temporaryLoadData = mockChargeData;
       mockSpanService.section.mockReturnValue(mockSection);
+      mockWorkerPythonService.runTask.mockResolvedValue({ result: { success: true }, error: null });
 
       await service.calculateLoad();
 
@@ -470,7 +394,7 @@ describe('LoadFormsService', () => {
       expect(mockObstacleStateService.syncObstacles).not.toHaveBeenCalled();
     });
 
-    it('should not call cableModification when reapplyCableModifications is deactivated', async () => {
+    it('should re-apply saved cable modifications after changeState so lengthening/shortening is not lost', async () => {
       mockPlotService.temporaryLoadData = mockChargeData;
       mockSpanService.section.mockReturnValue({
         ...mockSection,
@@ -485,30 +409,39 @@ describe('LoadFormsService', () => {
           }
         ]
       } as Section);
-      mockWorkerPythonService.runTask.mockResolvedValueOnce({ result: { success: true }, error: null });
+      mockWorkerPythonService.runTask
+        .mockResolvedValueOnce({ result: { success: true }, error: null }) // changeState
+        .mockResolvedValueOnce({ result: { current: { id: 'after-cable-mod' }, base: null }, error: null }); // cableModification
 
       await service.calculateLoad();
 
       expect(mockWorkerPythonService.runTask).toHaveBeenCalledWith(Task.changeState, expect.any(Object));
-      expect(mockWorkerPythonService.runTask).not.toHaveBeenCalledWith(Task.cableModification, expect.any(Object));
+      expect(mockWorkerPythonService.runTask).toHaveBeenCalledWith(
+        Task.cableModification,
+        expect.objectContaining({
+          spanIndex: 0,
+          widthCable: 'lengthening',
+          sizeCable: 0.5,
+          distanceSupportRef: 100,
+          supportRef: 'LEFT'
+        })
+      );
+      // Final litData reflects the cable modification, not the bare change-state.
+      expect(mockPlotService.litData.set).toHaveBeenLastCalledWith({ id: 'after-cable-mod' });
     });
 
-    it('should set plotService.error and diagnostics when runTask returns an error', async () => {
+    it('should set plotService.error when runTask returns an error', async () => {
       mockPlotService.temporaryLoadData = mockChargeData;
       mockSpanService.section.mockReturnValue(mockSection);
-      const diagnostics = [
-        { code: PythonErrorCode.SolverError, severity: 'error' as const, origin: 'exception' as const, rawText: 'mock' }
-      ];
       mockWorkerPythonService.runTask.mockResolvedValue({
         result: null,
         error: 'CALCULATION_FAILED',
-        diagnostics
+        diagnostics: []
       });
 
       await service.calculateLoad();
 
       expect(mockPlotService.error.set).toHaveBeenCalledWith('CALCULATION_FAILED');
-      expect(mockPlotService.diagnostics.set).toHaveBeenCalledWith(diagnostics);
     });
 
     it('should not call refreshProjection when runTask returns an error', async () => {
@@ -569,41 +502,81 @@ describe('LoadFormsService', () => {
 
       expect(mockWorkerPythonService.runTask).not.toHaveBeenCalledWith(Task.cableModification, expect.any(Object));
     });
+
+    it('should store final litData in litDataCache after successful calculation', async () => {
+      const finalLitData = { litCode: 'final' } as unknown as GetSectionOutput;
+      mockPlotService.temporaryLoadData = mockChargeData;
+      mockSpanService.section.mockReturnValue({
+        ...mockSection,
+        selected_charge_uuid: 'charge-uuid-1'
+      } as Section);
+      mockWorkerPythonService.runTask.mockResolvedValue({ result: { success: true }, error: null });
+      mockPlotService.litData.mockReturnValue(finalLitData);
+
+      await service.calculateLoad();
+
+      expect(mockPlotService.litDataCache.get('charge-uuid-1')).toBe(finalLitData);
+    });
+
+    it('should NOT update litDataCache when runTask returns an error', async () => {
+      mockPlotService.temporaryLoadData = mockChargeData;
+      mockSpanService.section.mockReturnValue({
+        ...mockSection,
+        selected_charge_uuid: 'charge-uuid-1'
+      } as Section);
+      mockWorkerPythonService.runTask.mockResolvedValue({
+        result: null,
+        error: 'CALCULATION_FAILED',
+        diagnostics: []
+      });
+
+      await service.calculateLoad();
+
+      expect(mockPlotService.litDataCache.has('charge-uuid-1')).toBe(false);
+    });
   });
 
   describe('deleteLoad', () => {
-    it('should call deleteAllLoads and changeState with base climate', async () => {
-      mockSpanService.section.mockReturnValue({
-        ...mockSection,
-        initial_conditions: [{ uuid: 'ic-1', base_temperature: 20 }],
-        selected_initial_condition_uuid: 'ic-1'
-      });
-      mockPlotService.temporaryLoadData = mockChargeData;
-
-      await service.deleteLoad();
-
-      expect(mockWorkerPythonService.runTask).toHaveBeenCalledWith(Task.deleteAllLoads, undefined);
-      expect(mockWorkerPythonService.runTask).toHaveBeenCalledWith(Task.changeState, {
-        climate: expect.objectContaining({ windPressure: 0, iceThickness: 0, cableTemperature: 20 })
-      });
-    });
-
-    it('should clear temporaryLoadData and call refreshProjection', async () => {
-      mockSpanService.section.mockReturnValue(mockSection);
-      mockPlotService.temporaryLoadData = mockChargeData;
-
-      await service.deleteLoad();
-
-      expect(mockPlotService.temporaryLoadData).toBeNull();
-      expect(mockPlotService.refreshProjection).toHaveBeenCalled();
-    });
-
-    it('should not call chargesService.deleteCharge', async () => {
+    it('should return early when studyUuid is missing', () => {
+      mockPlotService.study.mockReturnValue(null);
       mockSpanService.section.mockReturnValue(mockSection);
 
-      await service.deleteLoad();
+      service.deleteLoad();
 
       expect(mockChargesService.deleteCharge).not.toHaveBeenCalled();
+    });
+
+    it('should return early when sectionUuid is missing', () => {
+      mockPlotService.study.mockReturnValue({ uuid: 'study-uuid' } as Partial<Study> as Study);
+      mockSpanService.section.mockReturnValue(null);
+
+      service.deleteLoad();
+
+      expect(mockChargesService.deleteCharge).not.toHaveBeenCalled();
+    });
+
+    it('should return early when chargeUuid is missing', () => {
+      mockPlotService.study.mockReturnValue({ uuid: 'study-uuid' } as Partial<Study> as Study);
+      mockSpanService.section.mockReturnValue({
+        ...mockSection,
+        selected_charge_uuid: null
+      } as Section);
+
+      service.deleteLoad();
+
+      expect(mockChargesService.deleteCharge).not.toHaveBeenCalled();
+    });
+
+    it('should call deleteCharge with correct parameters', () => {
+      mockPlotService.study.mockReturnValue({ uuid: 'study-uuid' } as Partial<Study> as Study);
+      mockSpanService.section.mockReturnValue({
+        ...mockSection,
+        selected_charge_uuid: 'charge-uuid-1'
+      } as Section);
+
+      service.deleteLoad();
+
+      expect(mockChargesService.deleteCharge).toHaveBeenCalledWith('study-uuid', 'section-uuid-1', 'charge-uuid-1');
     });
   });
 
@@ -646,6 +619,444 @@ describe('LoadFormsService', () => {
       expect(spanLoad?.loadWeight).toBe(0);
       expect(spanLoad?.type).toBe(LoadType.PUNCTUAL);
       expect(spanLoad?.referenceSupport).toBe('LEFT');
+    });
+  });
+
+  describe('litData cache on charge change', () => {
+    it('should NOT call litData.set when baseLitData is null and no cache entry', () => {
+      // On service creation: section() = null → chargeUuid = null ≠ undefined → effect fires
+      // no cache entry, baseLitData() = null → guard prevents litData.set
+      expect(mockPlotService.litData.set).not.toHaveBeenCalled();
+    });
+
+    it('should set litData to baseLitData on cache miss when baseLitData is set', () => {
+      const mockBaseData = { litCode: 'base' } as unknown as GetSectionOutput;
+      const freshPlotService = {
+        ...mockPlotService,
+        baseLitData: vi.fn().mockReturnValue(mockBaseData),
+        litData: { set: vi.fn() },
+        litDataCache: new Map()
+      };
+      const freshSpanService = {
+        section: vi.fn().mockReturnValue({
+          ...mockSection,
+          selected_charge_uuid: 'charge-uuid-1'
+        } as Section)
+      };
+
+      TestBed.resetTestingModule();
+      TestBed.configureTestingModule({
+        providers: [
+          LoadFormsService,
+          { provide: PlotService, useValue: freshPlotService },
+          { provide: PlotSpanService, useValue: freshSpanService },
+          { provide: PlotOptionsService, useValue: plotOptionsServiceMock },
+          { provide: ChargesService, useValue: mockChargesService },
+          { provide: WorkerPythonService, useValue: mockWorkerPythonService },
+          { provide: ObstacleStateService, useValue: mockObstacleStateService }
+        ]
+      });
+
+      const freshService = TestBed.inject(LoadFormsService);
+      TestBed.flushEffects();
+      expect(freshService).toBeTruthy();
+      expect(freshPlotService.litData.set).toHaveBeenCalledWith(mockBaseData);
+    });
+
+    it('should restore litData from cache on cache hit', () => {
+      const cachedData = { litCode: 'cached' } as unknown as GetSectionOutput;
+      const cache = new Map([['charge-uuid-1', cachedData]]);
+      const freshPlotService = {
+        ...mockPlotService,
+        baseLitData: vi.fn().mockReturnValue({ litCode: 'base' }),
+        litData: { set: vi.fn() },
+        litDataCache: cache
+      };
+      const freshSpanService = {
+        section: vi.fn().mockReturnValue({
+          ...mockSection,
+          selected_charge_uuid: 'charge-uuid-1'
+        } as Section)
+      };
+
+      TestBed.resetTestingModule();
+      TestBed.configureTestingModule({
+        providers: [
+          LoadFormsService,
+          { provide: PlotService, useValue: freshPlotService },
+          { provide: PlotSpanService, useValue: freshSpanService },
+          { provide: PlotOptionsService, useValue: plotOptionsServiceMock },
+          { provide: ChargesService, useValue: mockChargesService },
+          { provide: WorkerPythonService, useValue: mockWorkerPythonService },
+          { provide: ObstacleStateService, useValue: mockObstacleStateService }
+        ]
+      });
+
+      const freshService = TestBed.inject(LoadFormsService);
+      TestBed.flushEffects();
+      expect(freshService).toBeTruthy();
+      // cache hit → restored, NOT the base
+      expect(freshPlotService.litData.set).toHaveBeenCalledWith(cachedData);
+      expect(freshPlotService.litData.set).not.toHaveBeenCalledWith({ litCode: 'base' });
+    });
+  });
+
+  describe('Deferred calculation during loading', () => {
+    it('should calculate immediately when loading is false', () => {
+      const mockBaseData = { litCode: 'base' } as unknown as GetSectionOutput;
+      const loadingSignal = signal(false);
+      const sectionSignal = signal<Section | null>({
+        ...mockSection,
+        selected_charge_uuid: null,
+        charges: [mockCharge]
+      } as Section);
+      const freshPlotService = {
+        ...mockPlotService,
+        baseLitData: signal(mockBaseData),
+        litData: signal<GetSectionOutput | null>(null),
+        litDataCache: new Map(),
+        loading: loadingSignal
+      };
+      const freshSpanService = {
+        section: sectionSignal
+      };
+      const spyCalculateLoad = vi.fn();
+
+      TestBed.resetTestingModule();
+      TestBed.configureTestingModule({
+        providers: [
+          LoadFormsService,
+          { provide: PlotService, useValue: freshPlotService },
+          { provide: PlotSpanService, useValue: freshSpanService },
+          { provide: PlotOptionsService, useValue: plotOptionsServiceMock },
+          { provide: ChargesService, useValue: mockChargesService },
+          { provide: WorkerPythonService, useValue: mockWorkerPythonService },
+          { provide: ObstacleStateService, useValue: mockObstacleStateService }
+        ]
+      });
+
+      const freshService = TestBed.inject(LoadFormsService);
+      freshService.calculateLoad = spyCalculateLoad;
+      TestBed.flushEffects();
+
+      // Now change to a charge (simulating user selecting a charge)
+      sectionSignal.set({
+        ...mockSection,
+        selected_charge_uuid: 'charge-uuid-1',
+        charges: [mockCharge]
+      } as Section);
+      TestBed.flushEffects();
+
+      // Verify calculateLoad was called immediately
+      expect(spyCalculateLoad).toHaveBeenCalled();
+    });
+
+    it('should defer calculation when loading is true', () => {
+      const mockBaseData = { litCode: 'base' } as unknown as GetSectionOutput;
+      const loadingSignal = signal(true);
+      const sectionSignal = signal<Section | null>({
+        ...mockSection,
+        selected_charge_uuid: null,
+        charges: [mockCharge]
+      } as Section);
+      const freshPlotService = {
+        ...mockPlotService,
+        baseLitData: signal(mockBaseData),
+        litData: signal<GetSectionOutput | null>(null),
+        litDataCache: new Map(),
+        loading: loadingSignal
+      };
+      const freshSpanService = {
+        section: sectionSignal
+      };
+      const spyCalculateLoad = vi.fn();
+
+      TestBed.resetTestingModule();
+      TestBed.configureTestingModule({
+        providers: [
+          LoadFormsService,
+          { provide: PlotService, useValue: freshPlotService },
+          { provide: PlotSpanService, useValue: freshSpanService },
+          { provide: PlotOptionsService, useValue: plotOptionsServiceMock },
+          { provide: ChargesService, useValue: mockChargesService },
+          { provide: WorkerPythonService, useValue: mockWorkerPythonService },
+          { provide: ObstacleStateService, useValue: mockObstacleStateService }
+        ]
+      });
+
+      const freshService = TestBed.inject(LoadFormsService);
+      freshService.calculateLoad = spyCalculateLoad;
+      TestBed.flushEffects();
+
+      // Now change to a charge while loading is true
+      sectionSignal.set({
+        ...mockSection,
+        selected_charge_uuid: 'charge-uuid-1',
+        charges: [mockCharge]
+      } as Section);
+      TestBed.flushEffects();
+
+      // Verify calculateLoad was NOT called because loading is true
+      expect(spyCalculateLoad).not.toHaveBeenCalled();
+      // Verify the pending flag is set (accessing private property via type assertion)
+      const pendingUuid = (
+        freshService as unknown as { _pendingChargeCalculation: () => string | null }
+      )._pendingChargeCalculation();
+      expect(pendingUuid).toBe('charge-uuid-1');
+    });
+
+    it('should trigger pending calculation when loading becomes false', () => {
+      const mockBaseData = { litCode: 'base' } as unknown as GetSectionOutput;
+      const loadingSignal = signal(true);
+      const sectionSignal = signal<Section | null>({
+        ...mockSection,
+        selected_charge_uuid: null,
+        charges: [mockCharge]
+      } as Section);
+      const freshPlotService = {
+        ...mockPlotService,
+        baseLitData: signal(mockBaseData),
+        litData: signal<GetSectionOutput | null>(null),
+        litDataCache: new Map(),
+        loading: loadingSignal
+      };
+      const freshSpanService = {
+        section: sectionSignal
+      };
+      const spyCalculateLoad = vi.fn();
+
+      TestBed.resetTestingModule();
+      TestBed.configureTestingModule({
+        providers: [
+          LoadFormsService,
+          { provide: PlotService, useValue: freshPlotService },
+          { provide: PlotSpanService, useValue: freshSpanService },
+          { provide: PlotOptionsService, useValue: plotOptionsServiceMock },
+          { provide: ChargesService, useValue: mockChargesService },
+          { provide: WorkerPythonService, useValue: mockWorkerPythonService },
+          { provide: ObstacleStateService, useValue: mockObstacleStateService }
+        ]
+      });
+
+      const freshService = TestBed.inject(LoadFormsService);
+      freshService.calculateLoad = spyCalculateLoad;
+      TestBed.flushEffects();
+
+      // Change to a charge while loading is true
+      sectionSignal.set({
+        ...mockSection,
+        selected_charge_uuid: 'charge-uuid-1',
+        charges: [mockCharge]
+      } as Section);
+      TestBed.flushEffects();
+
+      // Initially loading is true, so no calculation
+      expect(spyCalculateLoad).not.toHaveBeenCalled();
+
+      // Now set loading to false
+      loadingSignal.set(false);
+      TestBed.flushEffects();
+
+      // Verify calculateLoad was called after loading became false
+      expect(spyCalculateLoad).toHaveBeenCalled();
+      // Verify the pending flag is cleared
+      const pendingUuid = (
+        freshService as unknown as { _pendingChargeCalculation: () => string | null }
+      )._pendingChargeCalculation();
+      expect(pendingUuid).toBeNull();
+    });
+
+    it('should discard pending calculation if charge has changed again', () => {
+      const mockBaseData = { litCode: 'base' } as unknown as GetSectionOutput;
+      const loadingSignal = createSignalMock(true);
+      const sectionSignal = createSignalMock({
+        ...mockSection,
+        selected_charge_uuid: 'charge-uuid-1',
+        charges: [mockCharge, { ...mockCharge, uuid: 'charge-uuid-2', name: 'Charge 2' }]
+      } as Section);
+      const freshPlotService = {
+        ...mockPlotService,
+        baseLitData: vi.fn().mockReturnValue(mockBaseData),
+        litData: { set: vi.fn() },
+        litDataCache: new Map(),
+        loading: loadingSignal
+      };
+      const freshSpanService = {
+        section: sectionSignal
+      };
+      const spyCalculateLoad = vi.fn();
+
+      TestBed.resetTestingModule();
+      TestBed.configureTestingModule({
+        providers: [
+          LoadFormsService,
+          { provide: PlotService, useValue: freshPlotService },
+          { provide: PlotSpanService, useValue: freshSpanService },
+          { provide: PlotOptionsService, useValue: plotOptionsServiceMock },
+          { provide: ChargesService, useValue: mockChargesService },
+          { provide: WorkerPythonService, useValue: mockWorkerPythonService },
+          { provide: ObstacleStateService, useValue: mockObstacleStateService }
+        ]
+      });
+
+      const freshService = TestBed.inject(LoadFormsService);
+      freshService.calculateLoad = spyCalculateLoad;
+      TestBed.flushEffects();
+
+      // Initially loading is true, charge-uuid-1 is pending
+      expect(spyCalculateLoad).not.toHaveBeenCalled();
+
+      // Change to charge-uuid-2
+      sectionSignal.set({
+        ...mockSection,
+        selected_charge_uuid: 'charge-uuid-2',
+        charges: [mockCharge, { ...mockCharge, uuid: 'charge-uuid-2', name: 'Charge 2' }]
+      } as Section);
+      TestBed.flushEffects();
+
+      // Now set loading to false
+      loadingSignal.set(false);
+      TestBed.flushEffects();
+
+      // Verify pending calculation was discarded (UUID mismatch)
+      // The pending was charge-uuid-1 but current is charge-uuid-2
+      const pendingUuid = (
+        freshService as unknown as { _pendingChargeCalculation: () => string | null }
+      )._pendingChargeCalculation();
+      expect(pendingUuid).toBeNull();
+    });
+
+    it('should handle multiple rapid charge changes during loading', () => {
+      const mockBaseData = { litCode: 'base' } as unknown as GetSectionOutput;
+      const loadingSignal = signal(true);
+      const sectionSignal = signal<Section | null>({
+        ...mockSection,
+        selected_charge_uuid: null,
+        charges: [
+          mockCharge,
+          { ...mockCharge, uuid: 'charge-uuid-2', name: 'Charge 2' },
+          { ...mockCharge, uuid: 'charge-uuid-3', name: 'Charge 3' }
+        ]
+      } as Section);
+      const freshPlotService = {
+        ...mockPlotService,
+        baseLitData: signal(mockBaseData),
+        litData: signal<GetSectionOutput | null>(null),
+        litDataCache: new Map(),
+        loading: loadingSignal
+      };
+      const freshSpanService = {
+        section: sectionSignal
+      };
+      const spyCalculateLoad = vi.fn();
+
+      TestBed.resetTestingModule();
+      TestBed.configureTestingModule({
+        providers: [
+          LoadFormsService,
+          { provide: PlotService, useValue: freshPlotService },
+          { provide: PlotSpanService, useValue: freshSpanService },
+          { provide: PlotOptionsService, useValue: plotOptionsServiceMock },
+          { provide: ChargesService, useValue: mockChargesService },
+          { provide: WorkerPythonService, useValue: mockWorkerPythonService },
+          { provide: ObstacleStateService, useValue: mockObstacleStateService }
+        ]
+      });
+
+      const freshService = TestBed.inject(LoadFormsService);
+      freshService.calculateLoad = spyCalculateLoad;
+      TestBed.flushEffects();
+
+      // Change to charge-uuid-1
+      sectionSignal.set({
+        ...mockSection,
+        selected_charge_uuid: 'charge-uuid-1',
+        charges: [
+          mockCharge,
+          { ...mockCharge, uuid: 'charge-uuid-2', name: 'Charge 2' },
+          { ...mockCharge, uuid: 'charge-uuid-3', name: 'Charge 3' }
+        ]
+      } as Section);
+      TestBed.flushEffects();
+
+      // Change to charge-uuid-2
+      sectionSignal.set({
+        ...mockSection,
+        selected_charge_uuid: 'charge-uuid-2',
+        charges: [
+          mockCharge,
+          { ...mockCharge, uuid: 'charge-uuid-2', name: 'Charge 2' },
+          { ...mockCharge, uuid: 'charge-uuid-3', name: 'Charge 3' }
+        ]
+      } as Section);
+      TestBed.flushEffects();
+
+      // Change to charge-uuid-3
+      sectionSignal.set({
+        ...mockSection,
+        selected_charge_uuid: 'charge-uuid-3',
+        charges: [
+          mockCharge,
+          { ...mockCharge, uuid: 'charge-uuid-2', name: 'Charge 2' },
+          { ...mockCharge, uuid: 'charge-uuid-3', name: 'Charge 3' }
+        ]
+      } as Section);
+      TestBed.flushEffects();
+
+      // Now set loading to false
+      loadingSignal.set(false);
+      TestBed.flushEffects();
+
+      // Verify calculateLoad was called only once for the last charge (charge-uuid-3)
+      expect(spyCalculateLoad).toHaveBeenCalledTimes(1);
+    });
+
+    it('should use cache immediately even when loading is true', () => {
+      const cachedData = { litCode: 'cached' } as unknown as GetSectionOutput;
+      const cache = new Map([['charge-uuid-1', cachedData]]);
+      const loadingSignal = createSignalMock(true);
+      const freshPlotService = {
+        ...mockPlotService,
+        baseLitData: vi.fn().mockReturnValue({ litCode: 'base' }),
+        litData: { set: vi.fn() },
+        litDataCache: cache,
+        loading: loadingSignal
+      };
+      const freshSpanService = {
+        section: vi.fn().mockReturnValue({
+          ...mockSection,
+          selected_charge_uuid: 'charge-uuid-1',
+          charges: [mockCharge]
+        } as Section)
+      };
+      const spyCalculateLoad = vi.fn();
+
+      TestBed.resetTestingModule();
+      TestBed.configureTestingModule({
+        providers: [
+          LoadFormsService,
+          { provide: PlotService, useValue: freshPlotService },
+          { provide: PlotSpanService, useValue: freshSpanService },
+          { provide: PlotOptionsService, useValue: plotOptionsServiceMock },
+          { provide: ChargesService, useValue: mockChargesService },
+          { provide: WorkerPythonService, useValue: mockWorkerPythonService },
+          { provide: ObstacleStateService, useValue: mockObstacleStateService }
+        ]
+      });
+
+      const freshService = TestBed.inject(LoadFormsService);
+      freshService.calculateLoad = spyCalculateLoad;
+      TestBed.flushEffects();
+
+      // Verify cache was used immediately
+      expect(freshPlotService.litData.set).toHaveBeenCalledWith(cachedData);
+      // Verify calculateLoad was NOT called (cache hit)
+      expect(spyCalculateLoad).not.toHaveBeenCalled();
+      // Verify no pending calculation
+      const pendingUuid = (
+        freshService as unknown as { _pendingChargeCalculation: () => string | null }
+      )._pendingChargeCalculation();
+      expect(pendingUuid).toBeNull();
     });
   });
 });

--- a/src/app/features/studio/loads/presentation/services/loadForms.service.ts
+++ b/src/app/features/studio/loads/presentation/services/loadForms.service.ts
@@ -91,7 +91,7 @@ export class LoadFormsService {
           this._pendingChargeCalculation.set(null);
           untracked(() => this.calculateLoad());
         } else {
-          // Le cas a changé entre-temps, on annule la demande obsolète
+          // The charge case has changed in the meantime, cancel the stale request
           this._pendingChargeCalculation.set(null);
         }
       }

--- a/src/app/features/studio/loads/presentation/services/loadForms.service.ts
+++ b/src/app/features/studio/loads/presentation/services/loadForms.service.ts
@@ -116,7 +116,7 @@ export class LoadFormsService {
       ...currentCharge,
       data: temporaryLoadData
     });
-    await this.plotService.refreshProjection();
+    await this.calculateLoad();
   };
 
   /**

--- a/src/app/features/studio/loads/presentation/services/loadForms.service.ts
+++ b/src/app/features/studio/loads/presentation/services/loadForms.service.ts
@@ -138,7 +138,8 @@ export class LoadFormsService {
       };
 
       const { result: changeResult, error } = await this.workerPythonService.runTask(Task.changeState, {
-        climate: temporaryLoadData.climate
+        climate: temporaryLoadData.climate,
+        spanLoads: checkedSpanLoads
       });
 
       if (error) {

--- a/src/app/features/studio/loads/presentation/services/loadForms.service.ts
+++ b/src/app/features/studio/loads/presentation/services/loadForms.service.ts
@@ -1,15 +1,13 @@
 import { PlotService } from '@services/plot/plot.service';
 import { PlotSpanService } from '@services/plot/plot-span.service';
 import { PlotOptionsService } from '@services/plot/plot-options.service';
-import { effect, inject, Injectable, signal } from '@angular/core';
+import { effect, inject, Injectable, signal, untracked } from '@angular/core';
 import { cloneDeep } from 'lodash';
 import { ChargesService } from '@services/charges/charges.service';
 import { recheckSpanLoads } from '@shared/domain/helpers/span-loads.helpers';
 import { emptySpanLoad } from '../helpers';
-import { getBaseClimate } from '@shared/domain/helpers/climate.helpers';
 import { WorkerPythonService } from '@services/worker_python/worker-python.service';
-import { Task, TaskError } from '@services/worker_python/tasks/types';
-import { LoggerService } from '@core/services/logger/logger.service';
+import { Task } from '@services/worker_python/tasks/types';
 
 @Injectable({
   providedIn: 'root'
@@ -21,53 +19,23 @@ export class LoadFormsService {
 
   /** UUID of the span support to select in the span form, set when clicking a load annotation. Cleared after consumption. */
   readonly selectedSpanSupportUuid = signal<string | null>(null);
-
-  /** UUID of the charge case last pushed to the Python engine — prevents redundant setLoads on section updates. */
-  private lastLoadedChargeUuid: string | null = null;
   /**
-   * Initialize the temporary load data by getting the selected charge case and checking the span loads,
-   * then push all span loads into the Python engine via setLoads.
+   * Initialize the temporary load data by getting the selected charge case and checking the span loads
    */
-  initTemporaryLoadData = async () => {
-    const section = this.spanService.section();
-    const currentChargeUuid = section?.selected_charge_uuid;
+  initTemporaryLoadData = () => {
+    const currentChargeUuid = this.spanService.section()?.selected_charge_uuid;
     if (!currentChargeUuid) {
       this.plotService.temporaryLoadData = null;
-      this.lastLoadedChargeUuid = null;
       return;
     }
-
-    // Skip entirely when re-entering for the same charge case
-    // (e.g. after save writes back to IndexedDB and liveQuery re-fires).
-    if (currentChargeUuid === this.lastLoadedChargeUuid) return;
-
-    const charge = section?.charges?.find((c) => c.uuid === currentChargeUuid);
+    const charge = this.spanService.section()?.charges?.find((c) => c.uuid === currentChargeUuid);
     if (!charge) {
       this.plotService.temporaryLoadData = null;
       return;
     }
     const newData = cloneDeep(charge.data);
-    const rawSpanLoads = newData.spanLoads || [];
-    newData.spanLoads = recheckSpanLoads(rawSpanLoads, section?.supports ?? []);
+    newData.spanLoads = recheckSpanLoads(newData.spanLoads || [], this.spanService.section()?.supports ?? []);
     this.plotService.temporaryLoadData = newData;
-    // Set before async calls so the effect guard prevents concurrent re-entrant
-    // invocations (e.g. liveQuery re-firing while setLoads is still in-flight).
-    this.lastLoadedChargeUuid = currentChargeUuid;
-
-    try {
-      // When there are no saved span loads, pass an empty array so the Python engine
-      // takes its "no loads" code path instead of receiving zero-weight placeholder
-      // entries created by recheckSpanLoads (which would have the wrong array size).
-      await this.workerPythonService.runTask(Task.setLoads, {
-        spanLoads: rawSpanLoads.length > 0 ? newData.spanLoads : []
-      });
-      await this.workerPythonService.runTask(Task.changeState, { climate: newData.climate });
-      await this.plotService.refreshProjection();
-    } catch (err) {
-      this.lastLoadedChargeUuid = null; // Allow retry on next signal change
-      this.plotService.error.set(TaskError.CALCULATION_ERROR);
-      this.logger.error('initTemporaryLoadData failed', err);
-    }
   };
 
   private readonly plotService = inject(PlotService);
@@ -75,21 +43,58 @@ export class LoadFormsService {
   private readonly plotOptionsService = inject(PlotOptionsService);
   private readonly chargesService = inject(ChargesService);
   private readonly workerPythonService = inject(WorkerPythonService);
-  private readonly logger = inject(LoggerService);
   // private readonly obstacleStateService = inject(ObstacleStateService);
+
+  private _chargeUuidForLitDataReset: string | null | undefined = undefined;
+  private readonly _pendingChargeCalculation = signal<string | null>(null);
 
   constructor() {
     effect(() => {
-      if (!this.plotService.workerReady()) return;
-      // Wait for initSectionStudio to complete (litData is populated by refreshProjection after initLit succeeds).
-      // Without this gate, setLoads could be posted before initialize_study finishes.
-      if (!this.plotService.litData()) return;
-      void this.initTemporaryLoadData();
+      this.initTemporaryLoadData();
+    });
+    effect(() => {
+      const chargeUuid = this.spanService.section()?.selected_charge_uuid ?? null;
+      if (chargeUuid === this._chargeUuidForLitDataReset) return;
+      const previousChargeUuid = this._chargeUuidForLitDataReset;
+      this._chargeUuidForLitDataReset = chargeUuid;
+      untracked(() => {
+        const cached = chargeUuid ? this.plotService.litDataCache.get(chargeUuid) : undefined;
+        if (cached) {
+          this.plotService.litData.set(cached);
+        } else {
+          const base = this.plotService.baseLitData();
+          if (base) {
+            this.plotService.litData.set(base);
+          }
+          if (chargeUuid && previousChargeUuid !== undefined) {
+            if (!this.plotService.loading()) {
+              this.calculateLoad();
+            } else {
+              this._pendingChargeCalculation.set(chargeUuid);
+            }
+          }
+        }
+      });
+    });
+    effect(() => {
+      const isLoading = this.plotService.loading();
+      const pendingUuid = this._pendingChargeCalculation();
+
+      if (!isLoading && pendingUuid) {
+        const currentChargeUuid = this.spanService.section()?.selected_charge_uuid ?? null;
+        if (pendingUuid === currentChargeUuid) {
+          this._pendingChargeCalculation.set(null);
+          untracked(() => this.calculateLoad());
+        } else {
+          // Le cas a changé entre-temps, on annule la demande obsolète
+          this._pendingChargeCalculation.set(null);
+        }
+      }
     });
   }
 
   /**
-   * Persist the temporary load data (inputs only), then calculate to refresh the graph.
+   * Save the temporary load data in the section by creating or updating the charge case
    */
   saveTemporaryLoadDataInSection = async () => {
     const temporaryLoadData = this.plotService.temporaryLoadData;
@@ -106,7 +111,7 @@ export class LoadFormsService {
       ...currentCharge,
       data: temporaryLoadData
     });
-    await this.calculateLoad();
+    await this.plotService.refreshProjection();
   };
 
   /**
@@ -117,7 +122,6 @@ export class LoadFormsService {
     if (!temporaryLoadData) {
       return;
     }
-    this.plotOptionsService.refreshCamera();
     this.plotService.loading.set(true);
 
     try {
@@ -128,20 +132,12 @@ export class LoadFormsService {
         spanLoads: checkedSpanLoads
       };
 
-      await this.workerPythonService.runTask(Task.setLoads, {
-        spanLoads: checkedSpanLoads
-      });
-      const {
-        result: changeResult,
-        error,
-        diagnostics
-      } = await this.workerPythonService.runTask(Task.changeState, {
+      const { result: changeResult, error } = await this.workerPythonService.runTask(Task.changeState, {
         climate: temporaryLoadData.climate
       });
 
       if (error) {
         this.plotService.error.set(error);
-        this.plotService.diagnostics.set(diagnostics);
         return;
       }
 
@@ -158,6 +154,12 @@ export class LoadFormsService {
       //   );
       // }
 
+      // Preserve the camera position before refreshing the projection, as the aspect
+      // ratio recalculation in refreshProjection may cause a visual resize that would
+      // otherwise reset the camera zoom and angle. Store the camera as-is so we can
+      // restore it after all geometry updates are complete.
+      const preservedCamera = this.plotOptionsService.getCamera();
+
       // refreshProjection gets all data (litData, baseLitData, obstacles, distances)
       await this.plotService.refreshProjection();
 
@@ -165,14 +167,64 @@ export class LoadFormsService {
       // result. `Task.changeState` resets the engine to the climate state without
       // knowing about cable_modifications, which would otherwise be silently
       // dropped from the recomputed geometry.
-      // await this.reapplyCableModifications(currentSection);
+      await this.reapplyCableModifications(currentSection);
+
+      const chargeUuid = currentSection?.selected_charge_uuid;
+      const finalLitData = this.plotService.litData();
+      if (chargeUuid && finalLitData) {
+        this.plotService.litDataCache.set(chargeUuid, finalLitData);
+      }
+
+      // Restore the preserved camera position to prevent zoom/angle changes caused
+      // by aspect ratio updates. This ensures the user's viewport remains stable
+      // when switching between charge cases.
+      if (preservedCamera) {
+        this.plotOptionsService.camera.set(preservedCamera);
+      } else {
+        // If no camera was preserved (e.g., first render), synchronize with the DOM
+        this.plotOptionsService.refreshCamera();
+      }
     } finally {
       this.plotService.loading.set(false);
     }
   };
 
   /**
-   * Reset the span load for the given support UUID in the engine and refresh the plot.
+   * Re-runs `Task.cableModification` for each saved modification of the
+   * current section so the lengthening/shortening effect survives a load
+   * recalculation. The last applied modification wins (the Python task uses
+   * a single simulated temperature on the whole engine), which matches the
+   * current single-modification-per-section product constraint.
+   */
+  private async reapplyCableModifications(currentSection: ReturnType<PlotSpanService['section']>): Promise<void> {
+    const modifications = currentSection?.cable_modifications ?? [];
+    if (modifications.length === 0) return;
+
+    const supportUuidToIndex = new Map<string, number>();
+    (currentSection?.supports ?? []).forEach((support, index) => {
+      supportUuidToIndex.set(support.uuid, index);
+    });
+
+    for (const modification of modifications) {
+      const spanIndex = supportUuidToIndex.get(modification.spanUuid);
+      if (spanIndex === undefined) continue;
+
+      const { result } = await this.workerPythonService.runTask(Task.cableModification, {
+        spanIndex,
+        widthCable: modification.widthCable,
+        sizeCable: modification.sizeCable,
+        distanceSupportRef: modification.distanceSupportRef,
+        supportRef: modification.supportRef
+      });
+      if (result) {
+        this.plotService.litData.set(result.current);
+        this.plotService.baseLitData.set(result.base);
+      }
+    }
+  }
+
+  /**
+   * Reset the span load for the given support UUID to its empty state.
    */
   async deleteSpanLoad(supportUuid: string): Promise<void> {
     const temporaryLoadData = this.plotService.temporaryLoadData;
@@ -183,30 +235,18 @@ export class LoadFormsService {
 
     const reset = { ...emptySpanLoad, supportUuid };
     Object.assign(spanLoad, reset);
-
-    const supportIndex = this.spanService.section()?.supports?.findIndex((s) => s.uuid === supportUuid) ?? -1;
-    if (supportIndex === -1) return;
-
-    this.plotService.loading.set(true);
-    try {
-      await this.workerPythonService.runTask(Task.deleteLoad, { supportIndex });
-      await this.plotService.refreshProjection();
-    } finally {
-      this.plotService.loading.set(false);
-    }
+    await this.plotService.refreshProjection();
   }
 
   /**
-   * Clear all loads from the Python engine and reset to the default change state
-   * (base climate, no span loads), then refresh the plot.
-   * The caller is responsible for deleting the charge from the database.
+   * Delete the load by deleting the charge case
    */
   async deleteLoad(): Promise<void> {
-    await this.workerPythonService.runTask(Task.deleteAllLoads, undefined);
-    const baseClimate = getBaseClimate(this.spanService.section());
-    await this.workerPythonService.runTask(Task.changeState, { climate: baseClimate });
-    this.plotService.temporaryLoadData = null;
-    this.lastLoadedChargeUuid = null;
+    const studyUuid = this.plotService.study()?.uuid;
+    const sectionUuid = this.spanService.section()?.uuid;
+    const chargeUuid = this.spanService.section()?.selected_charge_uuid;
+    if (!studyUuid || !sectionUuid || !chargeUuid) return;
+    await this.chargesService.deleteCharge(studyUuid, sectionUuid, chargeUuid);
     await this.plotService.refreshProjection();
   }
 }

--- a/src/app/features/studio/loads/presentation/services/loadForms.service.ts
+++ b/src/app/features/studio/loads/presentation/services/loadForms.service.ts
@@ -62,9 +62,14 @@ export class LoadFormsService {
         if (cached) {
           this.plotService.litData.set(cached);
         } else {
-          const base = this.plotService.baseLitData();
-          if (base) {
-            this.plotService.litData.set(base);
+          // When deselecting a charge case (chargeUuid is null), revert to the base state immediately.
+          // When switching to a different charge case, keep the current litData visible until
+          // calculateLoad returns the new result — avoids a flash of the uncharged base state.
+          if (!chargeUuid) {
+            const base = this.plotService.baseLitData();
+            if (base) {
+              this.plotService.litData.set(base);
+            }
           }
           if (chargeUuid && previousChargeUuid !== undefined) {
             if (!this.plotService.loading()) {

--- a/src/app/shared/components/studio/section/helpers/plot.constants.ts
+++ b/src/app/shared/components/studio/section/helpers/plot.constants.ts
@@ -21,8 +21,11 @@ export const getShadowColor = (view: '2d' | '3d'): string => {
   return view === '3d' ? SPAN_COLOR : `rgba(${SPAN_COLOR_RGB},${SHADOW_OPACITY})`;
 };
 
-/** Debounce delay in ms for studio plot refresh operations. */
-export const STUDIO_PLOT_DEBOUNCE_DELAY = 300;
+/** Debounce delay in ms for the Plotly render — keeps the render responsive after data signals settle. */
+export const STUDIO_PLOT_DEBOUNCE_DELAY = 50;
+
+/** Debounce delay in ms for slider/user-input interactions — prevents rapid Worker calls during dragging. */
+export const STUDIO_SLIDER_DEBOUNCE_DELAY = 300;
 
 /** Shared Plotly axis background configuration used across all plot views. */
 export const PLOT_AXIS_CONFIG = {

--- a/stellar-engine/src/stellar_engine/plot/run_solver.py
+++ b/stellar-engine/src/stellar_engine/plot/run_solver.py
@@ -12,6 +12,7 @@ from mechaphlowers import SectionStudy
 from mechaphlowers.core.models.balance.interfaces import IBalanceModel
 from mechaphlowers.utils import arr
 
+from stellar_engine.core.loads import apply_span_loads
 from stellar_engine.entities.inputs import ClimateCharge, compute_ice_thickness
 
 logger = logging.getLogger("stellar_engine")
@@ -57,7 +58,11 @@ def change_state(
     cable_temperature = climate.cableTemperature
     ice_thickness = compute_ice_thickness(climate, len(study.balance_engine))
 
-    # apply_span_loads(study, change_state_inputs["spanLoads"])
+    # Apply span loads before checking has_span, so the engine reflects the current charge case
+    span_loads = change_state_inputs.get("spanLoads", None)
+    if span_loads is not None:
+        apply_span_loads(study, span_loads)
+
     logger.debug("---------Load case applied to engine---------")
     logger.debug(
         "Wind pressure: %s, Cable temperature: %s, Ice thickness: %s",


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
<!-- please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes -->
- [x] Tests for the changes have been added (for bug fixes / features)


[769](https://github.com/phlowers/phlowers-stellar-app/issues/769)

## Description

This PR fixes an issue occurring when switching between load cases.

When a load case containing a point load applied to a span is selected, then another existing load case is selected or a new load case is created, the values from the previously selected load case remain displayed in both the tab and the graphical area.

The expected behavior is to display the values associated with the newly selected load case in both the tab and the graphical area.
