### PR TITLE
Compute diffuse and beam radiation (bis)

### DIFF
--- a/assets/i18n/messages.fr.xlf
+++ b/assets/i18n/messages.fr.xlf
@@ -1083,12 +1083,8 @@
     </unit>
     <unit id="187187500641108332">
       <segment state="initial">
-        <source>
-          <ph id="0" equiv="INTERPOLATION" disp="{{ cardTitle() }}"/>
-        </source>
-        <target>
-          <ph id="0" equiv="INTERPOLATION" disp="{{ cardTitle() }}"/>
-        </target>
+        <source><ph id="0" equiv="INTERPOLATION" disp="{{ cardTitle() }}"/></source>
+        <target><ph id="0" equiv="INTERPOLATION" disp="{{ cardTitle() }}"/></target>
       </segment>
     </unit>
     <unit id="997715536640361323">
@@ -2549,28 +2545,22 @@
         <target>Flux solaire :</target>
       </segment>
     </unit>
-    <unit id="4841701538805347294">
+    <unit id="3808497976539301592">
       <segment state="initial">
         <source>Diffuse solar radiation</source>
         <target>Flux solaire diffus</target>
       </segment>
     </unit>
-    <unit id="230124996532453189">
+    <unit id="4226146180293313534">
       <segment state="initial">
         <source>Beam solar radiation</source>
         <target>Flux solaire direct</target>
       </segment>
     </unit>
-    <unit id="4412456247511617977">
+    <unit id="7894946941174275313">
       <segment state="initial">
         <source>Diffuse + beam solar radiation</source>
         <target>Flux solaire diffus + direct</target>
-      </segment>
-    </unit>
-    <unit id="6052330236106770932">
-      <segment state="initial">
-        <source> Measured diffuse + beam solar radiation (not required) </source>
-        <target> Flux solaire diffus + direct mesuré (facultatif) </target>
       </segment>
     </unit>
     <unit id="4153303378370584000">
@@ -4845,6 +4835,12 @@
       <segment state="initial">
         <source>Conformity results updated.</source>
         <target>Résultats de la conformité mis à jour.</target>
+      </segment>
+    </unit>
+    <unit id="2568633915195803623">
+      <segment state="initial">
+        <source> Measured diffuse + beam solar radiation (not required) </source>
+        <target> Flux solaire diffus + direct mesuré (facultatif) </target>
       </segment>
     </unit>
   </file>

--- a/assets/i18n/messages.fr.xlf
+++ b/assets/i18n/messages.fr.xlf
@@ -2551,25 +2551,25 @@
     </unit>
     <unit id="4841701538805347294">
       <segment state="initial">
-        <source>Diffused solar flux</source>
+        <source>Diffuse solar radiation</source>
         <target>Flux solaire diffus</target>
       </segment>
     </unit>
     <unit id="230124996532453189">
       <segment state="initial">
-        <source>Direct solar flux</source>
+        <source>Beam solar radiation</source>
         <target>Flux solaire direct</target>
       </segment>
     </unit>
     <unit id="4412456247511617977">
       <segment state="initial">
-        <source>Diffused + direct solar flux</source>
+        <source>Diffuse + beam solar radiation</source>
         <target>Flux solaire diffus + direct</target>
       </segment>
     </unit>
     <unit id="6052330236106770932">
       <segment state="initial">
-        <source> Measured diffused + direct solar flux (not required) </source>
+        <source> Measured diffuse + beam solar radiation (not required) </source>
         <target> Flux solaire diffus + direct mesuré (facultatif) </target>
       </segment>
     </unit>

--- a/assets/i18n/messages.xlf
+++ b/assets/i18n/messages.xlf
@@ -1495,22 +1495,22 @@
     </unit>
     <unit id="4841701538805347294">
       <segment>
-        <source>Diffused solar flux</source>
+        <source>Diffuse solar radiation</source>
       </segment>
     </unit>
     <unit id="230124996532453189">
       <segment>
-        <source>Direct solar flux</source>
+        <source>Beam solar radiation</source>
       </segment>
     </unit>
     <unit id="4412456247511617977">
       <segment>
-        <source>Diffused + direct solar flux</source>
+        <source>Diffuse + beam solar radiation</source>
       </segment>
     </unit>
     <unit id="6052330236106770932">
       <segment>
