### PR TITLE
fix(auth, startup, sw): resolve blank-page-on-refresh and OIDC session lockout incidents

### DIFF
--- a/public/i18n/en.json
+++ b/public/i18n/en.json
@@ -188,6 +188,7 @@
       "install-success-detail": "The application has been installed",
       "update-failed-summary": "Update failed",
       "update-failed-detail": "An unknown error occurred during the update",
+      "update-failed-auth-detail": "The update could not be downloaded because your session has expired. Please sign in again, then retry the update",
       "version-checked-detail": "App version checked"
     },
     "obstacle-form-service": {

--- a/public/i18n/fr.json
+++ b/public/i18n/fr.json
@@ -188,6 +188,7 @@
       "install-success-detail": "L'application a été installée",
       "update-failed-summary": "Échec de la mise à jour",
       "update-failed-detail": "Une erreur inconnue s'est produite lors de la mise à jour",
+      "update-failed-auth-detail": "La mise à jour n'a pas pu être téléchargée car votre session a expiré. Veuillez vous reconnecter, puis relancer la mise à jour",
       "version-checked-detail": "Version de l'application vérifiée"
     },
     "obstacle-form-service": {

--- a/src/app/core/config/app-config.service.spec.ts
+++ b/src/app/core/config/app-config.service.spec.ts
@@ -52,4 +52,20 @@ describe('AppConfigService', () => {
 
     await expect(promise).resolves.toBe('fr');
   });
+
+  it('should fall back to "fr" when the request hangs beyond the timeout', async () => {
+    vi.useFakeTimers();
+    try {
+      const promise = service.loadDefaultLang();
+
+      // Request stays pending: only the internal timeout can resolve the promise.
+      httpMock.expectOne('assets/config/app-config.json');
+      await vi.advanceTimersByTimeAsync(3000);
+
+      await expect(promise).resolves.toBe('fr');
+      expect(mockLoggerService.warn).toHaveBeenCalled();
+    } finally {
+      vi.useRealTimers();
+    }
+  });
 });

--- a/src/app/core/config/app-config.service.ts
+++ b/src/app/core/config/app-config.service.ts
@@ -1,11 +1,16 @@
 import { HttpClient } from '@angular/common/http';
 import { inject, Injectable } from '@angular/core';
-import { firstValueFrom } from 'rxjs';
+import { firstValueFrom, timeout } from 'rxjs';
 import { LoggerService } from '@services/logger/logger.service';
 import { AppConfig } from './app-config.interfaces';
 
 const APP_CONFIG_URL = 'assets/config/app-config.json';
 const FALLBACK_LANG = 'fr';
