### PR TITLE
Feat/917/adjust support values of section from geoliaison

### DIFF
--- a/assets/i18n/messages.fr.xlf
+++ b/assets/i18n/messages.fr.xlf
@@ -4207,6 +4207,12 @@
         <target>Longueur de corde</target>
       </segment>
     </unit>
+    <unit id="2861737300887040849">
+      <segment state="initial">
+        <source>The attachment support from the geolink file is not present in the application support catalog</source>
+        <target>Le support d'accrochage du fichier de géoliaison n'est pas présent au catalogue des supports de l'application</target>
+      </segment>
+    </unit>
     <unit id="8749123360857368229">
       <segment state="initial">
         <source>Shifting clamp length</source>

--- a/assets/i18n/messages.xlf
+++ b/assets/i18n/messages.xlf
@@ -3527,6 +3527,11 @@
         <source>Rope length</source>
       </segment>
     </unit>
+    <unit id="2861737300887040849">
+      <segment>
+        <source>The attachment support from the geolink file is not present in the application support catalog</source>
+      </segment>
+    </unit>
     <unit id="2872097738404332614">
       <segment>
         <source>displac. manip. type</source>

--- a/src/app/features/study/application/services/section-import.constantes.ts
+++ b/src/app/features/study/application/services/section-import.constantes.ts
@@ -21,7 +21,7 @@ export const sectionImportErrors = {
 };
 
 /** Warning shown when at least one GeoLiaison support cannot be resolved with complete catalog data. */
-export const geoLiaisonSupportCatalogMissingWarning = $localize`Le support d'accrochage du fichier de géoliaison n'est pas présent au catalogue des supports de l'application`;
+export const geoLiaisonSupportCatalogMissingWarning = $localize`The attachment support from the geolink file is not present in the application support catalog`;
 
 /**
  * Builds the localized info toast detail shown after a GeoLiaison import whenever the

--- a/src/app/features/study/application/services/section-import.constantes.ts
+++ b/src/app/features/study/application/services/section-import.constantes.ts
@@ -20,6 +20,9 @@ export const sectionImportErrors = {
   lambertReprojectionError: $localize`Error computing GPS coordinates from Lambert93 data`
 };
 
+/** Warning shown when at least one GeoLiaison support cannot be resolved with complete catalog data. */
+export const geoLiaisonSupportCatalogMissingWarning = $localize`Le support d'accrochage du fichier de géoliaison n'est pas présent au catalogue des supports de l'application`;
+
 /**
  * Builds the localized info toast detail shown after a GeoLiaison import whenever the
  * Lambert93-to-GPS reprojection was computed, reporting the mean absolute error (in meters)

--- a/src/app/features/study/application/services/section-import.service.spec.ts
+++ b/src/app/features/study/application/services/section-import.service.spec.ts
@@ -744,27 +744,27 @@ describe('SectionImportService', () => {
       expect(support?.heightBelowConsole).toBe(99.9);
     });
 
-    it('should keep file attachmentSet but null out armLength/heightBelowConsole and warn once when SUPPORT_IDR is absent from catalog', async () => {
+    it('should keep file attachmentSet and file armLength/heightBelowConsole and warn once when SUPPORT_IDR is absent from catalog', async () => {
       attachmentServiceMock.resolveGeoLiaisonCatalogAttachment.mockResolvedValue(undefined);
 
       const result = await service.processFile(makeJsonFile(buildValidGeoLiaisonPayload()), neverAccept);
 
       expect(result?.supports[0].attachmentSet).toBe(19);
-      expect(result?.supports[0].armLength).toBeNull();
-      expect(result?.supports[0].heightBelowConsole).toBeNull();
+      expect(result?.supports[0].armLength).toBe(3.0);
+      expect(result?.supports[0].heightBelowConsole).toBe(2.5);
       expect(messageServiceMock.add).toHaveBeenCalledWith(
         expect.objectContaining({ severity: 'warn', detail: geoLiaisonSupportCatalogMissingWarning })
       );
     });
 
-    it('should keep file attachmentSet but null out armLength/heightBelowConsole and warn once when matching support exists but attachment set is absent', async () => {
+    it('should keep file attachmentSet and file armLength/heightBelowConsole and warn once when matching support exists but attachment set is absent', async () => {
       attachmentServiceMock.resolveGeoLiaisonCatalogAttachment.mockResolvedValue(undefined);
 
       const result = await service.processFile(makeJsonFile(buildValidGeoLiaisonPayload()), neverAccept);
 
       expect(result?.supports[0].attachmentSet).toBe(19);
-      expect(result?.supports[0].armLength).toBeNull();
-      expect(result?.supports[0].heightBelowConsole).toBeNull();
+      expect(result?.supports[0].armLength).toBe(3.0);
+      expect(result?.supports[0].heightBelowConsole).toBe(2.5);
       expect(
         messageServiceMock.add.mock.calls.filter((call) =>
           [geoLiaisonSupportCatalogMissingWarning].includes(call[0].detail as string)

--- a/src/app/features/study/application/services/section-import.service.spec.ts
+++ b/src/app/features/study/application/services/section-import.service.spec.ts
@@ -18,6 +18,7 @@ import { MaintenanceService } from '@shared/catalog/services/maintenance.service
 import { AttachmentService } from '@shared/catalog/services/attachment.service';
 import { CatalogMaintenance } from '@shared/domain';
 import { SupportNameEntry } from '@shared/catalog/services/attachment.interfaces';
+import { geoLiaisonSupportCatalogMissingWarning } from './section-import.constantes';
 
 // ---------------------------------------------------------------------------
 // Polyfill File.prototype.text — jsdom 26 does not implement it
@@ -171,7 +172,10 @@ describe('SectionImportService', () => {
   let messageServiceMock: vi.Mocked<MessageService>;
   let loggerSpy: vi.Mocked<LoggerService>;
   let maintenanceServiceMock: { getMaintenance: ReturnType<typeof vi.fn> };
-  let attachmentServiceMock: { addSupportNamesIfAbsent: ReturnType<typeof vi.fn> };
+  let attachmentServiceMock: {
+    addSupportNamesIfAbsent: ReturnType<typeof vi.fn>;
+    resolveGeoLiaisonCatalogAttachment: ReturnType<typeof vi.fn>;
+  };
   let workerPythonServiceMock: { runTask: ReturnType<typeof vi.fn> };
 
   /** Default successful runTask mock: returns arrays matching the length of the input arrays. */