-        <source> Measured diffused + direct solar flux (not required) </source>
+        <source> Measured diffuse + beam solar radiation (not required) </source>
       </segment>
     </unit>
     <unit id="4153303378370584000">

--- a/assets/i18n/messages.xlf
+++ b/assets/i18n/messages.xlf
@@ -573,9 +573,7 @@
     </unit>
     <unit id="187187500641108332">
       <segment>
-        <source>
-          <ph id="0" equiv="INTERPOLATION" disp="{{ cardTitle() }}"/>
-        </source>
+        <source><ph id="0" equiv="INTERPOLATION" disp="{{ cardTitle() }}"/></source>
       </segment>
     </unit>
     <unit id="997715536640361323">
@@ -1493,24 +1491,19 @@
         <source>Solar flux :</source>
       </segment>
     </unit>
-    <unit id="4841701538805347294">
+    <unit id="3808497976539301592">
       <segment>
         <source>Diffuse solar radiation</source>
       </segment>
     </unit>
-    <unit id="230124996532453189">
+    <unit id="4226146180293313534">
       <segment>
         <source>Beam solar radiation</source>
       </segment>
     </unit>
-    <unit id="4412456247511617977">
+    <unit id="7894946941174275313">
       <segment>
         <source>Diffuse + beam solar radiation</source>
-      </segment>
-    </unit>
-    <unit id="6052330236106770932">
-      <segment>
-        <source> Measured diffuse + beam solar radiation (not required) </source>
       </segment>
     </unit>
     <unit id="4153303378370584000">
@@ -4037,6 +4030,11 @@
     <unit id="7435704250978299258">
       <segment>
         <source>Calculating conformity…</source>
+      </segment>
+    </unit>
+    <unit id="2568633915195803623">
+      <segment>
+        <source> Measured diffuse + beam solar radiation (not required) </source>
       </segment>
     </unit>
   </file>

--- a/src/app/core/services/worker_python/tasks/handle-task.ts
+++ b/src/app/core/services/worker_python/tasks/handle-task.ts
@@ -52,6 +52,10 @@ const tasks: Record<
     function: 'temperature_calculation',
     externalPackages: []
   },