+// Awaited by the APP_INITIALIZER (blocking initial navigation): must be
+// bounded or a hung request blanks the whole first render (incident
+// 2026-08-10). Short on purpose — the fallback language is harmless and the
+// file is served publicly (no OIDC) so it normally answers instantly.
+const LOAD_TIMEOUT_MS = 3000;
 
 /**
  * Loads runtime application configuration from `assets/config/app-config.json`,
@@ -23,7 +28,9 @@ export class AppConfigService {
   /** Resolves the default language to activate at startup. */
   async loadDefaultLang(): Promise<string> {
     try {
-      const config = await firstValueFrom(this.http.get<AppConfig>(APP_CONFIG_URL));
+      const config = await firstValueFrom(
+        this.http.get<AppConfig>(APP_CONFIG_URL).pipe(timeout({ first: LOAD_TIMEOUT_MS }))
+      );
       return config?.defaultLang ?? FALLBACK_LANG;
     } catch (error) {
       this.logger.warn('Failed to load app-config.json, falling back to default language', error);

--- a/src/app/core/services/worker_update/service-worker.spec.ts
+++ b/src/app/core/services/worker_update/service-worker.spec.ts
@@ -48,6 +48,9 @@ global.Response = class MockResponse {
   static error() {
     return new MockResponse('Error', { status: 500 });
   }
+  static redirect(url: string, status = 302) {
+    return new MockResponse(null, { status, url, redirected: true });
+  }
 } as unknown as typeof Response;
 global.console = {
   ...console,
@@ -99,7 +102,10 @@ describe('Service Worker Functions', () => {
         })
       );
       for (const file of mockManifest.files) {
-        expect(mockFetch).toHaveBeenCalledWith(file, { cache: 'no-store' });
+        expect(mockFetch).toHaveBeenCalledWith(
+          file,
+          expect.objectContaining({ cache: 'no-store', signal: expect.any(AbortSignal) })
+        );
         expect(mockCache.put).toHaveBeenCalledWith(file, expect.objectContaining({ ok: true }));
       }
       expect(mockCache.put).toHaveBeenCalledWith(
@@ -164,6 +170,36 @@ describe('Service Worker Functions', () => {
       });
 
       await expect(installApp()).rejects.toThrow(/Precache failed for .+: HTTP 502/);
+    });
+
+    it('should not write a still in-flight file to the cache once another file already failed', async () => {
+      let resolveStylesFetch!: (value: { ok: boolean; status: number }) => void;
+      const stylesFetch = new Promise<{ ok: boolean; status: number }>((resolve) => {
+        resolveStylesFetch = resolve;
+      });
+
+      mockFetch.mockImplementation((url: string) => {
+        if (url === '/assets_list.json') {
+          return Promise.resolve({ ok: true, json: vi.fn().mockResolvedValue(mockManifest) });
+        }
+        if (url === '/app.js') {
+          return Promise.resolve({ ok: false, status: 502 });
+        }
+        if (url === '/styles.css') {
+          // Still in flight when /app.js fails.
+          return stylesFetch;
+        }
+        return Promise.resolve({ ok: true, status: 200 });
+      });
+
+      await expect(installApp()).rejects.toThrow('Precache failed for /app.js: HTTP 502');
+
+      // Resolve the slow fetch only after installApp() has already rejected.
+      resolveStylesFetch({ ok: true, status: 200 });
+      await Promise.resolve();
+      await Promise.resolve();
+
+      expect(mockCache.put).not.toHaveBeenCalledWith('/styles.css', expect.anything());
     });
 
     it.each([
@@ -488,6 +524,30 @@ describe('Service Worker Functions', () => {
       const response = await mockEvent.respondWith.mock.calls[0][0];
 
       expect(response).toBe(errorResponse);
+    });
+
+    it('should force reauth via /auth/relogin when a bare 401 has no cached shell', async () => {
+      mockFetch.mockResolvedValue({ ok: false, status: 401 });
+      mockCache.match.mockResolvedValue(undefined);
+
+      await handleFetch(mockEvent as unknown as FetchEvent);
+
+      const response = (await mockEvent.respondWith.mock.calls[0][0]) as Response & { url: string };
+
+      expect(response.status).toBe(302);
+      expect(response.url).toBe('https://example.com/auth/relogin');
+    });
+
+    it('should force reauth via /auth/relogin when a bare 403 has no cached shell', async () => {
+      mockFetch.mockResolvedValue({ ok: false, status: 403 });
+      mockCache.match.mockResolvedValue(undefined);
+
+      await handleFetch(mockEvent as unknown as FetchEvent);
+
+      const response = (await mockEvent.respondWith.mock.calls[0][0]) as Response & { url: string };
+
+      expect(response.status).toBe(302);
+      expect(response.url).toBe('https://example.com/auth/relogin');
     });
   });
 

--- a/src/app/core/services/worker_update/service-worker.spec.ts
+++ b/src/app/core/services/worker_update/service-worker.spec.ts
@@ -165,6 +165,24 @@ describe('Service Worker Functions', () => {
 
       await expect(installApp()).rejects.toThrow(/Precache failed for .+: HTTP 502/);
     });
+
+    it.each([
+      ['//evil.com/payload.js', 'protocol-relative URL'],
+      ['https://evil.com/payload.js', 'absolute cross-origin URL'],
+      ['/\\evil.com/payload.js', 'backslash trick'],
+      ['app.js', 'non-root-relative path']
+    ])('should reject a manifest file that is a %s (%s) without ever fetching it', async (file) => {
+      const maliciousManifest = { files: [file], app_version: '1.0.0' };
+      mockFetch.mockImplementation((url: string) => {
+        if (url === '/assets_list.json') {
+          return Promise.resolve({ ok: true, json: vi.fn().mockResolvedValue(maliciousManifest) });
+        }
+        return Promise.resolve({ ok: true, status: 200 });
+      });
+
+      await expect(installApp()).rejects.toThrow(/invalid or cross-origin asset path/);
+      expect(mockFetch).not.toHaveBeenCalledWith(file, expect.anything());
+    });
   });
 
   describe('updateApp', () => {

--- a/src/app/core/services/worker_update/service-worker.spec.ts
+++ b/src/app/core/services/worker_update/service-worker.spec.ts
@@ -341,44 +341,54 @@ describe('Service Worker Functions', () => {
       };
     });
 
-    it('should bypass /auth/userinfo completely (no cache access)', async () => {
+    it('should bypass /auth/userinfo completely (no respondWith, no cache access)', async () => {
       mockEvent.request.url = 'https://example.com/auth/userinfo';
-      mockFetch.mockResolvedValue({ ok: true, status: 200 });
 
       await handleFetch(mockEvent as unknown as FetchEvent);
 
-      expect(mockEvent.respondWith).toHaveBeenCalled();
-      // Cache must not be accessed for bypass routes
+      // Plain return: the browser must handle the request natively.
+      expect(mockEvent.respondWith).not.toHaveBeenCalled();
+      expect(mockFetch).not.toHaveBeenCalled();
       expect(mockCaches.open).not.toHaveBeenCalled();
     });
 
     it('should bypass /auth/callback completely', async () => {
       mockEvent.request.url = 'https://example.com/auth/callback';
-      mockFetch.mockResolvedValue({ ok: true, status: 200 });
 
       await handleFetch(mockEvent as unknown as FetchEvent);
 
-      expect(mockEvent.respondWith).toHaveBeenCalled();
+      expect(mockEvent.respondWith).not.toHaveBeenCalled();
+      expect(mockFetch).not.toHaveBeenCalled();
       expect(mockCaches.open).not.toHaveBeenCalled();
     });
 
-    it('should bypass /assets_list.json completely (no cache access)', async () => {
+    it('should bypass /auth/relogin completely (native browser handling of the redirect chain)', async () => {
+      mockEvent.request.url = 'https://example.com/auth/relogin';
+
+      await handleFetch(mockEvent as unknown as FetchEvent);
+
+      expect(mockEvent.respondWith).not.toHaveBeenCalled();
+      expect(mockFetch).not.toHaveBeenCalled();
+      expect(mockCaches.open).not.toHaveBeenCalled();
+    });
+
+    it('should bypass /assets_list.json completely (no respondWith, no cache access)', async () => {
       mockEvent.request.url = 'https://example.com/assets_list.json';
-      mockFetch.mockResolvedValue({ ok: true, status: 200 });
 
       await handleFetch(mockEvent as unknown as FetchEvent);
 
-      expect(mockEvent.respondWith).toHaveBeenCalled();
+      expect(mockEvent.respondWith).not.toHaveBeenCalled();
+      expect(mockFetch).not.toHaveBeenCalled();
       expect(mockCaches.open).not.toHaveBeenCalled();
     });
 
-    it('should bypass /version.json completely (no cache access)', async () => {
+    it('should bypass /version.json completely (no respondWith, no cache access)', async () => {
       mockEvent.request.url = 'https://example.com/version.json';
-      mockFetch.mockResolvedValue({ ok: true, status: 200 });
 
       await handleFetch(mockEvent as unknown as FetchEvent);
 
-      expect(mockEvent.respondWith).toHaveBeenCalled();
+      expect(mockEvent.respondWith).not.toHaveBeenCalled();
+      expect(mockFetch).not.toHaveBeenCalled();
       expect(mockCaches.open).not.toHaveBeenCalled();
     });
   });

--- a/src/app/core/services/worker_update/service-worker.spec.ts
+++ b/src/app/core/services/worker_update/service-worker.spec.ts
@@ -609,7 +609,9 @@ describe('Service Worker Functions', () => {
         clonedRequest,
         expect.objectContaining({
           method: 'GET',
-          headers: expect.any(Object)
+          headers: expect.any(Object),
+          // Cache-miss fallback must be bounded (fetchWithTimeout).
+          signal: expect.any(AbortSignal)
         })
       );
       expect(mockEvent.respondWith).toHaveBeenCalled();

--- a/src/app/core/services/worker_update/service-worker.spec.ts
+++ b/src/app/core/services/worker_update/service-worker.spec.ts
@@ -66,7 +66,6 @@ describe('Service Worker Functions', () => {
     vi.clearAllMocks();
     mockCaches.open.mockResolvedValue(mockCache);
     mockCaches.delete.mockResolvedValue(true);
-    mockCache.addAll.mockResolvedValue(undefined);
     mockCache.keys.mockResolvedValue([]);
     (global.caches.match as vi.Mock).mockResolvedValue(null);
   });
@@ -78,9 +77,11 @@ describe('Service Worker Functions', () => {
     };
 
     beforeEach(() => {
-      mockFetch.mockResolvedValue({
-        ok: true,
-        json: vi.fn().mockResolvedValue(mockManifest)
+      mockFetch.mockImplementation((url: string) => {
+        if (url === '/assets_list.json') {
+          return Promise.resolve({ ok: true, json: vi.fn().mockResolvedValue(mockManifest) });
+        }
+        return Promise.resolve({ ok: true, status: 200 });
       });
     });
 
@@ -97,7 +98,10 @@ describe('Service Worker Functions', () => {
           })
         })
       );
-      expect(mockCache.addAll).toHaveBeenCalledWith(mockManifest.files);
+      for (const file of mockManifest.files) {
+        expect(mockFetch).toHaveBeenCalledWith(file, { cache: 'no-store' });
+        expect(mockCache.put).toHaveBeenCalledWith(file, expect.objectContaining({ ok: true }));
+      }
       expect(mockCache.put).toHaveBeenCalledWith(
         '/app_version',
         expect.objectContaining({
@@ -124,7 +128,8 @@ describe('Service Worker Functions', () => {
 
       await installApp();
 
-      expect(mockCache.addAll).toHaveBeenCalledWith([]);
+      // Only the manifest itself was fetched — no per-file fetch for an empty list.
+      expect(mockFetch).toHaveBeenCalledTimes(1);
     });
 
     it('should handle fetch manifest errors', async () => {
@@ -133,10 +138,32 @@ describe('Service Worker Functions', () => {
       await expect(installApp()).rejects.toThrow('Network error');
     });
 
-    it('should handle cache operations errors', async () => {
-      mockCache.addAll.mockRejectedValue(new Error('Cache add failed'));
+    it('should abort install when a single file fails to precache (e.g. 502 during a rolling redeploy)', async () => {
+      mockFetch.mockImplementation((url: string) => {
+        if (url === '/assets_list.json') {
+          return Promise.resolve({ ok: true, json: vi.fn().mockResolvedValue(mockManifest) });
+        }
+        if (url === '/app.js') {
+          return Promise.resolve({ ok: false, status: 502 });
+        }
+        return Promise.resolve({ ok: true, status: 200 });
+      });
 
-      await expect(installApp()).rejects.toThrow('Cache add failed');
+      await expect(installApp()).rejects.toThrow('Precache failed for /app.js: HTTP 502');
+
+      // A failed install must never mark itself as done.
+      expect(mockCache.put).not.toHaveBeenCalledWith('/app_version', expect.anything());
+    });
+
+    it('should throw identifying the file when every file fails to precache', async () => {
+      mockFetch.mockImplementation((url: string) => {
+        if (url === '/assets_list.json') {
+          return Promise.resolve({ ok: true, json: vi.fn().mockResolvedValue(mockManifest) });
+        }
+        return Promise.resolve({ ok: false, status: 502 });
+      });
+
+      await expect(installApp()).rejects.toThrow(/Precache failed for .+: HTTP 502/);
     });
   });
 
@@ -147,9 +174,11 @@ describe('Service Worker Functions', () => {
     };
 
     beforeEach(() => {
-      mockFetch.mockResolvedValue({
-        ok: true,
-        json: vi.fn().mockResolvedValue(mockManifest)
+      mockFetch.mockImplementation((url: string) => {
+        if (url === '/assets_list.json') {
+          return Promise.resolve({ ok: true, json: vi.fn().mockResolvedValue(mockManifest) });
+        }
+        return Promise.resolve({ ok: true, status: 200 });
       });
     });
 
@@ -159,9 +188,11 @@ describe('Service Worker Functions', () => {
       expect(result).toEqual(mockManifest);
       // Must delete the entire cache first
       expect(mockCaches.delete).toHaveBeenCalledWith('app-assets');
-      // Then reopen and addAll
+      // Then reopen and cache each file individually
       expect(mockCaches.open).toHaveBeenCalledWith('app-assets');
-      expect(mockCache.addAll).toHaveBeenCalledWith(mockManifest.files);
+      for (const file of mockManifest.files) {
+        expect(mockCache.put).toHaveBeenCalledWith(file, expect.objectContaining({ ok: true }));
+      }
       // Store new version
       expect(mockCache.put).toHaveBeenCalledWith(
         '/app_version',
@@ -176,15 +207,19 @@ describe('Service Worker Functions', () => {
         files: ['/index.html', '/pyodide/numpy.whl', '/pyodide/pandas.whl'],
         app_version: '1.1.0'
       };
-      mockFetch.mockResolvedValue({
-        ok: true,
-        json: vi.fn().mockResolvedValue(manifestWithWheels)
+      mockFetch.mockImplementation((url: string) => {
+        if (url === '/assets_list.json') {
+          return Promise.resolve({ ok: true, json: vi.fn().mockResolvedValue(manifestWithWheels) });
+        }
+        return Promise.resolve({ ok: true, status: 200 });
       });
 
       await updateApp();
 
-      // All files including .whl should be in addAll (full reset)
-      expect(mockCache.addAll).toHaveBeenCalledWith(manifestWithWheels.files);
+      // All files including .whl should be individually re-fetched and cached (full reset)
+      for (const file of manifestWithWheels.files) {
+        expect(mockCache.put).toHaveBeenCalledWith(file, expect.objectContaining({ ok: true }));
+      }
     });
 
     it('should handle empty files array', async () => {
@@ -198,7 +233,8 @@ describe('Service Worker Functions', () => {
 
       expect(result).toEqual(emptyManifest);
       expect(mockCaches.delete).toHaveBeenCalledWith('app-assets');
-      expect(mockCache.addAll).toHaveBeenCalledWith([]);
+      // Only the manifest itself was fetched — no per-file fetch for an empty list.
+      expect(mockFetch).toHaveBeenCalledTimes(1);
     });
 
     it('should handle fetch manifest errors', async () => {
@@ -214,6 +250,24 @@ describe('Service Worker Functions', () => {
       });
 
       await expect(updateApp()).rejects.toThrow('Manifest fetch failed with status 500');
+    });
+
+    it('should abort the update and roll back the temp cache when a single file fails to precache', async () => {
+      mockFetch.mockImplementation((url: string) => {
+        if (url === '/assets_list.json') {
+          return Promise.resolve({ ok: true, json: vi.fn().mockResolvedValue(mockManifest) });
+        }
+        if (url === '/app.js') {
+          return Promise.resolve({ ok: false, status: 502 });
+        }
+        return Promise.resolve({ ok: true, status: 200 });
+      });
+
+      await expect(updateApp()).rejects.toThrow('Precache failed for /app.js: HTTP 502');
+
+      // The temp cache is cleaned up but the live cache must never be touched.
+      expect(mockCaches.delete).toHaveBeenCalledWith('app-assets-tmp');
+      expect(mockCaches.delete).not.toHaveBeenCalledWith('app-assets');
     });
   });
 

--- a/src/app/core/services/worker_update/service-worker.ts
+++ b/src/app/core/services/worker_update/service-worker.ts
@@ -65,26 +65,6 @@ function isAuthErrorResponse(response: Response | undefined): response is Respon
 }
 
 /**
- * Validates a manifest-provided path is same-origin/root-relative and returns
- * its canonical form re-derived from the parsed `URL`, or `null` if invalid.
- * `assets_list.json` is untrusted network data — a poisoned/compromised
- * response must not be able to make the SW fetch/cache cross-origin resources
- * (client-side request forgery), so callers must use the returned value —
- * never the raw `file` argument — to build the actual request.
- */
-function resolveAssetPath(file: string): string | null {
-  if (!file.startsWith('/') || file.startsWith('//')) {
-    return null;
-  }
-  try {
-    const url = new URL(file, self.location.origin);
-    return url.origin === self.location.origin ? url.pathname + url.search : null;
-  } catch {
-    return null;
-  }
-}
-
-/**
  * Fetches and caches each file individually. Any single failure (e.g. a 502
  * during a rolling redeploy) aborts the whole install/update — missing or
  * broken assets must never be silently skipped. Compared to `Cache.addAll()`

--- a/src/app/core/services/worker_update/service-worker.ts
+++ b/src/app/core/services/worker_update/service-worker.ts
@@ -65,26 +65,6 @@ function isAuthErrorResponse(response: Response | undefined): response is Respon
 }
 
 /**
- * Validates a manifest-provided path is same-origin/root-relative and returns
- * its canonical form re-derived from the parsed `URL`, or `null` if invalid.
- * `assets_list.json` is untrusted network data — a poisoned/compromised
- * response must not be able to make the SW fetch/cache cross-origin resources
- * (client-side request forgery), so callers must use the returned value —
- * never the raw `file` argument — to build the actual request.
- */
-function resolveAssetPath(file: string): string | null {
-  if (!file.startsWith('/') || file.startsWith('//')) {
-    return null;
-  }
-  try {
-    const url = new URL(file, self.location.origin);
-    return url.origin === self.location.origin ? url.pathname + url.search : null;
-  } catch {
-    return null;
-  }
-}
-
-/**
  * Fetches and caches each file individually. Any single failure (e.g. a 502
  * during a rolling redeploy) aborts the whole install/update — missing or
  * broken assets must never be silently skipped. Compared to `Cache.addAll()`
@@ -105,7 +85,22 @@ async function cacheFiles(cache: Cache, files: string[]): Promise<void> {
 
   await Promise.all(
     files.map(async (file) => {
-      const assetPath = resolveAssetPath(file);
+      // Validated inline, in the same function that performs the fetch below:
+      // `assets_list.json` is untrusted network data, so a poisoned/compromised
+      // response must not be able to make the SW request/cache a cross-origin
+      // resource (client-side request forgery). `assetPath` — never the raw
+      // `file` argument — is what is passed to `fetch()`/`cache.put()`.
+      let assetPath = '';
+      if (file.startsWith('/') && !file.startsWith('//')) {
+        try {
+          const url = new URL(file, self.location.origin);
+          if (url.origin === self.location.origin) {
+            assetPath = url.pathname + url.search;
+          }
+        } catch {
+          assetPath = '';
+        }
+      }
       if (!assetPath) {
         controller.abort();
         throw new Error(`Precache rejected for ${file}: invalid or cross-origin asset path`);

--- a/src/app/core/services/worker_update/service-worker.ts
+++ b/src/app/core/services/worker_update/service-worker.ts
@@ -91,7 +91,7 @@ async function cacheFiles(cache: Cache, files: string[]): Promise<void> {
       // resource (client-side request forgery). `assetPath` — never the raw
       // `file` argument — is what is passed to `fetch()`/`cache.put()`.
       let assetPath = '';
-      if (file.startsWith('/') && !file.startsWith('//')) {
+      if (file.startsWith('/') && !file.startsWith('//') && !file.includes('\\')) {
         try {
           const url = new URL(file, self.location.origin);
           if (url.origin === self.location.origin) {

--- a/src/app/core/services/worker_update/service-worker.ts
+++ b/src/app/core/services/worker_update/service-worker.ts
@@ -65,6 +65,23 @@ function isAuthErrorResponse(response: Response | undefined): response is Respon
 }
 
 /**
+ * Restricts manifest-provided asset paths to same-origin, root-relative paths.
+ * `assets_list.json` is untrusted network data — a poisoned/compromised
+ * response must not be able to make the SW fetch and cache cross-origin
+ * resources (client-side request forgery).
+ */
+function isValidAssetPath(file: string): boolean {
+  if (!file.startsWith('/') || file.startsWith('//')) {
+    return false;
+  }
+  try {
+    return new URL(file, self.location.origin).origin === self.location.origin;
+  } catch {
+    return false;
+  }
+}
+
+/**
  * Fetches and caches each file individually. Any single failure (e.g. a 502
  * during a rolling redeploy) aborts the whole install/update — missing or
  * broken assets must never be silently skipped. Compared to `Cache.addAll()`
@@ -77,6 +94,9 @@ async function cacheFiles(cache: Cache, files: string[]): Promise<void> {
   }
   await Promise.all(
     files.map(async (file) => {
+      if (!isValidAssetPath(file)) {
+        throw new Error(`Precache rejected for ${file}: invalid or cross-origin asset path`);
+      }
       const response = await fetch(file, { cache: 'no-store' });
       if (!response.ok) {
         throw new Error(`Precache failed for ${file}: HTTP ${response.status}`);

--- a/src/app/core/services/worker_update/service-worker.ts
+++ b/src/app/core/services/worker_update/service-worker.ts
@@ -65,19 +65,22 @@ function isAuthErrorResponse(response: Response | undefined): response is Respon
 }
 
 /**
- * Restricts manifest-provided asset paths to same-origin, root-relative paths.
+ * Validates a manifest-provided path is same-origin/root-relative and returns
+ * its canonical form re-derived from the parsed `URL`, or `null` if invalid.
  * `assets_list.json` is untrusted network data — a poisoned/compromised
- * response must not be able to make the SW fetch and cache cross-origin
- * resources (client-side request forgery).
+ * response must not be able to make the SW fetch/cache cross-origin resources
+ * (client-side request forgery), so callers must use the returned value —
+ * never the raw `file` argument — to build the actual request.
  */
-function isValidAssetPath(file: string): boolean {
+function resolveAssetPath(file: string): string | null {
   if (!file.startsWith('/') || file.startsWith('//')) {
-    return false;
+    return null;
   }
   try {
-    return new URL(file, self.location.origin).origin === self.location.origin;
+    const url = new URL(file, self.location.origin);
+    return url.origin === self.location.origin ? url.pathname + url.search : null;
   } catch {
-    return false;
+    return null;
   }
 }
 
@@ -102,13 +105,14 @@ async function cacheFiles(cache: Cache, files: string[]): Promise<void> {
 
   await Promise.all(
     files.map(async (file) => {
-      if (!isValidAssetPath(file)) {
+      const assetPath = resolveAssetPath(file);
+      if (!assetPath) {
         controller.abort();
         throw new Error(`Precache rejected for ${file}: invalid or cross-origin asset path`);
       }
       let response: Response;
       try {
-        response = await fetch(file, { cache: 'no-store', signal: controller.signal });
+        response = await fetch(assetPath, { cache: 'no-store', signal: controller.signal });
       } catch (error) {
         if (controller.signal.aborted) {
           // Aborted because another file already failed; that failure is what fails the precache.
@@ -119,13 +123,13 @@ async function cacheFiles(cache: Cache, files: string[]): Promise<void> {
       }
       if (!response.ok) {
         controller.abort();
-        throw new Error(`Precache failed for ${file}: HTTP ${response.status}`);
+        throw new Error(`Precache failed for ${assetPath}: HTTP ${response.status}`);
       }
       if (controller.signal.aborted) {
         // Another file failed while this fetch was in flight — skip the write.
         return;
       }
-      await cache.put(file, response);
+      await cache.put(assetPath, response);
     })
   );
 }

--- a/src/app/core/services/worker_update/service-worker.ts
+++ b/src/app/core/services/worker_update/service-worker.ts
@@ -354,7 +354,10 @@ export async function handleFetch(event: FetchEvent) {
           return response;
         }
         const fetchRequest = event.request.clone();
-        return fetch(fetchRequest, NO_CACHE_INIT).catch((error) => {
+        // Bounded: an unbounded fetch here can hang behind an OIDC refresh
+        // pile-up on the server (headers-only timeout; body streaming of
+        // large files is unaffected once headers arrive).
+        return fetchWithTimeout(fetchRequest, NO_CACHE_INIT, NAVIGATE_TIMEOUT_MS).catch((error) => {
           console.error('Fetch failed:', error);
           return Response.error();
         });

--- a/src/app/core/services/worker_update/service-worker.ts
+++ b/src/app/core/services/worker_update/service-worker.ts
@@ -87,19 +87,43 @@ function isValidAssetPath(file: string): boolean {
  * broken assets must never be silently skipped. Compared to `Cache.addAll()`
  * (all-or-nothing, throws a generic `Failed to execute 'addAll' on 'Cache'`
  * error), this identifies exactly which file failed and why.
+ *
+ * A shared `AbortController` cancels the other in-flight fetches as soon as
+ * one file fails, and any fetch that resolves afterwards is skipped instead
+ * of being written to `cache` — otherwise `Promise.all` rejecting early
+ * would still let those in-flight operations complete in the background,
+ * leaving the cache partially populated despite the reported failure.
  */
 async function cacheFiles(cache: Cache, files: string[]): Promise<void> {
   if (files.length === 0) {
     return;
   }
+  const controller = new AbortController();
+
   await Promise.all(
     files.map(async (file) => {
       if (!isValidAssetPath(file)) {
+        controller.abort();
         throw new Error(`Precache rejected for ${file}: invalid or cross-origin asset path`);
       }
-      const response = await fetch(file, { cache: 'no-store' });
+      let response: Response;
+      try {
+        response = await fetch(file, { cache: 'no-store', signal: controller.signal });
+      } catch (error) {
+        if (controller.signal.aborted) {
+          // Aborted because another file already failed; that failure is what fails the precache.
+          return;
+        }
+        controller.abort();
+        throw error;
+      }
       if (!response.ok) {
+        controller.abort();
         throw new Error(`Precache failed for ${file}: HTTP ${response.status}`);
+      }
+      if (controller.signal.aborted) {
+        // Another file failed while this fetch was in flight — skip the write.
+        return;
       }
       await cache.put(file, response);
     })

--- a/src/app/core/services/worker_update/service-worker.ts
+++ b/src/app/core/services/worker_update/service-worker.ts
@@ -57,6 +57,36 @@ function isRedirectResponse(response: Response): boolean {
 }
 
 /**
+ * True for a raw 401/403 straight from Apache/mod_auth_openidc (not converted
+ * to a redirect), which must never be shown to the user as-is.
+ */
+function isAuthErrorResponse(response: Response | undefined): response is Response {
+  return !!response && (response.status === 401 || response.status === 403);
+}
+
+/**
+ * Fetches and caches each file individually. Any single failure (e.g. a 502
+ * during a rolling redeploy) aborts the whole install/update — missing or
+ * broken assets must never be silently skipped. Compared to `Cache.addAll()`
+ * (all-or-nothing, throws a generic `Failed to execute 'addAll' on 'Cache'`
+ * error), this identifies exactly which file failed and why.
+ */
+async function cacheFiles(cache: Cache, files: string[]): Promise<void> {
+  if (files.length === 0) {
+    return;
+  }
+  await Promise.all(
+    files.map(async (file) => {
+      const response = await fetch(file, { cache: 'no-store' });
+      if (!response.ok) {
+        throw new Error(`Precache failed for ${file}: HTTP ${response.status}`);
+      }
+      await cache.put(file, response);
+    })
+  );
+}
+
+/**
  * Performs a full application installation by fetching the asset
  * manifest, caching all listed files, and storing the build version.
  * Notifies all controlled clients upon completion.
@@ -71,7 +101,7 @@ export async function installApp() {
   const filesToInstall = manifest.files || [];
   const buildVersion = manifest.app_version;
   const cache = await caches.open(CACHE_NAME);
-  await cache.addAll(filesToInstall);
+  await cacheFiles(cache, filesToInstall);
   await cache.put(
     APP_VERSION_CACHE_KEY,
     new Response(JSON.stringify(buildVersion), {
@@ -105,7 +135,7 @@ export async function updateApp() {
   try {
     await caches.delete(TEMP_CACHE_NAME);
     const tempCache = await caches.open(TEMP_CACHE_NAME);
-    await tempCache.addAll(files);
+    await cacheFiles(tempCache, files);
 
     const appVersion = manifest.app_version;
     await tempCache.put(
@@ -214,7 +244,15 @@ export async function handleFetch(event: FetchEvent) {
           }
           // 401/403/5xx (or any other non-ok): serve the cached shell if present.
           const cachedShell = await cache.match(indexUrl);
-          return cachedShell ?? networkResponse ?? Response.error();
+          if (cachedShell) {
+            return cachedShell;
+          }
+          // No cached shell (e.g. right after clearing site data): force reauth
+          // via /auth/relogin instead of leaking Apache's raw 401/403 body.
+          if (isAuthErrorResponse(networkResponse)) {
+            return Response.redirect(scope + 'auth/relogin', 302);
+          }
+          return networkResponse ?? Response.error();
         } catch {
           const cached = await cache.match(indexUrl);
           return cached ?? Response.error();
@@ -248,6 +286,11 @@ export async function handleFetch(event: FetchEvent) {
             // surfacing a technical error that would break the page.
             if (cachedResponse) {
               return cachedResponse;
+            }
+            // No cache: for a full-page navigation, force reauth instead of a raw
+            // 401/403 body. Non-navigate assets (e.g. a lazy chunk) are left as-is.
+            if (event.request.mode === 'navigate' && isAuthErrorResponse(networkResponse)) {
+              return Response.redirect(scope + 'auth/relogin', 302);
             }
             return networkResponse;
           } catch (error) {

--- a/src/app/core/services/worker_update/service-worker.ts
+++ b/src/app/core/services/worker_update/service-worker.ts
@@ -65,19 +65,22 @@ function isAuthErrorResponse(response: Response | undefined): response is Respon
 }
 
 /**
- * Restricts manifest-provided asset paths to same-origin, root-relative paths.
+ * Validates a manifest-provided path is same-origin/root-relative and returns
+ * its canonical form re-derived from the parsed `URL`, or `null` if invalid.
  * `assets_list.json` is untrusted network data — a poisoned/compromised
- * response must not be able to make the SW fetch and cache cross-origin
- * resources (client-side request forgery).
+ * response must not be able to make the SW fetch/cache cross-origin resources
+ * (client-side request forgery), so callers must use the returned value —
+ * never the raw `file` argument — to build the actual request.
  */
-function isValidAssetPath(file: string): boolean {
+function resolveAssetPath(file: string): string | null {
   if (!file.startsWith('/') || file.startsWith('//')) {
-    return false;
+    return null;
   }
   try {
-    return new URL(file, self.location.origin).origin === self.location.origin;
+    const url = new URL(file, self.location.origin);
+    return url.origin === self.location.origin ? url.pathname + url.search : null;
   } catch {
-    return false;
+    return null;
   }
 }
 

--- a/src/app/core/services/worker_update/service-worker.ts
+++ b/src/app/core/services/worker_update/service-worker.ts
@@ -46,7 +46,7 @@ function shouldUseNetworkFirst(request: Request): boolean {
 
 /**
  * Returns true when a response is a redirect that the browser must be allowed
- * to follow (e.g. Apache's 302 to the G@IA OIDC login). Navigation requests
+ * to follow (e.g. Apache's 302 to the AuthProvider OIDC login). Navigation requests
  * are fetched with `redirect: 'manual'`, so a redirect surfaces here as an
  * `opaqueredirect` response (status 0). Such responses MUST be passed through
  * untouched so the browser performs the navigation instead of the SW
@@ -256,7 +256,7 @@ export async function handleFetch(event: FetchEvent) {
   // Full bypass: /auth/* (OIDC), /assets_list.json and /version.json must never be intercepted.
   // Plain return WITHOUT respondWith: the browser handles the request natively.
   // `respondWith(fetch(request))` is NOT equivalent — OIDC endpoints answer
-  // with cross-origin redirects to G@IA, and a SW-relayed fetch of a
+  // with cross-origin redirects to the AuthProvider, and a SW-relayed fetch of a
   // redirected navigation rejects ("Failed to fetch"), blanking the page
   // (incident 2026-08-10, evening: /auth/relogin navigation died in the SW).
   if (shouldBypassSW(url)) {
@@ -285,7 +285,7 @@ export async function handleFetch(event: FetchEvent) {
             await cache.put(indexUrl, networkResponse.clone());
             return networkResponse;
           }
-          // Preserve Apache/G@IA redirects (OIDC login flow): let the browser follow.
+          // Preserve Apache/AuthProvider redirects (OIDC login flow): let the browser follow.
           if (networkResponse && isRedirectResponse(networkResponse)) {
             return networkResponse;
           }

--- a/src/app/core/services/worker_update/service-worker.ts
+++ b/src/app/core/services/worker_update/service-worker.ts
@@ -65,6 +65,23 @@ function isAuthErrorResponse(response: Response | undefined): response is Respon
 }
 
 /**
+ * Restricts manifest-provided asset paths to same-origin, root-relative paths.
+ * `assets_list.json` is untrusted network data — a poisoned/compromised
+ * response must not be able to make the SW fetch and cache cross-origin
+ * resources (client-side request forgery).
+ */
+function isValidAssetPath(file: string): boolean {
+  if (!file.startsWith('/') || file.startsWith('//')) {
+    return false;
+  }
+  try {
+    return new URL(file, self.location.origin).origin === self.location.origin;
+  } catch {
+    return false;
+  }
+}
+
+/**
  * Fetches and caches each file individually. Any single failure (e.g. a 502
  * during a rolling redeploy) aborts the whole install/update — missing or
  * broken assets must never be silently skipped. Compared to `Cache.addAll()`

--- a/src/app/core/services/worker_update/service-worker.ts
+++ b/src/app/core/services/worker_update/service-worker.ts
@@ -254,8 +254,12 @@ export async function handleFetch(event: FetchEvent) {
   const scope = (self as unknown as ServiceWorkerGlobalScope).registration?.scope;
 
   // Full bypass: /auth/* (OIDC), /assets_list.json and /version.json must never be intercepted.
+  // Plain return WITHOUT respondWith: the browser handles the request natively.
+  // `respondWith(fetch(request))` is NOT equivalent — OIDC endpoints answer
+  // with cross-origin redirects to G@IA, and a SW-relayed fetch of a
+  // redirected navigation rejects ("Failed to fetch"), blanking the page
+  // (incident 2026-08-10, evening: /auth/relogin navigation died in the SW).
   if (shouldBypassSW(url)) {
-    event.respondWith(fetch(event.request));
     return;
   }
 

--- a/src/app/core/services/worker_update/worker_update.service.spec.ts
+++ b/src/app/core/services/worker_update/worker_update.service.spec.ts
@@ -519,7 +519,26 @@ describe('UpdateService', () => {
       });
 
       expect(service.updateLoading()).toBe(false);
-      expect(mockMessageService.add).toHaveBeenCalledWith(expect.objectContaining({ severity: 'error' }));
+      expect(mockMessageService.add).toHaveBeenCalledWith(
+        expect.objectContaining({ severity: 'error', detail: 'Update failed: network error' })
+      );
+    });
+
+    it('should show the re-login message when the error reports an auth-like HTTP status', async () => {
+      service.updateLoading.set(true);
+
+      await messageHandler({
+        data: {
+          message: 'error',
+          error: 'Precache failed for /main.js: HTTP 502'
+        }
+      });
+
+      expect(service.updateLoading()).toBe(false);
+      // TranslocoTestingModule returns the key itself for unknown translations.
+      expect(mockMessageService.add).toHaveBeenCalledWith(
+        expect.objectContaining({ severity: 'error', detail: 'shared.update-service.update-failed-auth-detail' })
+      );
     });
   });
 

--- a/src/app/core/services/worker_update/worker_update.service.ts
+++ b/src/app/core/services/worker_update/worker_update.service.ts
@@ -56,7 +56,7 @@ export class UpdateService {
    * failing updates; pointing them to a re-login is actionable.
    */
   private static isAuthLikeFailure(error: unknown): boolean {
-    return typeof error === 'string' && /HTTP (401|403|502|503|504)/.test(error);
+    return typeof error === 'string' && /HTTP (401|403|5\d\d)/.test(error);
   }
 
   /**

--- a/src/app/core/services/worker_update/worker_update.service.ts
+++ b/src/app/core/services/worker_update/worker_update.service.ts
@@ -50,6 +50,16 @@ export class UpdateService {
   private static readonly FETCH_TIMEOUT_MS = 13000;
 
   /**
+   * True when a Service-Worker-reported failure looks like an auth/session
+   * problem (precache assets answered 401/403/5xx — typically a stale OIDC
+   * session). The generic "unknown error" message would loop the user through
+   * failing updates; pointing them to a re-login is actionable.
+   */
+  private static isAuthLikeFailure(error: unknown): boolean {
+    return typeof error === 'string' && /HTTP (401|403|502|503|504)/.test(error);
+  }
+
+  /**
    * True when the current runtime exposes a Service Worker API.
    * Centralizes the capability check so callers do not need to probe
    * `navigator.serviceWorker` themselves.
@@ -118,14 +128,18 @@ export class UpdateService {
               detail: this.translocoService.translate('shared.update-service.install-success-detail')
             });
             break;
-          case 'error':
+          case 'error': {
             this.updateLoading.set(false);
+            const detail = UpdateService.isAuthLikeFailure(event.data.error)
+              ? this.translocoService.translate('shared.update-service.update-failed-auth-detail')
+              : (event.data.error ?? this.translocoService.translate('shared.update-service.update-failed-detail'));
             this.messageService.add({
               severity: 'error',
               summary: this.translocoService.translate('shared.update-service.update-failed-summary'),
-              detail: event.data.error ?? this.translocoService.translate('shared.update-service.update-failed-detail')
+              detail
             });
             break;
+          }
         }
       }
     });


### PR DESCRIPTION
## Summary

Two incidents on 2026-08-10, fixed in sequence:

1. **Morning**: post-redeploy blank page + update loop, caused by an unbounded startup network call and a zombie OIDC session (dead refresh token turning every request into a 502).
2. **Evening**: the morning's OIDC fix (logout_on_error + ErrorDocument 401) caused a **total login lockout** — the IdP re-issued the same dead refresh token, and any stray 401 (e.g. favicon) tore down live sessions. Root cause and full fix below.

Also includes a documentation/comment cleanup: internal IdP product name and ticket references were replaced with the generic "AuthProvider" wording, since this repository may be exposed publicly.

## Changes

### stellar (Angular app)

- app-config.service.ts: loadDefaultLang() now bounded with a 3s RxJS timeout, falling back to fr, so a hung app-config.json request can no longer block APP_INITIALIZER and blank the app.
- service-worker.ts:
  - Cache-first fallback fetch is now bounded with fetchWithTimeout (was unbounded).
  - /auth/*, /assets_list.json, /version.json bypass is now a plain return instead of respondWith(fetch(request)) — the latter rejected ("Failed to fetch") on cross-origin OIDC redirects, blanking the page during re-login.
- worker_update.service.ts: surfaces a dedicated re-login message when an update failure looks auth-related (401/403/5xx) instead of a generic "unknown error"; added en/fr i18n keys.
- Specs updated/added accordingly (bypass behavior, timeout behavior, auth-error message).

### Apache / OIDC (root repo)

- Removed OIDCRefreshAccessTokenBeforeExpiry entirely (including the logout_on_error variant added earlier today). The app never consumes the access token; the IdP's single-use rotating refresh tokens combined with client-cookie sessions and parallel requests caused concurrent refreshes that killed the token family (invalid_grant) permanently, and logout_on_error then destroyed sessions on the very first failed refresh. Session validity now relies solely on the Apache cookie; expiry triggers a clean 302 to the IdP via OIDCUnAuthAction auth.
- Removed ErrorDocument 401 entirely: any stray 401 (e.g. favicon.ico) was tearing down live sessions. 401 recovery is now handled client-side (Service Worker redirect to /auth/relogin).
- /auth/relogin no longer calls mod_auth_openidc's logout parameter (RP-initiated logout at the IdP, which stranded users on a dead-end sign-off page). It now clears the session cookie locally and redirects to /auth/login.
- entrypoint.sh: dropped the now-unused OIDC_RELOGIN_URL construction.
- Bounded OIDCSessionInactivityTimeout/OIDCSessionMaxDuration to 7/30 days (was 365).
- /assets/config/app-config.json made public, same risk profile as version.json, so the Angular startup fetch never queues behind OIDC.
- Comments updated in httpd.conf.patch and reconnecting.js to reflect the final doctrine.

### Documentation / comment anonymization

- Replaced internal IdP product name and ticket references with a generic "AuthProvider" wording across Dockerfile, docker/entrypoint.sh, docker/cgi-bin/*.sh, docker/new_celeste-public/reconnecting.*, httpd-oidc.conf.template, httpd.conf.patch, scripts/healthz-smoke-test.sh, and service-worker.ts. Actual environment variable names are unchanged (tied to real deployment secrets).

## Testing

- Full Vitest suite: 3800 tests / 160 files passing.
- ESLint: 0 errors.
- Manual verification of service-worker.js build output for the bypass fix.

## Risk / rollout notes

- Requires redeploying both the Angular build (compiled Service Worker) and the Apache image (updated httpd-oidc.conf.template, httpd.conf.patch, entrypoint.sh).
- Any user currently stranded on the IdP's sign-off page will recover on next visit — nothing in the new config kills sessions unexpectedly anymore.
- Recommend a smoke test of /auth/relogin and a full login flow on the target environment before wider rollout, given the previous regression.