### PR TITLE
Fix 2D POV retain when selecting an obstacle point or its distance

### DIFF
--- a/src/app/shared/components/studio/section/helpers/createPlot.spec.ts
+++ b/src/app/shared/components/studio/section/helpers/createPlot.spec.ts
@@ -557,6 +557,20 @@ describe('createPlot', () => {
     });
   });
 
+  describe('config identity across renders', () => {
+    it('should pass the exact same config object to consecutive Plotly.react calls', () => {
+      // Plotly.react diffs the config: a new object (fresh button closures) on each call
+      // registers as a config change and downgrades the react into a full re-plot,
+      // wiping the 2D zoom/pan state that uirevision would preserve (bug #1032).
+      createPlot({ ...createDefaultParams(), view: '2d' });
+      createPlot({ ...createDefaultParams(), view: '2d', currentObstacleUuid: 'obstacle-1' });
+
+      const firstConfig = (Plotly.react as Mock).mock.calls[0][3];
+      const secondConfig = (Plotly.react as Mock).mock.calls[1][3];
+      expect(secondConfig).toBe(firstConfig);
+    });
+  });
+
   describe('modebar camera reset buttons removal', () => {
     it.each(['resetCameraDefault3d', 'resetCameraLastSave3d', 'resetScale2d', 'zoom3d', 'pan3d'])(
       'should include %s in modeBarButtonsToRemove',

--- a/src/app/shared/components/studio/section/helpers/createPlot.spec.ts
+++ b/src/app/shared/components/studio/section/helpers/createPlot.spec.ts
@@ -11,6 +11,7 @@ import { SpanLoad } from '@shared/domain';
 import { GetSectionOutput } from '@core/services/worker_python/tasks/types';
 import { DataObject } from './createPlotDataObject';
 import { type Mock } from 'vitest';
+import { TranslocoService } from '@jsverse/transloco';
 
 // Mock Plotly
 vi.mock('plotly.js-dist-min', () => ({
@@ -568,6 +569,29 @@ describe('createPlot', () => {
       const firstConfig = (Plotly.react as Mock).mock.calls[0][3];
       const secondConfig = (Plotly.react as Mock).mock.calls[1][3];
       expect(secondConfig).toBe(firstConfig);
+    });
+
+    it('should rebuild the config with the new button titles when the active language changes', () => {
+      const enTranslations: Record<string, string> = { 'shared.studio.orbital-rotation': 'Orbital rotation' };
+      const frTranslations: Record<string, string> = { 'shared.studio.orbital-rotation': 'Rotation orbitale' };
+      const enTransloco = {
+        translate: (key: string) => enTranslations[key] ?? key
+      } as unknown as TranslocoService;
+      const frTransloco = {
+        translate: (key: string) => frTranslations[key] ?? key
+      } as unknown as TranslocoService;
+
+      createPlot({ ...createDefaultParams(), view: '2d', translocoService: enTransloco });
+      createPlot({ ...createDefaultParams(), view: '2d', translocoService: frTransloco });
+
+      const firstConfig = (Plotly.react as Mock).mock.calls[0][3];
+      const secondConfig = (Plotly.react as Mock).mock.calls[1][3];
+
+      expect(secondConfig).not.toBe(firstConfig);
+      const orbitButton = (secondConfig.modeBarButtonsToAdd as { name: string; title: string }[]).find(
+        (btn) => btn.name === 'customOrbitRotation'
+      );
+      expect(orbitButton?.title).toBe('Rotation orbitale');
     });
   });
 

--- a/src/app/shared/components/studio/section/helpers/createPlot.ts
+++ b/src/app/shared/components/studio/section/helpers/createPlot.ts
@@ -151,6 +151,16 @@ const createScene = (
   };
 };
 
+const BUTTON_TITLE_TRANSLATIONS = [
+  { key: 'shared.studio.orbital-rotation', fallback: 'Orbital rotation' },
+  { key: 'shared.studio.turntable-rotation', fallback: 'Turntable rotation' },
+  { key: 'shared.studio.zoom', fallback: 'Zoom' },
+  { key: 'shared.studio.pan', fallback: 'Pan' }
+] as const;
+
+const translateButtonTitles = (translocoService?: TranslocoService): string[] =>
+  BUTTON_TITLE_TRANSLATIONS.map(({ key, fallback }) => (translocoService ? translocoService.translate(key) : fallback));
+
 /**
  * Builds the Plotly config including custom orbit/turntable/zoom/pan modebar buttons.
  * Defined as a function so that `Plotly.Icons` is accessed at call-time
@@ -161,9 +171,14 @@ const createScene = (
  * which triggers `updateFx()` and resets the 3D camera (POV, angle, zoom) — bug #703.
  * The custom replacements use `setDragmodeDirect()` to bypass `relayout` and preserve
  * the camera. Tests in `createPlot.spec.ts` guard against this regression.
+ *
+ * @param titles - Pre-translated button titles (see `translateButtonTitles`), in
+ *   orbit/turntable/zoom/pan order. Translation happens once in `getConfig` so this
+ *   is only invoked — and new button/closure objects only allocated — when the
+ *   titles actually change (bug #1032).
  */
-const buildConfig = (translocoService?: TranslocoService) => {
-  const t = (key: string, fallback: string): string => (translocoService ? translocoService.translate(key) : fallback);
+const buildConfig = (titles: string[]) => {
+  const [orbitTitle, turntableTitle, zoomTitle, panTitle] = titles;
   /**
    * Switches the 3D scene dragmode by directly setting the internal
    * orbit-camera-controller mode. This bypasses Plotly.relayout and its
@@ -196,7 +211,7 @@ const buildConfig = (translocoService?: TranslocoService) => {
 
   const orbitButton: ModeBarButton = {
     name: 'customOrbitRotation',
-    title: t('shared.studio.orbital-rotation', 'Orbital rotation'),
+    title: orbitTitle,
     icon: Plotly.Icons['3d_rotate'] as Icon,
     attr: 'scene.dragmode',
     val: 'orbit',
@@ -207,7 +222,7 @@ const buildConfig = (translocoService?: TranslocoService) => {
 
   const turntableButton: ModeBarButton = {
     name: 'customTurntableRotation',
-    title: t('shared.studio.turntable-rotation', 'Turntable rotation'),
+    title: turntableTitle,
     icon: Plotly.Icons['z-axis'] as Icon,
     attr: 'scene.dragmode',
     val: 'turntable',
@@ -218,7 +233,7 @@ const buildConfig = (translocoService?: TranslocoService) => {
 
   const zoom3dButton: ModeBarButton = {
     name: 'customZoom3d',
-    title: t('shared.studio.zoom', 'Zoom'),
+    title: zoomTitle,
     icon: Plotly.Icons['zoombox'] as Icon,
     attr: 'scene.dragmode',
     val: 'zoom',
@@ -229,7 +244,7 @@ const buildConfig = (translocoService?: TranslocoService) => {
 
   const pan3dButton: ModeBarButton = {
     name: 'customPan3d',
-    title: t('shared.studio.pan', 'Pan'),
+    title: panTitle,
     icon: Plotly.Icons['pan'] as Icon,
     attr: 'scene.dragmode',
     val: 'pan',
@@ -275,10 +290,10 @@ const buildConfig = (translocoService?: TranslocoService) => {
  */
 let cachedConfig: { key: string; config: ReturnType<typeof buildConfig> } | null = null;
 const getConfig = (translocoService?: TranslocoService) => {
-  const config = buildConfig(translocoService);
-  const key = config.modeBarButtonsToAdd.map((button) => button.title).join('|');
+  const titles = translateButtonTitles(translocoService);
+  const key = titles.join('|');
   if (cachedConfig?.key !== key) {
-    cachedConfig = { key, config };
+    cachedConfig = { key, config: buildConfig(titles) };
   }
   return cachedConfig.config;
 };

--- a/src/app/shared/components/studio/section/helpers/createPlot.ts
+++ b/src/app/shared/components/studio/section/helpers/createPlot.ts
@@ -162,7 +162,7 @@ const createScene = (
  * The custom replacements use `setDragmodeDirect()` to bypass `relayout` and preserve
  * the camera. Tests in `createPlot.spec.ts` guard against this regression.
  */
-const getConfig = (translocoService?: TranslocoService) => {
+const buildConfig = (translocoService?: TranslocoService) => {
   const t = (key: string, fallback: string): string => (translocoService ? translocoService.translate(key) : fallback);
   /**
    * Switches the 3D scene dragmode by directly setting the internal
@@ -261,6 +261,26 @@ const getConfig = (translocoService?: TranslocoService) => {
     ] as ModeBarDefaultButtons[],
     modeBarButtonsToAdd: [orbitButton, turntableButton, zoom3dButton, pan3dButton]
   };
+};
+
+/**
+ * Returns the Plotly config, reusing the same object across calls.
+ *
+ * `Plotly.react` diffs the config on every call: handing it a freshly built object
+ * (new button objects, new click closures) makes that diff report a change each time,
+ * which downgrades the react into a full re-plot and wipes all interactive GUI state —
+ * in particular the 2D zoom/pan ranges that `uirevision` would otherwise preserve
+ * (bug #1032). The config is therefore memoized on the translated button titles: the
+ * exact same object is returned until the active language actually changes them.
+ */
+let cachedConfig: { key: string; config: ReturnType<typeof buildConfig> } | null = null;
+const getConfig = (translocoService?: TranslocoService) => {
+  const config = buildConfig(translocoService);
+  const key = config.modeBarButtonsToAdd.map((button) => button.title).join('|');
+  if (cachedConfig?.key !== key) {
+    cachedConfig = { key, config };
+  }
+  return cachedConfig.config;
 };
 
 const layout3d = (


### PR DESCRIPTION
createPlot.ts:266-285 — renamed the builder to buildConfig and made getConfig memorize it, returning the exact same object across calls. The cache is keyed on the translated button titles, so a language switch still produces a fresh config (one legitimate full replot) while normal refreshes keep object identity.

**Please check if the PR fulfills these requirements**
<!-- please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes -->
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**Does this PR already have an issue describing the problem?**
Complementary PR for #1032 