+  [Task.diffuseAndBeamRadiationsCalculation]: {
+    function: 'compute_diffuse_and_beam_radiations',
+    externalPackages: []
+  },
   [Task.calculateParameter15CWithoutWind]: {
     function: 'parameter_15_without_wind',
     externalPackages: []

--- a/src/app/core/services/worker_python/tasks/python-scripts/api.py
+++ b/src/app/core/services/worker_python/tasks/python-scripts/api.py
@@ -83,6 +83,13 @@ def temperature_calculation(js_inputs):
 
 
 @debug_log
+def compute_diffuse_and_beam_radiations(js_inputs):
+    return temperature.compute_diffuse_and_beam_radiations(
+        inputs=js_inputs.to_py(default_converter=default_converter),
+    )
+
+
+@debug_log
 def calculate_papoto(js_inputs):
     return papoto.calculate_papoto(inputs=js_inputs.to_py())
 

--- a/src/app/core/services/worker_python/tasks/python-scripts/api.py
+++ b/src/app/core/services/worker_python/tasks/python-scripts/api.py
@@ -29,7 +29,7 @@ from mechaphlowers import SectionStudy
 from mechaphlowers.config import options
 from stellar_engine.utils import get_section_middle_span, make_debug_log
 
-from stellar_engine.pyodide_utils import js_to_python, default_converter
+from stellar_engine.pyodide_utils import js_to_python, date_converter
 
 logger = logging.getLogger("stellar_engine")
 debug_log = make_debug_log(logger, prefix="API")
@@ -77,7 +77,7 @@ def parameter_15_without_wind(js_inputs):
 def temperature_calculation(js_inputs):
     global study
     return temperature.temperature_calculation(
-        inputs=js_inputs.to_py(default_converter=default_converter),
+        inputs=js_inputs.to_py(default_converter=date_converter),
         engine=study.balance_engine,
     )
 
@@ -85,7 +85,7 @@ def temperature_calculation(js_inputs):
 @debug_log
 def compute_diffuse_and_beam_radiations(js_inputs):
     return temperature.compute_diffuse_and_beam_radiations(
-        inputs=js_inputs.to_py(default_converter=default_converter),
+        inputs=js_inputs.to_py(default_converter=date_converter),
     )
 
 

--- a/src/app/core/services/worker_python/tasks/types.ts
+++ b/src/app/core/services/worker_python/tasks/types.ts
@@ -36,6 +36,8 @@ export enum Task {
   setLogLevel = 'setLogLevel',
   // Calculate cable temperature from ambient conditions
   temperatureCalculation = 'temperatureCalculation',
+  // Calculate some sun radiations from datetime, coordinates and sky cover
+  diffuseAndBeamRadiationsCalculation = 'diffuseAndBeamRadiationsCalculation',
   // Calculate parameter at 15°C without wind
   calculateParameter15CWithoutWind = 'calculateParameter15CWithoutWind',
   // Set the number of calculation points per span
@@ -347,6 +349,14 @@ export interface TaskInputs {
     windSpeed: number;
     windSpeedUnit: 'kmh' | 'ms';
     windDirection: string;
+    skyCover: string;
+  };
+  /** Inputs for computeDiffuseAndBeamRadiation task */
+  [Task.diffuseAndBeamRadiationsCalculation]: {
+    date: Date | null;
+    time: Date | null;
+    longitude: number;
+    latitude: number;
     skyCover: string;
   };
   /** Inputs for calculateParameter15CWithoutWind task */
@@ -687,6 +697,11 @@ export interface TaskOutputs {
     cableSolarFlux: number;
     cableTemperature: number;
     cableTemperatureUncertainty: number;
+  };
+  [Task.diffuseAndBeamRadiationsCalculation]: {
+    diffuseRadiation: number;
+    beamRadiation: number;
+    diffusePlusBeamRadiation: number;
   };
   /** Output from calculateParameter15CWithoutWind task */
   [Task.calculateParameter15CWithoutWind]: {

--- a/src/app/features/studio/field-measuring/presentation/components/temperature-calculation/temperature-calculation.component.html
+++ b/src/app/features/studio/field-measuring/presentation/components/temperature-calculation/temperature-calculation.component.html
@@ -120,13 +120,13 @@
 
   <dl class="contents">
     <dt i18n class="diffusedSolarFlux__label">Diffused solar flux</dt>
-    <dd class="diffusedSolarFlux__value">{{ measureData().diffusedSolarFlux }} W/m²</dd>
+    <dd class="diffusedSolarFlux__value">{{ measureData().diffusedSolarFlux | number: '1.0-2' }} W/m²</dd>
 
     <dt i18n class="directSolarFlux__label">Direct solar flux</dt>
-    <dd class="directSolarFlux__value">{{ measureData().directSolarFlux }} W/m²</dd>
+    <dd class="directSolarFlux__value">{{ measureData().directSolarFlux | number: '1.0-2' }} W/m²</dd>
 
     <dt i18n class="diffusedPlusDirectSolarFlux__label">Diffused + direct solar flux</dt>
-    <dd class="diffusedPlusDirectSolarFlux__value">{{ measureData().diffusedPlusDirectSolarFlux }} W/m²</dd>
+    <dd class="diffusedPlusDirectSolarFlux__value">{{ measureData().diffusedPlusDirectSolarFlux  | number: '1.0-2' }} W/m²</dd>
   </dl>
 
   <label for="measuredDiffusedPlusDirectSolarFlux" i18n class="measuredDiffusedPlusDirectSolarFlux__label">

--- a/src/app/features/studio/field-measuring/presentation/components/temperature-calculation/temperature-calculation.component.html
+++ b/src/app/features/studio/field-measuring/presentation/components/temperature-calculation/temperature-calculation.component.html
@@ -119,20 +119,20 @@
   />
 
   <dl class="contents">
-    <dt i18n class="diffusedSolarFlux__label">Diffused solar flux</dt>
+    <dt i18n class="diffusedSolarFlux__label">Diffuse solar radiation</dt>
     <dd class="diffusedSolarFlux__value">{{ measureData().diffusedSolarFlux | number: '1.0-2' }} W/m²</dd>
 
-    <dt i18n class="directSolarFlux__label">Direct solar flux</dt>
+    <dt i18n class="directSolarFlux__label">Beam solar radiation</dt>
     <dd class="directSolarFlux__value">{{ measureData().directSolarFlux | number: '1.0-2' }} W/m²</dd>
 
-    <dt i18n class="diffusedPlusDirectSolarFlux__label">Diffused + direct solar flux</dt>
+    <dt i18n class="diffusedPlusDirectSolarFlux__label">Diffuse + beam solar radiation</dt>
     <dd class="diffusedPlusDirectSolarFlux__value">
       {{ measureData().diffusedPlusDirectSolarFlux | number: '1.0-2' }} W/m²
     </dd>
   </dl>
 
   <label for="measuredDiffusedPlusDirectSolarFlux" i18n class="measuredDiffusedPlusDirectSolarFlux__label">
-    Measured diffused + direct solar flux (not required)
+    Measured diffuse + beam solar radiation (not required)
   </label>
   <p-inputgroup class="measuredDiffusedPlusDirectSolarFlux__value">
     <input

--- a/src/app/features/studio/field-measuring/presentation/components/temperature-calculation/temperature-calculation.component.html
+++ b/src/app/features/studio/field-measuring/presentation/components/temperature-calculation/temperature-calculation.component.html
@@ -126,7 +126,9 @@
     <dd class="directSolarFlux__value">{{ measureData().directSolarFlux | number: '1.0-2' }} W/m²</dd>
 
     <dt i18n class="diffusedPlusDirectSolarFlux__label">Diffused + direct solar flux</dt>
-    <dd class="diffusedPlusDirectSolarFlux__value">{{ measureData().diffusedPlusDirectSolarFlux  | number: '1.0-2' }} W/m²</dd>
+    <dd class="diffusedPlusDirectSolarFlux__value">
+      {{ measureData().diffusedPlusDirectSolarFlux | number: '1.0-2' }} W/m²
+    </dd>
   </dl>
 
   <label for="measuredDiffusedPlusDirectSolarFlux" i18n class="measuredDiffusedPlusDirectSolarFlux__label">

--- a/src/app/features/studio/field-measuring/presentation/components/temperature-calculation/temperature-calculation.component.ts
+++ b/src/app/features/studio/field-measuring/presentation/components/temperature-calculation/temperature-calculation.component.ts
@@ -176,4 +176,76 @@ export class TemperatureCalculationComponent {
       this.isCalculating.set(false);
     }
   }
+
+  private async computeDiffuseAndBeamRadiation(): Promise<void> {
+    const data = this.measureData();
+    const { result, error } = await this.workerPythonService.runTask(Task.diffuseAndBeamRadiationsCalculation, {
+      longitude: data.longitude || 0,
+      latitude: data.latitude || 0,
+      date: data.date ?? null,
+      time: data.time ?? null,
+      skyCover: data.skyCover ?? ''
+    });
+    if (!error && result !== undefined) {
+      this.measureData.update((d) => ({
+        ...d,
+        diffuseSolarRadiation: result.diffuseRadiation,
+        beamSolarRadiation: result.beamRadiation,
+        diffusePlusBeamSolarRadiation: result.diffusePlusBeamRadiation
+      }));
+    }
+  }
+
+  private readonly lastDiffuseAndBeamRadiationInput = signal<{
+    longitude: number;
+    latitude: number;
+    date: Date | null;
+    time: Date | null;
+    skyCover: string;
+  } | null>(null);
+
+  private readonly diffuseAndBeamRadiationEffect = effect(() => {
+    const isWorkerReady = this.workerReady();
+    const { longitude, latitude, date, time, skyCover } = this.measureData();
+
+    if (
+      !isWorkerReady ||
+      longitude === null ||
+      longitude === undefined ||
+      latitude === null ||
+      latitude === undefined ||
+      date === null ||
+      date === undefined ||
+      time === null ||
+      time === undefined ||
+      skyCover === undefined ||
+      skyCover === null
+    ) {
+      this.lastDiffuseAndBeamRadiationInput.set(null);
+      return;
+    }
+
+    const lastInput = this.lastDiffuseAndBeamRadiationInput();
+    const hasSameInput =
+      lastInput !== null &&
+      lastInput.longitude === longitude &&
+      lastInput.latitude === latitude &&
+      lastInput.date === date &&
+      lastInput.time === time &&
+      lastInput.skyCover === skyCover;
+
+    if (hasSameInput) {
+      return;
+    }
+
+    this.lastDiffuseAndBeamRadiationInput.set({
+      longitude,
+      latitude,
+      date,
+      time,
+      skyCover
+    });
+
+    void this.computeDiffuseAndBeamRadiation();
+  });
 }

--- a/src/app/features/studio/field-measuring/presentation/components/temperature-calculation/temperature-calculation.component.ts
+++ b/src/app/features/studio/field-measuring/presentation/components/temperature-calculation/temperature-calculation.component.ts
@@ -204,7 +204,21 @@ export class TemperatureCalculationComponent {
     skyCover: string;
   } | null>(null);
 
+  private resetSolarFluxResults(): void {
+    const { diffusedSolarFlux, directSolarFlux, diffusedPlusDirectSolarFlux } = this.measureData();
+    if (diffusedSolarFlux !== null || directSolarFlux !== null || diffusedPlusDirectSolarFlux != null) {
+      this.measureData.update((d) => ({
+        ...d,
+        diffusedSolarFlux: null,
+        directSolarFlux: null,
+        diffusedPlusDirectSolarFlux: null
+      }));
+    }
+  }
+
   private readonly diffuseAndBeamRadiationEffect = effect(() => {
+    console.log('diffuseAndBeamRadiationEffect triggered');
+
     const isWorkerReady = this.workerReady();
     const { longitude, latitude, date, time, skyCover } = this.measureData();
 
@@ -222,6 +236,7 @@ export class TemperatureCalculationComponent {
       skyCover === null
     ) {
       this.lastDiffuseAndBeamRadiationInput.set(null);
+      this.resetSolarFluxResults();
       return;
     }
 

--- a/src/app/features/studio/field-measuring/presentation/components/temperature-calculation/temperature-calculation.component.ts
+++ b/src/app/features/studio/field-measuring/presentation/components/temperature-calculation/temperature-calculation.component.ts
@@ -179,20 +179,25 @@ export class TemperatureCalculationComponent {
 
   private async computeDiffuseAndBeamRadiation(): Promise<void> {
     const data = this.measureData();
-    const { result, error } = await this.workerPythonService.runTask(Task.diffuseAndBeamRadiationsCalculation, {
-      longitude: data.longitude || 0,
-      latitude: data.latitude || 0,
-      date: data.date ?? null,
-      time: data.time ?? null,
-      skyCover: data.skyCover ?? ''
-    });
-    if (!error && result !== undefined) {
-      this.measureData.update((d) => ({
-        ...d,
-        diffusedSolarFlux: result.diffuseRadiation,
-        directSolarFlux: result.beamRadiation,
-        diffusedPlusDirectSolarFlux: result.diffusePlusBeamRadiation
-      }));
+    this.isCalculating.set(true);
+    try {
+      const { result, error } = await this.workerPythonService.runTask(Task.diffuseAndBeamRadiationsCalculation, {
+        longitude: data.longitude || 0,
+        latitude: data.latitude || 0,
+        date: data.date ?? null,
+        time: data.time ?? null,
+        skyCover: data.skyCover ?? ''
+      });
+      if (!error && result !== undefined) {
+        this.measureData.update((d) => ({
+          ...d,
+          diffusedSolarFlux: result.diffuseRadiation,
+          directSolarFlux: result.beamRadiation,
+          diffusedPlusDirectSolarFlux: result.diffusePlusBeamRadiation
+        }));
+      }
+    } finally {
+      this.isCalculating.set(false);
     }
   }
 

--- a/src/app/features/studio/field-measuring/presentation/components/temperature-calculation/temperature-calculation.component.ts
+++ b/src/app/features/studio/field-measuring/presentation/components/temperature-calculation/temperature-calculation.component.ts
@@ -189,9 +189,9 @@ export class TemperatureCalculationComponent {
     if (!error && result !== undefined) {
       this.measureData.update((d) => ({
         ...d,
-        diffuseSolarRadiation: result.diffuseRadiation,
-        beamSolarRadiation: result.beamRadiation,
-        diffusePlusBeamSolarRadiation: result.diffusePlusBeamRadiation
+        diffusedSolarFlux: result.diffuseRadiation,
+        directSolarFlux: result.beamRadiation,
+        diffusedPlusDirectSolarFlux: result.diffusePlusBeamRadiation
       }));
     }
   }

--- a/src/app/features/studio/field-measuring/presentation/components/temperature-calculation/temperature-calculation.component.ts
+++ b/src/app/features/studio/field-measuring/presentation/components/temperature-calculation/temperature-calculation.component.ts
@@ -222,8 +222,6 @@ export class TemperatureCalculationComponent {
   }
 
   private readonly diffuseAndBeamRadiationEffect = effect(() => {
-    console.log('diffuseAndBeamRadiationEffect triggered');
-
     const isWorkerReady = this.workerReady();
     const { longitude, latitude, date, time, skyCover } = this.measureData();
 

--- a/stellar-engine/src/stellar_engine/entities/inputs.py
+++ b/stellar-engine/src/stellar_engine/entities/inputs.py
@@ -295,6 +295,25 @@ class TemperatureCalculationInputs:
 
 
 @dataclass
+class DiffuseAndBeamRadiationInputs:
+    date: datetime.datetime
+    time: datetime.datetime
+    longitude: float
+    latitude: float
+    skyCover: Literal[
+        "N0",
+        "N1",
+        "N2",
+        "N3",
+        "N4",
+        "N5",
+        "N6",
+        "N7",
+        "N8",
+    ]
+
+
+@dataclass
 class WindAngleCalculationInputs:
     azimuth: float
     windDirection: str

--- a/stellar-engine/src/stellar_engine/pyodide_utils.py
+++ b/stellar-engine/src/stellar_engine/pyodide_utils.py
@@ -34,7 +34,7 @@ def js_to_python(js_inputs) -> dict:
 
 
 @debug_log
-def default_converter(value, _ignored1, _ignored2):
+def date_converter(value, _ignored1, _ignored2):
     """Convert js Date object into python Datetime object"""
     if value.constructor.name == "Date":
         # Convert to UTC

--- a/stellar-engine/src/stellar_engine/pyodide_utils.py
+++ b/stellar-engine/src/stellar_engine/pyodide_utils.py
@@ -37,5 +37,9 @@ def js_to_python(js_inputs) -> dict:
 def default_converter(value, _ignored1, _ignored2):
     """Convert js Date object into python Datetime object"""
     if value.constructor.name == "Date":
-        return datetime.fromtimestamp(value.valueOf() / 1000)
+        # Convert to UTC
+        # Value has type pyodide.ffi.JsProxy
+        # and thus has same methods as javascript Date
+        # NB: summer/winter time ignored
+        return datetime.fromisoformat(value.toISOString())
     return value

--- a/stellar-engine/src/stellar_engine/tools/__init__.py
+++ b/stellar-engine/src/stellar_engine/tools/__init__.py
@@ -9,11 +9,15 @@
 from stellar_engine.tools.guying import calculate_guying
 from stellar_engine.tools.papoto import calculate_papoto
 from stellar_engine.tools.param_calibration import parameter_15_without_wind
-from stellar_engine.tools.temperature import temperature_calculation
+from stellar_engine.tools.temperature import (
+    compute_diffuse_and_beam_radiations,
+    temperature_calculation,
+)
 
 __all__ = [
     "calculate_guying",
     "parameter_15_without_wind",
     "calculate_papoto",
     "temperature_calculation",
+    "compute_diffuse_and_beam_radiations",
 ]

--- a/stellar-engine/src/stellar_engine/tools/temperature.py
+++ b/stellar-engine/src/stellar_engine/tools/temperature.py
@@ -5,10 +5,13 @@
 # SPDX-License-Identifier: MPL-2.0
 
 
+from datetime import datetime
+
 import numpy as np
 from mechaphlowers import BalanceEngine, ThermalEngine, units
 
 from stellar_engine.entities.inputs import (
+    DiffuseAndBeamRadiationInputs,
     TemperatureCalculationInputs,
     WindAngleCalculationInputs,
 )
@@ -39,9 +42,44 @@ COVER_MAP = {
 UNIT_MAP = {"kmh": "km/h", "ms": "m/s"}
 
 
+def _check_inputs_are_datetimes(date, time) -> None:
+    error_messages = []
+    if not isinstance(date, datetime):
+        error_messages.append(
+            f"`date` should be a datetime, found {type(date)} instead."
+        )
+    if not isinstance(time, datetime):
+        error_messages.append(
+            f"`time` should be a datetime, found {type(time)} instead."
+        )
+    if error_messages:
+        error_message = "\n".join(error_messages)
+        raise TypeError(error_message)
+
+
+def _check_sky_cover_input(sky_cover: str) -> None:
+    if not isinstance(sky_cover, str):
+        raise TypeError("`sky_cover` should be a string")
+    if sky_cover not in COVER_MAP:
+        raise ValueError(
+            "`sky_cover` should be one of following values:\n"
+            + ", ".join(COVER_MAP)
+            + ".\n"
+            f"Got {sky_cover}"
+        )
+
+
+def _build_np_datetime64(date: datetime, time: datetime) -> np.datetime64:
+    _check_inputs_are_datetimes(date, time)
+    return np.datetime64(
+        f"{date.strftime('%Y-%m-%d')}T{time.strftime('%H:%M')}"
+    )
+
+
 def temperature_calculation(inputs: dict, engine: BalanceEngine):
     # TODO: remove engine in inputs and use temp_inputs.cableName instead
     temp_inputs = TemperatureCalculationInputs(**inputs)
+    _check_sky_cover_input(temp_inputs.skyCover)
     thermal_engine = ThermalEngine()
     wind_speed = (
         units(temp_inputs.windSpeed, UNIT_MAP[temp_inputs.windSpeedUnit])
@@ -57,11 +95,7 @@ def temperature_calculation(inputs: dict, engine: BalanceEngine):
         altitude=np.array([temp_inputs.altitude]),
         azimuth=np.array([temp_inputs.azimuth]),
         datetime_utc=np.array(
-            [
-                np.datetime64(
-                    f"{temp_inputs.date.strftime('%Y-%m-%d')}T{temp_inputs.time.strftime('%H:%M')}"
-                )
-            ]
+            [_build_np_datetime64(temp_inputs.date, temp_inputs.time)]
         ),
         intensity=np.array([temp_inputs.transit]),
         ambient_temp=np.array([temp_inputs.ambientTemperature]),
@@ -76,6 +110,26 @@ def temperature_calculation(inputs: dict, engine: BalanceEngine):
             0
         ],
         "cableTemperatureUncertainty": 0,
+    }
+
+
+def compute_diffuse_and_beam_radiations(inputs: dict) -> dict[str, float]:
+    parsed_inputs = DiffuseAndBeamRadiationInputs(**inputs)
+    _check_sky_cover_input(parsed_inputs.skyCover)
+    datetime_utc = _build_np_datetime64(parsed_inputs.date, parsed_inputs.time)
+    nebulosity = COVER_MAP[parsed_inputs.skyCover]
+    radiation_result = ThermalEngine.diffuse_and_beam_solar_radiations(
+        datetime_utc=np.array([datetime_utc]),
+        latitude=np.array([parsed_inputs.latitude]),
+        longitude=np.array([parsed_inputs.longitude]),
+        nebulosity=np.array([nebulosity]),
+    )
+    return {
+        "diffuseRadiation": radiation_result.data["diffuse_radiation"].iloc[0],
+        "beamRadiation": radiation_result.data["beam_radiation"].iloc[0],
+        "diffusePlusBeamRadiation": radiation_result.data[
+            "diffuse_plus_beam_radiation"
+        ].iloc[0],
     }
 
 

--- a/stellar-engine/test/tools/test_temperature.py
+++ b/stellar-engine/test/tools/test_temperature.py
@@ -7,9 +7,11 @@
 import datetime
 
 import numpy as np
+import pytest
 from mechaphlowers import BalanceEngine
 
 from stellar_engine.tools.temperature import (
+    compute_diffuse_and_beam_radiations,
     get_wind_attack_angle,
     temperature_calculation,
 )
@@ -41,3 +43,90 @@ def test_temp_calculation(balance_engine_base: BalanceEngine):
     result = temperature_calculation(inputs, engine=balance_engine_base)
     assert "cableTemperature" in result
     np.testing.assert_allclose(result["cableTemperature"], 15.1, atol=1e-1)
+
+
+def test_diffuse_and_beam_radiation() -> None:
+    inputs = {
+        "date": datetime.datetime(1970, 12, 21),
+        "time": datetime.datetime(1970, 3, 21, 12),
+        "longitude": 45.0,
+        "latitude": 0.0,
+        "skyCover": "N0",
+    }
+    result = compute_diffuse_and_beam_radiations(inputs)
+    expected_diffuse_radiation = 167.01
+    expected_beam_radiation = 604.43
+    np.testing.assert_allclose(
+        result["diffuseRadiation"], expected_diffuse_radiation, atol=0.01
+    )
+    np.testing.assert_allclose(
+        result["beamRadiation"], expected_beam_radiation, atol=0.01
+    )
+    np.testing.assert_allclose(
+        result["diffusePlusBeamRadiation"],
+        expected_diffuse_radiation + expected_beam_radiation,
+        atol=0.01,
+    )
+
+
+# Documentation test
+def test_diffuse_and_beam_radiation__night_pacific_ocean() -> None:
+    inputs = {
+        "date": datetime.datetime(1970, 12, 21),
+        # midday in Greenwich so night at longitude = 180 (Pacific Ocean)
+        # we interpret "time" as UTC, we do *not* infer a timezone from given longitude.
+        "time": datetime.datetime(1970, 3, 21, 12),
+        "longitude": 180,
+        "latitude": 0.0,
+        "skyCover": "N0",
+    }
+    result = compute_diffuse_and_beam_radiations(inputs)
+    # night so no radiation
+    expected_diffuse_radiation = 0
+    expected_beam_radiation = 0
+    np.testing.assert_allclose(
+        result["diffuseRadiation"], expected_diffuse_radiation, atol=0.01
+    )
+    np.testing.assert_allclose(
+        result["beamRadiation"], expected_beam_radiation, atol=0.01
+    )
+    np.testing.assert_allclose(
+        result["diffusePlusBeamRadiation"],
+        expected_diffuse_radiation + expected_beam_radiation,
+        atol=0.01,
+    )
+
+
+# TODO
+def test_diffuse_and_beam_radiation__wrong_date_type() -> None:
+    inputs = {
+        "date": "2026-07-10",
+        "time": "2026-07-10T23:00",
+        "longitude": -89,
+        "latitude": 45,
+        "skyCover": "N4",
+    }
+    with pytest.raises(TypeError, match=r"date.*time"):
+        compute_diffuse_and_beam_radiations(inputs)
+
+
+def test_diffuse_and_beam_radiation__wrong_sky_cover_type() -> None:
+    inputs = {
+        "date": datetime.datetime(1970, 12, 21),
+        "time": datetime.datetime(1970, 3, 21, 12),
+        "longitude": 45.0,
+        "latitude": 0.0,
+        "skyCover": 0,
+    }
+    with pytest.raises(TypeError):
+        compute_diffuse_and_beam_radiations(inputs)
+
+    inputs = {
+        "date": datetime.datetime(1970, 12, 21),
+        "time": datetime.datetime(1970, 3, 21, 12),
+        "longitude": 45.0,
+        "latitude": 0.0,
+        "skyCover": "0",
+    }
+    with pytest.raises(ValueError):
+        compute_diffuse_and_beam_radiations(inputs)


### PR DESCRIPTION
- Define `diffuseAndBeamRadiationsCalculation` task and related function in stellar-engine to compute diffuse and beam radiation using mechaphlowers.
- On field measurement popup, rename fields about solar radiations (formerly solar flux).
- On field measurement popup, automatically compute and display diffuse solar flux, beam solar flux and diffuse + beam solar flux. Update these fields everytime one of the input is updated (latitude, longitude, date, time, sky cover).

NB: the handling of timezone and winter/summer time is bugged and will be fixed in another PR, as well as for temperature computation. For now the time is interpreted as UTC, we do not use France timezone nor do we infer a timezone from GPS coordinates.

**Please check if the PR fulfills these requirements**
<!-- please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes -->
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**Does this PR already have an issue describing the problem?**
<!-- If so, link to this issue using `'Fixes #XXX'` and skip the rest -->
#764 

**What kind of change does this PR introduce?**
<!-- Bug fix, feature, docs update, ... -->

**Does this PR introduce a breaking change or deprecate an API?**
- [ ] Yes
- [x] No


Duplicate of #1077 because there was signoff issues