@@ -257,7 +261,8 @@ describe('SectionImportService', () => {
     };
 
     attachmentServiceMock = {
-      addSupportNamesIfAbsent: vi.fn().mockResolvedValue(undefined)
+      addSupportNamesIfAbsent: vi.fn().mockResolvedValue(undefined),
+      resolveGeoLiaisonCatalogAttachment: vi.fn().mockResolvedValue(undefined)
     };
 
     workerPythonServiceMock = {
@@ -573,6 +578,7 @@ describe('SectionImportService', () => {
   describe('processFile() — GeoLiaison format', () => {
     beforeEach(() => {
       service.setStudyContext(buildMockStudy());
+      attachmentServiceMock.resolveGeoLiaisonCatalogAttachment.mockResolvedValue(undefined);
     });
 
     it('should map UUID from CANTON_CUR', async () => {
@@ -685,6 +691,107 @@ describe('SectionImportService', () => {
       const result = await service.processFile(file, neverAccept);
 
       expect(result?.cable_name).toBe('GeoSection');
+    });
+
+    it('should always keep support name equal to SUPPORT_IDR in both catalog and fallback branches', async () => {
+      attachmentServiceMock.resolveGeoLiaisonCatalogAttachment.mockResolvedValueOnce({
+        uuid: 'cat-1',
+        created_at: 'c',
+        updated_at: 'u',
+        support_name: 'Support A',
+        support_tower: 'Tower X',
+        attachment_set: 19,
+        cross_arm_length: 4,
+        attachment_altitude: 40,
+        attachment_set_x: 1,
+        attachment_set_y: 2,
+        attachment_set_z: 40
+      });
+
+      const file = makeJsonFile(buildValidGeoLiaisonPayload());
+      const result = await service.processFile(file, neverAccept);
+
+      expect(result?.supports[0].name).toBe('Support_IDR_A');
+      expect(result?.supports[1].name).toBe('Support_IDR_A');
+    });
+
+    it('should prioritize catalog attachmentSet/armLength/heightBelowConsole over file values when complete', async () => {
+      attachmentServiceMock.resolveGeoLiaisonCatalogAttachment.mockResolvedValue({
+        uuid: 'cat-1',
+        created_at: 'c',
+        updated_at: 'u',
+        support_name: 'Support A',
+        support_tower: 'Tower X',
+        attachment_set: 7,
+        cross_arm_length: 9.9,
+        attachment_altitude: 99.9,
+        attachment_set_x: 1,
+        attachment_set_y: 2,
+        attachment_set_z: 99.9
+      });
+
+      const payload = buildValidGeoLiaisonPayload();
+      const portees = (payload.cantons as Record<string, unknown>[])[0]['portee unitaire'] as Record<string, unknown>[];
+      (portees[0]['accroche depart'] as Record<string, unknown>)['ACCROCHE_SET'] = '19';
+      (portees[0]['accroche depart'] as Record<string, unknown>)['LONGUEUR_BRAS'] = '3.0';
+      (portees[0]['accroche depart'] as Record<string, unknown>)['HAUTEUR_SOUS_CONSOLE'] = '2.5';
+
+      const result = await service.processFile(makeJsonFile(payload), neverAccept);
+      const support = result?.supports[0];
+
+      expect(support?.attachmentSet).toBe(7);
+      expect(support?.armLength).toBe(9.9);
+      expect(support?.heightBelowConsole).toBe(99.9);
+    });
+
+    it('should keep file attachmentSet but null out armLength/heightBelowConsole and warn once when SUPPORT_IDR is absent from catalog', async () => {
+      attachmentServiceMock.resolveGeoLiaisonCatalogAttachment.mockResolvedValue(undefined);
+
+      const result = await service.processFile(makeJsonFile(buildValidGeoLiaisonPayload()), neverAccept);
+
+      expect(result?.supports[0].attachmentSet).toBe(19);
+      expect(result?.supports[0].armLength).toBeNull();
+      expect(result?.supports[0].heightBelowConsole).toBeNull();
+      expect(messageServiceMock.add).toHaveBeenCalledWith(
+        expect.objectContaining({ severity: 'warn', detail: geoLiaisonSupportCatalogMissingWarning })
+      );
+    });
+
+    it('should keep file attachmentSet but null out armLength/heightBelowConsole and warn once when matching support exists but attachment set is absent', async () => {
+      attachmentServiceMock.resolveGeoLiaisonCatalogAttachment.mockResolvedValue(undefined);
+
+      const result = await service.processFile(makeJsonFile(buildValidGeoLiaisonPayload()), neverAccept);
+
+      expect(result?.supports[0].attachmentSet).toBe(19);
+      expect(result?.supports[0].armLength).toBeNull();
+      expect(result?.supports[0].heightBelowConsole).toBeNull();
+      expect(
+        messageServiceMock.add.mock.calls.filter((call) =>
+          [geoLiaisonSupportCatalogMissingWarning].includes(call[0].detail as string)
+        )
+      ).toHaveLength(1);
+    });
+
+    it('should accept zero values from catalog when complete geometry is present', async () => {
+      attachmentServiceMock.resolveGeoLiaisonCatalogAttachment.mockResolvedValue({
+        uuid: 'cat-1',
+        created_at: 'c',
+        updated_at: 'u',
+        support_name: 'Support A',
+        support_tower: 'Tower X',
+        attachment_set: 0,
+        cross_arm_length: 0,
+        attachment_altitude: 0,
+        attachment_set_x: 0,
+        attachment_set_y: 0,
+        attachment_set_z: 0
+      });
+
+      const result = await service.processFile(makeJsonFile(buildValidGeoLiaisonPayload()), neverAccept);
+
+      expect(result?.supports[0].attachmentSet).toBe(0);
+      expect(result?.supports[0].armLength).toBe(0);
+      expect(result?.supports[0].heightBelowConsole).toBe(0);
     });
 
     it('should handle null maintenance lookup gracefully when no match found', async () => {

--- a/src/app/features/study/application/services/section-import.service.ts
+++ b/src/app/features/study/application/services/section-import.service.ts
@@ -17,7 +17,12 @@ import { hasSupportsBoundsErrors } from '@features/study/presentation/components
 import { MaintenanceService } from '@shared/catalog/services/maintenance.service';
 import { AttachmentService } from '@shared/catalog/services/attachment.service';
 import { SupportNameEntry } from '@shared/catalog/services/attachment.interfaces';
-import { sectionImportErrors, importSuccessDetail, buildReprojectionInfoMessage } from './section-import.constantes';
+import {
+  sectionImportErrors,
+  importSuccessDetail,
+  buildReprojectionInfoMessage,
+  geoLiaisonSupportCatalogMissingWarning
+} from './section-import.constantes';
 import { GeoLiaisonAccroche, GeoLiaisonCanton, GeoLiaisonFormat, GeoLiaisonPortee } from './section-import.interfaces';
 import { Localization } from '@core/services/worker_python/tasks/types';
 import {
@@ -151,7 +156,7 @@ export class SectionImportService implements ImportAdapter<Section> {
     }
 
     // Stage: DECODING + PARSING
-    const { section, isGeoLiaison, rawGeoLiaison } = await this.parseJsonFile(file);
+    const { section, isGeoLiaison, rawGeoLiaison, hasCatalogFallbackWarnings } = await this.parseJsonFile(file);
 
     // Stage: VALIDATION
     // GeoLiaison: validate on the raw JSON so error messages show original field names
@@ -164,7 +169,7 @@ export class SectionImportService implements ImportAdapter<Section> {
     }
 
     // Stage: COLLISION_CHECK + PERSISTENCE
-    return this.persistSection(section, study, collisionResolver);
+    return this.persistSection(section, study, collisionResolver, isGeoLiaison && hasCatalogFallbackWarnings);
   }
 
   // ---------------------------------------------------------------------------
@@ -195,9 +200,12 @@ export class SectionImportService implements ImportAdapter<Section> {
   // Private — parsing
   // ---------------------------------------------------------------------------
 
-  private async parseJsonFile(
-    file: File
-  ): Promise<{ section: Section; isGeoLiaison: boolean; rawGeoLiaison?: GeoLiaisonFormat }> {
+  private async parseJsonFile(file: File): Promise<{
+    section: Section;
+    isGeoLiaison: boolean;
+    rawGeoLiaison?: GeoLiaisonFormat;
+    hasCatalogFallbackWarnings: boolean;
+  }> {
     let text: string;
     try {
       text = await file.text();
@@ -237,18 +245,21 @@ export class SectionImportService implements ImportAdapter<Section> {
         throw error;
       }
       const rawGeoLiaison = parsed as unknown as GeoLiaisonFormat;
-      const section = await this.mapGeoLiaisonToSection(rawGeoLiaison);
-      return { section, isGeoLiaison: true, rawGeoLiaison };
+      const { section, hasCatalogFallbackWarnings } = await this.mapGeoLiaisonToSection(rawGeoLiaison);
+      return { section, isGeoLiaison: true, rawGeoLiaison, hasCatalogFallbackWarnings };
     }
 
-    return { section: this.mapToSection(parsed), isGeoLiaison: false };
+    return { section: this.mapToSection(parsed), isGeoLiaison: false, hasCatalogFallbackWarnings: false };
   }
 
   // ---------------------------------------------------------------------------
   // Private — GeoLiaison mapping
   // ---------------------------------------------------------------------------
 
-  private async mapGeoLiaisonToSection(raw: GeoLiaisonFormat): Promise<Section> {
+  private async mapGeoLiaisonToSection(raw: GeoLiaisonFormat): Promise<{
+    section: Section;
+    hasCatalogFallbackWarnings: boolean;
+  }> {
     const canton = raw.cantons[0];
     const general = canton.general;
     const portees = canton['portee unitaire'] ?? [];
@@ -279,8 +290,6 @@ export class SectionImportService implements ImportAdapter<Section> {
       : undefined;
 
     const supports = this.mapGeoLiaisonSupports(sortedPortees);
-
-    // Persist new support names in the local catalog (RG.CAN.ATT)
     const accroches =
       sortedPortees.length === 0
         ? []
@@ -288,6 +297,10 @@ export class SectionImportService implements ImportAdapter<Section> {
             ...sortedPortees.map((p) => p['accroche depart']),
             sortedPortees[sortedPortees.length - 1]['accroche arrivee']
           ];
+    const { supports: supportsWithCatalogResolution, hasCatalogFallbackWarnings } =
+      await this.resolveGeoLiaisonCatalogSupportFields(supports, accroches);
+
+    // Persist new support names in the local catalog (RG.CAN.ATT)
     const supportNameEntries: SupportNameEntry[] = accroches
       .map((a) => ({ supportName: a.SUPPORT_IDR || a.SUPPORT_ADR || '', supportTower: a.SUPPORT_TOWER ?? null }))
       .filter((e) => !!e.supportName);
@@ -296,39 +309,96 @@ export class SectionImportService implements ImportAdapter<Section> {
     const lambertX = accroches.map((a) => parseFloatOrNull(a.PIED_X_LAMBERT93));
     const lambertY = accroches.map((a) => parseFloatOrNull(a.PIED_Y_LAMBERT93));
     const { supports: reprojectedSupports, meanReprojectionDiffMeters } = await this.applyLambertReprojection(
-      supports,
+      supportsWithCatalogResolution,
       lambertX,
       lambertY
     );
 
     return {
-      ...createEmptySection(),
-      uuid: general.CANTON_CUR.trim(),
-      name: buildSectionName(
-        appartenance?.BRANCHE_IDR ?? null,
-        general.CANTON_TYPE,
-        general.PHASE_ELECTRIQUE_NUMERO,
-        supports
-      ),
-      cable_name: general.CABLE_ADR ?? undefined,
-      type: general.CANTON_TYPE?.toLowerCase() ?? '',
-      cables_amount: parseFloatOrNull(general.FAISCEAU_CABLES_NOMBRE) ?? 1,
-      electric_phase_number: parseFloatOrNull(general.PHASE_ELECTRIQUE_NUMERO) ?? undefined,
-      lit_name: appartenance?.LIT_ADR ?? undefined,
-      lit_code: appartenance?.LIT_IDR ?? undefined,
-      link_name: appartenance?.LIAISON_IDR ?? undefined,
-      branch_idr: appartenance?.BRANCHE_IDR ? extractBranchIdr(appartenance.BRANCHE_IDR) : undefined,
-      voltage_idr: undefined,
-      maintenance_center_id: maintenanceCenterEntry?.maintenance_center_id ?? undefined,
-      maintenance_center_names: cmDesignation ? [cmDesignation] : [],
-      maintenance_team_id: maintenanceTeamEntry?.maintenance_team_id ?? undefined,
-      regional_team_id: regionalTeamEntry?.regional_team_id ?? undefined,
-      regional_maintenance_center_names: gmrDesignation ? [gmrDesignation] : [],
-      initial_conditions: [],
-      selected_initial_condition_uuid: undefined,
-      supports: reprojectedSupports,
-      mean_reprojection_diff_meters: meanReprojectionDiffMeters
+      section: {
+        ...createEmptySection(),
+        uuid: general.CANTON_CUR.trim(),
+        name: buildSectionName(
+          appartenance?.BRANCHE_IDR ?? null,
+          general.CANTON_TYPE,
+          general.PHASE_ELECTRIQUE_NUMERO,
+          supportsWithCatalogResolution
+        ),
+        cable_name: general.CABLE_ADR ?? undefined,
+        type: general.CANTON_TYPE?.toLowerCase() ?? '',
+        cables_amount: parseFloatOrNull(general.FAISCEAU_CABLES_NOMBRE) ?? 1,
+        electric_phase_number: parseFloatOrNull(general.PHASE_ELECTRIQUE_NUMERO) ?? undefined,
+        lit_name: appartenance?.LIT_ADR ?? undefined,
+        lit_code: appartenance?.LIT_IDR ?? undefined,
+        link_name: appartenance?.LIAISON_IDR ?? undefined,
+        branch_idr: appartenance?.BRANCHE_IDR ? extractBranchIdr(appartenance.BRANCHE_IDR) : undefined,
+        voltage_idr: undefined,
+        maintenance_center_id: maintenanceCenterEntry?.maintenance_center_id ?? undefined,
+        maintenance_center_names: cmDesignation ? [cmDesignation] : [],
+        maintenance_team_id: maintenanceTeamEntry?.maintenance_team_id ?? undefined,
+        regional_team_id: regionalTeamEntry?.regional_team_id ?? undefined,
+        regional_maintenance_center_names: gmrDesignation ? [gmrDesignation] : [],
+        initial_conditions: [],
+        selected_initial_condition_uuid: undefined,
+        supports: reprojectedSupports,
+        mean_reprojection_diff_meters: meanReprojectionDiffMeters
+      },
+      hasCatalogFallbackWarnings
     };
+  }
+
+  /**
+   * Resolves each support's name/attachmentSet/armLength/heightBelowConsole against the local
+   * attachment catalog (RG.CAN.SUP-NOM/SET/BRA).
+   *
+   * `AttachmentService.resolveGeoLiaisonCatalogAttachment` already guarantees a complete
+   * (L/X/Y/Z) entry when it returns one, so an `undefined` result is the single signal that the
+   * support is absent from the catalog — in that case the GeoLiaison file values are kept as-is,
+   * except for `armLength`/`heightBelowConsole` which must come from the catalog only and are
+   * therefore reset to `null` rather than falling back to the imported file values.
+   */
+  private async resolveGeoLiaisonCatalogSupportFields(
+    supports: Support[],
+    accroches: GeoLiaisonAccroche[]
+  ): Promise<{ supports: Support[]; hasCatalogFallbackWarnings: boolean }> {
+    let hasCatalogFallbackWarnings = false;
+
+    const resolvedSupports = await Promise.all(
+      supports.map(async (support, index) => {
+        const accroche = accroches[index];
+        if (!accroche) {
+          return support;
+        }
+
+        const catalogEntry = await this.attachmentService.resolveGeoLiaisonCatalogAttachment(
+          accroche.SUPPORT_IDR,
+          accroche.SUPPORT_ADR,
+          support.attachmentSet
+        );
+
+        if (!catalogEntry) {
+          hasCatalogFallbackWarnings = true;
+          return {
+            ...support,
+            name: accroche.SUPPORT_IDR ?? null,
+            // armLength/heightBelowConsole must come from the catalog only, never from the
+            // imported file — reset instead of keeping the GeoLiaison fallback values.
+            armLength: null,
+            heightBelowConsole: null
+          };
+        }
+
+        return {
+          ...support,
+          name: accroche.SUPPORT_IDR ?? null,
+          attachmentSet: catalogEntry.attachment_set ?? null,
+          armLength: catalogEntry.cross_arm_length ?? null,
+          heightBelowConsole: catalogEntry.attachment_altitude ?? null
+        };
+      })
+    );
+
+    return { supports: resolvedSupports, hasCatalogFallbackWarnings };
   }
 
   private mapGeoLiaisonSupports(sortedPortees: GeoLiaisonPortee[]): Support[] {
@@ -556,7 +626,8 @@ export class SectionImportService implements ImportAdapter<Section> {
   private async persistSection(
     section: Section,
     study: Study,
-    collisionResolver: UUIDCollisionResolver
+    collisionResolver: UUIDCollisionResolver,
+    hasCatalogFallbackWarnings: boolean
   ): Promise<Section | null> {
     const existingSection = study.sections.find((s) => s.uuid === section.uuid);
 
@@ -597,6 +668,7 @@ export class SectionImportService implements ImportAdapter<Section> {
 
       this.notificationService.success(importSuccessDetail);
       this.notifyGpsReprojection(section);
+      this.notifyGeoLiaisonCatalogFallbackWarnings(hasCatalogFallbackWarnings);
       return section;
     }
 
@@ -615,6 +687,7 @@ export class SectionImportService implements ImportAdapter<Section> {
 
     this.notificationService.success(importSuccessDetail);
     this.notifyGpsReprojection(section);
+    this.notifyGeoLiaisonCatalogFallbackWarnings(hasCatalogFallbackWarnings);
     return section;
   }
 
@@ -626,5 +699,13 @@ export class SectionImportService implements ImportAdapter<Section> {
     if (section.mean_reprojection_diff_meters != null) {
       this.notificationService.info(buildReprojectionInfoMessage(section.mean_reprojection_diff_meters));
     }
+  }
+
+  private notifyGeoLiaisonCatalogFallbackWarnings(hasCatalogFallbackWarnings: boolean): void {
+    if (!hasCatalogFallbackWarnings) {
+      return;
+    }
+
+    this.notificationService.warning(geoLiaisonSupportCatalogMissingWarning);
   }
 }

--- a/src/app/features/study/application/services/section-import.service.ts
+++ b/src/app/features/study/application/services/section-import.service.ts
@@ -380,15 +380,17 @@ export class SectionImportService implements ImportAdapter<Section> {
           // Support absent from catalog: keep the GeoLiaison file values for armLength
           // (LONGUEUR_BRAS) and heightBelowConsole (HAUTEUR_SOUS_CONSOLE) already mapped
           // into `support` by `mapAccrocheToSupport`.
+          // Fall back to SUPPORT_ADR if SUPPORT_IDR is missing, as it's already used
+          // in the catalog lookup and elsewhere as a secondary identifier.
           return {
             ...support,
-            name: accroche.SUPPORT_IDR ?? null
+            name: accroche.SUPPORT_IDR ?? accroche.SUPPORT_ADR ?? null
           };
         }
 
         return {
           ...support,
-          name: accroche.SUPPORT_IDR ?? null,
+          name: accroche.SUPPORT_IDR ?? accroche.SUPPORT_ADR ?? null,
           attachmentSet: catalogEntry.attachment_set ?? null,
           armLength: catalogEntry.cross_arm_length ?? null,
           heightBelowConsole: catalogEntry.attachment_altitude ?? null

--- a/src/app/features/study/application/services/section-import.service.ts
+++ b/src/app/features/study/application/services/section-import.service.ts
@@ -354,8 +354,7 @@ export class SectionImportService implements ImportAdapter<Section> {
    * `AttachmentService.resolveGeoLiaisonCatalogAttachment` already guarantees a complete
    * (L/X/Y/Z) entry when it returns one, so an `undefined` result is the single signal that the
    * support is absent from the catalog — in that case the GeoLiaison file values are kept as-is,
-   * except for `armLength`/`heightBelowConsole` which must come from the catalog only and are
-   * therefore reset to `null` rather than falling back to the imported file values.
+   * including `armLength` (`LONGUEUR_BRAS`) and `heightBelowConsole` (`HAUTEUR_SOUS_CONSOLE`).
    */
   private async resolveGeoLiaisonCatalogSupportFields(
     supports: Support[],
@@ -378,13 +377,12 @@ export class SectionImportService implements ImportAdapter<Section> {
 
         if (!catalogEntry) {
           hasCatalogFallbackWarnings = true;
+          // Support absent from catalog: keep the GeoLiaison file values for armLength
+          // (LONGUEUR_BRAS) and heightBelowConsole (HAUTEUR_SOUS_CONSOLE) already mapped
+          // into `support` by `mapAccrocheToSupport`.
           return {
             ...support,
-            name: accroche.SUPPORT_IDR ?? null,
-            // armLength/heightBelowConsole must come from the catalog only, never from the
-            // imported file — reset instead of keeping the GeoLiaison fallback values.
-            armLength: null,
-            heightBelowConsole: null
+            name: accroche.SUPPORT_IDR ?? null
           };
         }
 

--- a/src/app/features/study/presentation/components/sections-tab/newSectionModal/manualSection/supportsTable/attachmentSetModal/attachmentSetModal.component.spec.ts
+++ b/src/app/features/study/presentation/components/sections-tab/newSectionModal/manualSection/supportsTable/attachmentSetModal/attachmentSetModal.component.spec.ts
@@ -90,6 +90,17 @@ describe('AttachmentSetModalComponent', () => {
       created_at: '2023-01-01',
       updated_at: '2023-01-01',
       support_tower: 'Tower Model'
+    },
+    {
+      uuid: '4',
+      support_name: 'Test Support',
+      attachment_set: 1,
+      support_order: 1,
+      attachment_altitude: 10.0,
+      cross_arm_length: 2.5,
+      created_at: '2023-01-01',
+      updated_at: '2023-01-01',
+      support_tower: 'Tower Model'
     }
   ];
 
@@ -446,11 +457,13 @@ describe('AttachmentSetModalComponent', () => {
       fixture.detectChanges();
       await fixture.whenStable();
 
-      // Verify supportName is not set (resetValues(true) clears it)
+      // Support has no name, so no catalog lookup is possible.
+      // File-imported towerModel is kept as fallback, but armLength/heightBelowConsole must come
+      // from the catalog only and stay unset.
       expect(component.supportName()).toBeUndefined();
       expect(component.attachmentSet()).toBe(1);
-      expect(component.armLength()).toBe(2.5);
-      expect(component.heightBelowConsole()).toBe(10.0);
+      expect(component.armLength()).toBeUndefined();
+      expect(component.heightBelowConsole()).toBeUndefined();
       expect(component.towerModel()).toBe('Tower Model');
     });
 
@@ -498,14 +511,16 @@ describe('AttachmentSetModalComponent', () => {
       expect(component.towerModel()).toBe('Tower Model');
     });
 
-    it('keeps the existing derived values without a catalog lookup when the support already has them', async () => {
-      // mockSupport already carries armLength, heightBelowConsole and towerModel.
+    it('ALWAYS resolves catalog-derived fields to ensure catalog values override file-imported values (US RG.CAN.SUP-NOM.1)', async () => {
+      // mockSupport carries armLength/heightBelowConsole/towerModel from import file,
+      // but the catalog lookup MUST be called to replace them with catalog-only values.
+      // This ensures that file-imported values (e.g., placeholder 999.9) are never displayed.
       fixture.componentRef.setInput('support', mockSupport);
       fixture.componentRef.setInput('isOpen', true);
       fixture.detectChanges();
       await fixture.whenStable();
 
-      expect(attachmentServiceMock.getDerivedSupportFields).not.toHaveBeenCalled();
+      expect(attachmentServiceMock.getDerivedSupportFields).toHaveBeenCalledWith('Test Support', 1);
       expect(component.armLength()).toBe(2.5);
       expect(component.heightBelowConsole()).toBe(10.0);
       expect(component.towerModel()).toBe('Tower Model');

--- a/src/app/features/study/presentation/components/sections-tab/newSectionModal/manualSection/supportsTable/attachmentSetModal/attachmentSetModal.component.ts
+++ b/src/app/features/study/presentation/components/sections-tab/newSectionModal/manualSection/supportsTable/attachmentSetModal/attachmentSetModal.component.ts
@@ -137,7 +137,7 @@ export class AttachmentSetModalComponent {
     supportName: string,
     attachmentSet: number,
     requestId: number,
-    onlyIfEmpty: boolean = true
+    onlyIfEmpty = true
   ): Promise<void> {
     const derivedFields = await this.attachmentService.resolveDerivedSupportFields(supportName, attachmentSet);
     if (!this.derivedFieldsRequests.isCurrent(requestId) || !this.isOpen() || !derivedFields) {

--- a/src/app/features/study/presentation/components/sections-tab/newSectionModal/manualSection/supportsTable/attachmentSetModal/attachmentSetModal.component.ts
+++ b/src/app/features/study/presentation/components/sections-tab/newSectionModal/manualSection/supportsTable/attachmentSetModal/attachmentSetModal.component.ts
@@ -105,18 +105,15 @@ export class AttachmentSetModalComponent {
         const attachmentSet = support?.attachmentSet;
         if (attachmentSet) {
           this.attachmentSet.set(attachmentSet);
-          const armLength = support?.armLength ?? undefined;
-          const heightBelowConsole = support?.heightBelowConsole ?? undefined;
+          // Keep file-imported tower model as fallback, then try to override with catalog values.
+          // Per US RG.CAN.SUP-NOM.1, catalog values take priority if support+set exists in catalog.
+          // armLength/heightBelowConsole must come from the catalog only: they are left unset here
+          // (already reset to undefined above) and only ever populated by backfillDerivedFields.
           const towerModel = support?.towerModel ?? undefined;
-          this.armLength.set(armLength);
-          this.heightBelowConsole.set(heightBelowConsole);
           this.towerModel.set(towerModel);
-          // Backfill any catalog-derived field the support is missing (e.g. an attachment set
-          // assigned via inline edit / column copy before these fields were resolved). Resolving
-          // them all together keeps arm length / height / tower consistent — a tower-only backfill
-          // would leave the others undefined and validate() would emit 0.
-          if (name && (armLength == null || heightBelowConsole == null || !towerModel)) {
-            void this.backfillDerivedFields(name, attachmentSet, requestId);
+          // Try to resolve and override with catalog-derived fields (pass false to always overwrite)
+          if (name) {
+            void this.backfillDerivedFields(name, attachmentSet, requestId, false);
           }
         }
       }
@@ -129,17 +126,24 @@ export class AttachmentSetModalComponent {
   }
 
   /**
-   * Fills the catalog-derived fields (tower model, arm length, height below console) that the
-   * support does not already carry. Only empty signals are set, so user-edited values are kept.
+   * Fills the catalog-derived fields (tower model, arm length, height below console).
+   * When `onlyIfEmpty` is false (modal opening), all catalog values override file-imported values
+   * to ensure US RG.CAN.SUP-NOM.1 compliance (catalog-only values, never file values).
+   * When `onlyIfEmpty` is true, only empty signals are set, so user-edited values are kept.
    * The `requestId` (assigned by the open effect) guards against stale resolutions: the result is
    * dropped if a newer open/close or a user name/set change invalidated it while the lookup was in flight.
    */
-  private async backfillDerivedFields(supportName: string, attachmentSet: number, requestId: number): Promise<void> {
+  private async backfillDerivedFields(
+    supportName: string,
+    attachmentSet: number,
+    requestId: number,
+    onlyIfEmpty: boolean = true
+  ): Promise<void> {
     const derivedFields = await this.attachmentService.resolveDerivedSupportFields(supportName, attachmentSet);
     if (!this.derivedFieldsRequests.isCurrent(requestId) || !this.isOpen() || !derivedFields) {
       return;
     }
-    this.applyDerivedFields(derivedFields, true);
+    this.applyDerivedFields(derivedFields, onlyIfEmpty);
   }
 
   /**

--- a/src/app/features/study/presentation/components/sections-tab/newSectionModal/manualSection/supportsTable/attachmentSetModal/attachmentSetModal.component.ts
+++ b/src/app/features/study/presentation/components/sections-tab/newSectionModal/manualSection/supportsTable/attachmentSetModal/attachmentSetModal.component.ts
@@ -150,6 +150,8 @@ export class AttachmentSetModalComponent {
    * Fans a resolved `DerivedSupportAttachmentFields` out into the tower model, arm length and
    * height-below-console signals. When `onlyIfEmpty` is true (backfill), each signal is set only if
    * still empty so user-edited values survive; otherwise (a fresh selection) all three are overwritten.
+   * For towerModel specifically, only overwrite if the catalog has an actual non-null value,
+   * preserving the file-imported fallback when the catalog has no tower model.
    */
   private applyDerivedFields(derivedFields: DerivedSupportAttachmentFields, onlyIfEmpty: boolean): void {
     if (!onlyIfEmpty || this.armLength() == null) {
@@ -159,7 +161,11 @@ export class AttachmentSetModalComponent {
       this.heightBelowConsole.set(derivedFields.heightBelowConsole ?? undefined);
     }
     if (!onlyIfEmpty || !this.towerModel()) {
-      this.towerModel.set(derivedFields.towerModel ?? undefined);
+      // Only overwrite with catalog tower model if it has an actual value,
+      // preserving the file-imported fallback when catalog has none.
+      if (derivedFields.towerModel != null) {
+        this.towerModel.set(derivedFields.towerModel);
+      }
     }
   }
 

--- a/src/app/features/study/presentation/components/sections-tab/newSectionModal/manualSection/supportsTable/attachmentSetModal/attachmentSetModal.component.ts
+++ b/src/app/features/study/presentation/components/sections-tab/newSectionModal/manualSection/supportsTable/attachmentSetModal/attachmentSetModal.component.ts
@@ -103,7 +103,7 @@ export class AttachmentSetModalComponent {
           this.supportName.set(name);
         }
         const attachmentSet = support?.attachmentSet;
-        if (attachmentSet) {
+        if (attachmentSet != null) {
           this.attachmentSet.set(attachmentSet);
           // Keep file-imported tower model as fallback, then try to override with catalog values.
           // Per US RG.CAN.SUP-NOM.1, catalog values take priority if support+set exists in catalog.

--- a/src/app/features/study/presentation/components/sections-tab/newSectionModal/manualSection/supportsTable/supportsTable.component.html
+++ b/src/app/features/study/presentation/components/sections-tab/newSectionModal/manualSection/supportsTable/supportsTable.component.html
@@ -395,7 +395,7 @@
               <button
                 app-btn
                 btnSize="s"
-                [disabled]="!support.name || (catalogLoaded() && !supportFilterTable().includes(support.name))"
+                [disabled]="!support.name"
                 btnStyle="text"
                 aria-label="open attachment set modal"
                 i18n-aria-label

--- a/src/app/features/study/presentation/components/sections-tab/newSectionModal/manualSection/supportsTable/supportsTable.component.html
+++ b/src/app/features/study/presentation/components/sections-tab/newSectionModal/manualSection/supportsTable/supportsTable.component.html
@@ -395,7 +395,7 @@
               <button
                 app-btn
                 btnSize="s"
-                [disabled]="!support.name"
+                [disabled]="!support.name || (catalogLoaded() && !supportFilterTable().includes(support.name))"
                 btnStyle="text"
                 aria-label="open attachment set modal"
                 i18n-aria-label

--- a/src/app/features/study/presentation/components/sections-tab/newSectionModal/manualSection/supportsTable/supportsTable.component.spec.ts
+++ b/src/app/features/study/presentation/components/sections-tab/newSectionModal/manualSection/supportsTable/supportsTable.component.spec.ts
@@ -795,14 +795,14 @@ describe('SupportsTableComponent', () => {
   });
 
   describe('attachment set eye button availability', () => {
-    it('keeps the eye button enabled for unknown support names when support name is present', async () => {
+    it('disables the eye button for support names not in catalog when catalog is loaded', async () => {
       distinctSupportNamesSubject.next(['Support 1']);
       fixture.detectChanges();
       await Promise.resolve();
 
       const buttons = fixture.debugElement.queryAll(By.css('[data-testid="open-attachment-set-modal-btn"]'));
       const secondRowButton = buttons[1].nativeElement as HTMLButtonElement;
-      expect(secondRowButton.disabled).toBe(false);
+      expect(secondRowButton.disabled).toBe(true);
     });
   });
 
@@ -1124,11 +1124,11 @@ describe('SupportsTableComponent', () => {
       expect(isDisabled).toBe(false);
     });
 
-    it('should keep the button enabled when catalog is loaded and support name is not in catalog', () => {
+    it('should disable the button when catalog is loaded and support name is not in catalog', () => {
       distinctSupportNamesSubject.next(['CatalogType']);
       fixture.detectChanges();
       const btn = getByTestId('open-attachment-set-modal-btn') as HTMLButtonElement;
-      expect(btn.disabled).toBe(false);
+      expect(btn.disabled).toBe(true);
     });
 
     it('should disable the button when support name is null regardless of catalog state', () => {

--- a/src/app/features/study/presentation/components/sections-tab/newSectionModal/manualSection/supportsTable/supportsTable.component.spec.ts
+++ b/src/app/features/study/presentation/components/sections-tab/newSectionModal/manualSection/supportsTable/supportsTable.component.spec.ts
@@ -40,6 +40,8 @@ const mockAttachmentService = {
   getAttachmentDetails: vi.fn().mockResolvedValue(undefined),
   getDerivedSupportFields: vi.fn().mockResolvedValue(undefined),
   getDerivedSupportFieldsBySet: vi.fn().mockResolvedValue(new Map()),
+  resolveGeoLiaisonCatalogAttachment: vi.fn().mockResolvedValue(undefined),
+  getCompleteAttachmentSetsBySupportName: vi.fn().mockResolvedValue([]),
   // Mirrors the real wrapper: applies the (name, set) guard and delegates to getDerivedSupportFields
   // (returning its promise directly to preserve tick timing), so tests can keep asserting on it.
   resolveDerivedSupportFields: vi
@@ -545,6 +547,47 @@ describe('SupportsTableComponent', () => {
         support: { chainName: 'Non-existent Chain' }
       });
     });
+
+    it('should block non-catalog attachment sets when the row is in catalog-restricted mode', async () => {
+      mockAttachmentService.resolveGeoLiaisonCatalogAttachment.mockResolvedValue({
+        uuid: 'cat-1',
+        created_at: 'c',
+        updated_at: 'u',
+        support_name: 'Support 1',
+        support_tower: 'T1',
+        attachment_set: 1,
+        attachment_altitude: 10,
+        cross_arm_length: 2,
+        attachment_set_x: 1,
+        attachment_set_y: 1,
+        attachment_set_z: 10
+      });
+      mockAttachmentService.getCompleteAttachmentSetsBySupportName.mockResolvedValue([1, 2]);
+
+      await component.onSupportFieldChange('support1', 'name', 'Support 1');
+      vi.clearAllMocks();
+
+      await component.onSupportFieldChange('support1', 'attachmentSet', 9);
+
+      expect(component.supportChange.emit).not.toHaveBeenCalledWith({
+        uuid: 'support1',
+        support: { attachmentSet: 9 }
+      });
+    });
+
+    it('should allow free attachment-set input when catalog match is unresolved (fallback branch)', async () => {
+      mockAttachmentService.resolveGeoLiaisonCatalogAttachment.mockResolvedValue(undefined);
+
+      await component.onSupportFieldChange('support1', 'name', 'Support 1');
+      vi.clearAllMocks();
+
+      await component.onSupportFieldChange('support1', 'attachmentSet', 9);
+
+      expect(component.supportChange.emit).toHaveBeenCalledWith({
+        uuid: 'support1',
+        support: { attachmentSet: 9 }
+      });
+    });
   });
 
   // Regression tests for #657 (tower model) plus the arm-length / height-below-
@@ -664,6 +707,11 @@ describe('SupportsTableComponent', () => {
       const first = component.onSupportFieldChange('support1', 'attachmentSet', 1);
       const second = component.onSupportFieldChange('support1', 'attachmentSet', 2);
 
+      // onSupportFieldChange now awaits a catalog-restriction refresh before launching
+      // derived-field lookup, so let pending microtasks run before resolving promises.
+      await Promise.resolve();
+      await Promise.resolve();
+
       // The newer lookup (set 2) resolves first; the older one (set 1) resolves late.
       resolvers[1]();
       resolvers[0]();
@@ -743,6 +791,18 @@ describe('SupportsTableComponent', () => {
 
       expect(component.supportForAttachmentSetModal()).toEqual(mockSupports[0]);
       expect(component.attachmentSetModalOpen()).toBe(true);
+    });
+  });
+
+  describe('attachment set eye button availability', () => {
+    it('keeps the eye button enabled for unknown support names when support name is present', async () => {
+      distinctSupportNamesSubject.next(['Support 1']);
+      fixture.detectChanges();
+      await Promise.resolve();
+
+      const buttons = fixture.debugElement.queryAll(By.css('[data-testid="open-attachment-set-modal-btn"]'));
+      const secondRowButton = buttons[1].nativeElement as HTMLButtonElement;
+      expect(secondRowButton.disabled).toBe(false);
     });
   });
 
@@ -1060,15 +1120,15 @@ describe('SupportsTableComponent', () => {
       expect(component.catalogLoaded()).toBe(true);
       expect(component.supportFilterTable()).toContain('Support 1');
       const name = 'Support 1';
-      const isDisabled = !name || (component.catalogLoaded() && !component.supportFilterTable().includes(name));
+      const isDisabled = !name;
       expect(isDisabled).toBe(false);
     });
 
-    it('should disable the button when catalog is loaded and support name is not in catalog', () => {
+    it('should keep the button enabled when catalog is loaded and support name is not in catalog', () => {
       distinctSupportNamesSubject.next(['CatalogType']);
       fixture.detectChanges();
       const btn = getByTestId('open-attachment-set-modal-btn') as HTMLButtonElement;
-      expect(btn.disabled).toBe(true);
+      expect(btn.disabled).toBe(false);
     });
 
     it('should disable the button when support name is null regardless of catalog state', () => {
@@ -1076,9 +1136,7 @@ describe('SupportsTableComponent', () => {
       fixture.detectChanges();
       // Verify the condition: !null = true → always disabled
       const name: string | null = null;
-      expect(!name || (component.catalogLoaded() && !component.supportFilterTable().includes(name as string))).toBe(
-        true
-      );
+      expect(!name).toBe(true);
     });
   });
 

--- a/src/app/features/study/presentation/components/sections-tab/newSectionModal/manualSection/supportsTable/supportsTable.component.ts
+++ b/src/app/features/study/presentation/components/sections-tab/newSectionModal/manualSection/supportsTable/supportsTable.component.ts
@@ -108,6 +108,7 @@ export class SupportsTableComponent implements OnInit {
   supportFilterTable = signal<string[]>([]);
   supplementarySupportFilterTable = signal<string[]>([]);
   allSupportFilterTable = computed(() => [...this.supportFilterTable(), ...this.supplementarySupportFilterTable()]);
+  private readonly attachmentSetRestrictionsBySupportUuid = signal<Record<string, number[]>>({});
   private readonly chainsService = inject(ChainsService);
   private readonly attachmentService = inject(AttachmentService);
   private readonly allCatalogSupportNames = toSignal(this.attachmentService.distinctSupportNames$);
@@ -167,6 +168,9 @@ export class SupportsTableComponent implements OnInit {
 
   ngOnInit() {
     this.getData();
+    this.supports().forEach((support) => {
+      void this.refreshAttachmentSetRestriction(support.uuid, support.name, support.attachmentSet);
+    });
   }
 
   private hasLocalizationInputs(section: Section | null | undefined, supports: Support[]): boolean {
@@ -237,15 +241,69 @@ export class SupportsTableComponent implements OnInit {
   /** Latest derived-field resolution per support UUID, used to drop stale async results. */
   private readonly derivedFieldsRequests = new KeyedLatestRequestTracker<string>();
 
+  getRestrictedAttachmentSets(uuid: string): number[] {
+    return this.attachmentSetRestrictionsBySupportUuid()[uuid] ?? [];
+  }
+
+  private async refreshAttachmentSetRestriction(
+    uuid: string,
+    supportName: string | null,
+    attachmentSet: number | null
+  ): Promise<void> {
+    if (!supportName || attachmentSet == null) {
+      this.attachmentSetRestrictionsBySupportUuid.update((prev) => {
+        const rest = { ...prev };
+        delete rest[uuid];
+        return rest;
+      });
+      return;
+    }
+
+    const matchedEntry = await this.attachmentService.resolveGeoLiaisonCatalogAttachment(
+      supportName,
+      null,
+      attachmentSet
+    );
+    if (!matchedEntry) {
+      this.attachmentSetRestrictionsBySupportUuid.update((prev) => {
+        const rest = { ...prev };
+        delete rest[uuid];
+        return rest;
+      });
+      return;
+    }
+
+    const allowedSets = await this.attachmentService
+      .getCompleteAttachmentSetsBySupportName(supportName)
+      .catch(() => [] as number[]);
+    this.attachmentSetRestrictionsBySupportUuid.update((prev) => ({
+      ...prev,
+      [uuid]: allowedSets
+    }));
+  }
+
   async onSupportFieldChange(uuid: string, field: keyof Support, value: unknown) {
+    if (field === 'attachmentSet') {
+      const restrictedSets = this.getRestrictedAttachmentSets(uuid);
+      if (restrictedSets.length > 0 && value != null && !restrictedSets.includes(value as number)) {
+        return;
+      }
+    }
+
     const changes = buildFieldChangeUpdates(uuid, field, value, this.chainsOptions());
     changes.forEach((change) => this.supportChange.emit(change));
-    // The catalog-derived fields (tower model, arm length, height below console) depend on the
-    // (support name, attachment set) pair, so re-resolve them whenever either side changes.
+
+    // The attachment-set restriction and the catalog-derived fields (tower model, arm length,
+    // height below console) both depend on the (support name, attachment set) pair, so
+    // re-resolve them together whenever either side changes.
     if (field === 'name' || field === 'attachmentSet') {
-      const support = this.supports().find((support) => support.uuid === uuid);
-      const supportName = field === 'name' ? (value as string | null) : support?.name;
-      const attachmentSet = field === 'attachmentSet' ? (value as number | null) : support?.attachmentSet;
+      const support = this.supports().find((currentSupport) => currentSupport.uuid === uuid);
+      const supportName = field === 'name' ? (value as string | null) : (support?.name ?? null);
+      const attachmentSet =
+        field === 'attachmentSet' ? ((value as number | null) ?? null) : (support?.attachmentSet ?? null);
+
+      await this.refreshAttachmentSetRestriction(uuid, supportName, attachmentSet);
+
       // Guard against a stale update race: a faster edit of the same row (e.g. typing successive
       // digits into the attachment-set field) must not be overwritten by an older lookup resolving late.
       const requestId = this.derivedFieldsRequests.begin(uuid);

--- a/src/app/features/study/presentation/components/sections-tab/newSectionModal/manualSection/supportsTable/supportsTable.component.ts
+++ b/src/app/features/study/presentation/components/sections-tab/newSectionModal/manualSection/supportsTable/supportsTable.component.ts
@@ -268,11 +268,9 @@ export class SupportsTableComponent implements OnInit {
       return;
     }
 
-    const matchedEntry = await this.attachmentService.resolveGeoLiaisonCatalogAttachment(
-      supportName,
-      null,
-      attachmentSet
-    );
+    const matchedEntry = await this.attachmentService
+      .resolveGeoLiaisonCatalogAttachment(supportName, null, attachmentSet)
+      .catch(() => undefined);
     if (!this.restrictionRequests.isCurrent(uuid, requestId)) {
       return;
     }

--- a/src/app/features/study/presentation/components/sections-tab/newSectionModal/manualSection/supportsTable/supportsTable.component.ts
+++ b/src/app/features/study/presentation/components/sections-tab/newSectionModal/manualSection/supportsTable/supportsTable.component.ts
@@ -143,7 +143,11 @@ export class SupportsTableComponent implements OnInit {
     });
     // Drop derived-field request tokens for supports that no longer exist so the tracker
     // cannot grow unbounded across a long editing session (e.g. rows added then deleted).
-    effect(() => this.derivedFieldsRequests.retain(this.supports().map((support) => support.uuid)));
+    effect(() => {
+      const activeUuids = this.supports().map((support) => support.uuid);
+      this.derivedFieldsRequests.retain(activeUuids);
+      this.restrictionRequests.retain(activeUuids);
+    });
   }
 
   private updateSupportFilterTables(catalogNames: string[]): void {
@@ -240,6 +244,8 @@ export class SupportsTableComponent implements OnInit {
 
   /** Latest derived-field resolution per support UUID, used to drop stale async results. */
   private readonly derivedFieldsRequests = new KeyedLatestRequestTracker<string>();
+  /** Latest attachment-set restriction lookup per support UUID, used to drop stale async results. */
+  private readonly restrictionRequests = new KeyedLatestRequestTracker<string>();
 
   getRestrictedAttachmentSets(uuid: string): number[] {
     return this.attachmentSetRestrictionsBySupportUuid()[uuid] ?? [];
@@ -250,6 +256,9 @@ export class SupportsTableComponent implements OnInit {
     supportName: string | null,
     attachmentSet: number | null
   ): Promise<void> {
+    // Invalidate any in-flight lookup from a previous call so a stale resolution doesn't re-populate restrictions.
+    const requestId = this.restrictionRequests.begin(uuid);
+
     if (!supportName || attachmentSet == null) {
       this.attachmentSetRestrictionsBySupportUuid.update((prev) => {
         const rest = { ...prev };
@@ -264,7 +273,13 @@ export class SupportsTableComponent implements OnInit {
       null,
       attachmentSet
     );
+    if (!this.restrictionRequests.isCurrent(uuid, requestId)) {
+      return;
+    }
     if (!matchedEntry) {
+      if (!this.restrictionRequests.isCurrent(uuid, requestId)) {
+        return;
+      }
       this.attachmentSetRestrictionsBySupportUuid.update((prev) => {
         const rest = { ...prev };
         delete rest[uuid];
@@ -276,6 +291,9 @@ export class SupportsTableComponent implements OnInit {
     const allowedSets = await this.attachmentService
       .getCompleteAttachmentSetsBySupportName(supportName)
       .catch(() => [] as number[]);
+    if (!this.restrictionRequests.isCurrent(uuid, requestId)) {
+      return;
+    }
     this.attachmentSetRestrictionsBySupportUuid.update((prev) => ({
       ...prev,
       [uuid]: allowedSets

--- a/src/app/shared/catalog/services/attachment.service.spec.ts
+++ b/src/app/shared/catalog/services/attachment.service.spec.ts
@@ -184,6 +184,102 @@ describe('AttachmentService', () => {
     });
   });
 
+  describe('resolveGeoLiaisonCatalogAttachment', () => {
+    it('resolves using SUPPORT_IDR first and requires complete L/X/Y/Z', async () => {
+      mockTable.get.mockResolvedValue({
+        uuid: 'g',
+        created_at: 'c',
+        updated_at: 'u',
+        support_name: 'SUPPORT_IDR_1',
+        support_tower: 'T',
+        attachments: [
+          {
+            attachment_set: 4,
+            cross_arm_length: 3.2,
+            attachment_altitude: 20,
+            attachment_set_x: 1,
+            attachment_set_y: 2,
+            attachment_set_z: 20
+          }
+        ]
+      });
+
+      const result = await service.resolveGeoLiaisonCatalogAttachment('SUPPORT_IDR_1', 'SUPPORT_ADR_1', 4);
+      expect(result?.support_name).toBe('SUPPORT_IDR_1');
+      expect(mockTable.get).toHaveBeenCalledWith('SUPPORT_IDR_1');
+    });
+
+    it('falls back to SUPPORT_ADR when SUPPORT_IDR has no matching entry', async () => {
+      mockTable.get.mockResolvedValueOnce(undefined).mockResolvedValueOnce({
+        uuid: 'g',
+        created_at: 'c',
+        updated_at: 'u',
+        support_name: 'SUPPORT_ADR_1',
+        support_tower: 'T',
+        attachments: [
+          {
+            attachment_set: 4,
+            cross_arm_length: 3.2,
+            attachment_altitude: 20,
+            attachment_set_x: 1,
+            attachment_set_y: 2,
+            attachment_set_z: 20
+          }
+        ]
+      });
+
+      const result = await service.resolveGeoLiaisonCatalogAttachment('SUPPORT_IDR_1', 'SUPPORT_ADR_1', 4);
+      expect(result?.support_name).toBe('SUPPORT_ADR_1');
+    });
+
+    it('returns undefined when a matching set exists but geometry is incomplete', async () => {
+      mockTable.get.mockResolvedValue({
+        uuid: 'g',
+        created_at: 'c',
+        updated_at: 'u',
+        support_name: 'SUPPORT_IDR_1',
+        support_tower: 'T',
+        attachments: [
+          {
+            attachment_set: 4,
+            cross_arm_length: 3.2,
+            attachment_altitude: 20,
+            attachment_set_x: 1,
+            attachment_set_y: 2,
+            attachment_set_z: undefined
+          }
+        ]
+      });
+
+      const result = await service.resolveGeoLiaisonCatalogAttachment('SUPPORT_IDR_1', null, 4);
+      expect(result).toBeUndefined();
+    });
+
+    it('accepts zero values as complete geometry', async () => {
+      mockTable.get.mockResolvedValue({
+        uuid: 'g',
+        created_at: 'c',
+        updated_at: 'u',
+        support_name: 'SUPPORT_IDR_1',
+        support_tower: 'T',
+        attachments: [
+          {
+            attachment_set: 0,
+            cross_arm_length: 0,
+            attachment_altitude: 0,
+            attachment_set_x: 0,
+            attachment_set_y: 0,
+            attachment_set_z: 0
+          }
+        ]
+      });
+
+      const result = await service.resolveGeoLiaisonCatalogAttachment('SUPPORT_IDR_1', null, 0);
+      expect(result).toBeDefined();
+      expect(result?.attachment_set).toBe(0);
+    });
+  });
+
   describe('getDerivedSupportFields', () => {
     it('maps the matching attachment to tower, arm length and height, truncating arm length to one decimal', async () => {
       mockTable.get.mockResolvedValue({
@@ -320,6 +416,32 @@ describe('AttachmentService', () => {
       const result = await service.getDerivedSupportFieldsBySet('missing');
 
       expect(result.size).toBe(0);
+    });
+  });
+
+  describe('getCompleteAttachmentSetsBySupportName', () => {
+    it('returns only complete attachment sets for the support', async () => {
+      mockTable.get.mockResolvedValue({
+        uuid: 'g',
+        created_at: 'c',
+        updated_at: 'u',
+        support_name: 'S1',
+        support_tower: 'T1',
+        attachments: [
+          { attachment_set: 3, cross_arm_length: 1, attachment_set_x: 1, attachment_set_y: 1, attachment_set_z: 1 },
+          {
+            attachment_set: 2,
+            cross_arm_length: 1,
+            attachment_set_x: 1,
+            attachment_set_y: 1,
+            attachment_set_z: undefined
+          },
+          { attachment_set: 1, cross_arm_length: 0, attachment_set_x: 0, attachment_set_y: 0, attachment_set_z: 0 }
+        ]
+      });
+
+      const result = await service.getCompleteAttachmentSetsBySupportName('S1');
+      expect(result).toEqual([1, 3]);
     });
   });
 

--- a/src/app/shared/catalog/services/attachment.service.ts
+++ b/src/app/shared/catalog/services/attachment.service.ts
@@ -126,6 +126,46 @@ export class AttachmentService {
   }
 
   /**
+   * Resolves a GeoLiaison support/set lookup against the catalog, trying SUPPORT_IDR first
+   * and SUPPORT_ADR as fallback. Returns only complete L/X/Y/Z entries.
+   */
+  async resolveGeoLiaisonCatalogAttachment(
+    supportIdr: string | null | undefined,
+    supportAdr: string | null | undefined,
+    attachmentSet: number | null | undefined
+  ): Promise<CatalogAttachmentEntity | undefined> {
+    if (attachmentSet == null) {
+      return undefined;
+    }
+
+    const candidates = [...new Set([supportIdr?.trim(), supportAdr?.trim()].filter((name): name is string => !!name))];
+
+    for (const candidate of candidates) {
+      const details = await this.getAttachmentDetails(candidate, attachmentSet);
+      if (details && this.hasCompleteAttachmentGeometry(details)) {
+        return details;
+      }
+    }
+
+    return undefined;
+  }
+
+  /**
+   * Returns the attachment-set numbers with complete L/X/Y/Z data for the given support.
+   */
+  async getCompleteAttachmentSetsBySupportName(supportName: string): Promise<number[]> {
+    const group = await this.storageService.db?.catSupportAttachments.get(supportName);
+    if (!group) {
+      return [];
+    }
+
+    return group.attachments
+      .filter((item) => this.hasCompleteAttachmentSetGeometry(item))
+      .map((item) => item.attachment_set)
+      .sort((a, b) => a - b);
+  }
+
+  /**
    * Resolve the support fields derived from a catalog attachment for a
    * (support name, attachment set) pair.
    *
@@ -202,6 +242,24 @@ export class AttachmentService {
       armLength: details.cross_arm_length == null ? null : truncateNumberToOneDecimal(details.cross_arm_length),
       heightBelowConsole: details.attachment_altitude ?? null
     };
+  }
+
+  private hasCompleteAttachmentGeometry(details: CatalogAttachmentEntity): boolean {
+    return (
+      details.cross_arm_length != null &&
+      details.attachment_set_x != null &&
+      details.attachment_set_y != null &&
+      details.attachment_set_z != null
+    );
+  }
+
+  private hasCompleteAttachmentSetGeometry(item: CatalogSupportAttachmentEntity['attachments'][number]): boolean {
+    return (
+      item.cross_arm_length != null &&
+      item.attachment_set_x != null &&
+      item.attachment_set_y != null &&
+      item.attachment_set_z != null
+    );
   }
 
   /**


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
<!-- please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes -->
- [X] Tests for the changes have been added (for bug fixes / features)

[917](https://github.com/phlowers/phlowers-stellar-app/issues/917)


The "eye" icon is disabled if the media name and attachment set do not appear in the catalog; I found an old User Story confirming exactly this point.

https://gopro-collaboratif.rte-france.com/spaces/CLS/pages/551161184/SIG.030+Impossible+de+saisir+librement+un+nom+de+support+du+Canton